### PR TITLE
Feature/#13 대회 crud api 구현

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/api/ContestCategoryController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestCategoryController.java
@@ -1,0 +1,59 @@
+package com.opus.opus.modules.contest.api;
+
+import com.opus.opus.modules.contest.application.ContestCategoryCommandService;
+import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
+import com.opus.opus.modules.contest.application.dto.request.ContestCategoryRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestCategoryResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/categories")
+public class ContestCategoryController {
+
+    private final ContestCategoryCommandService contestCategoryCommandService;
+    private final ContestCategoryQueryService contestCategoryQueryService;
+
+    @PostMapping
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> createContestCategory(@Valid @RequestBody final ContestCategoryRequest request) {
+        contestCategoryCommandService.createCategory(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PatchMapping("/{categoryId}")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> updateContestCategory(@Valid @RequestBody final ContestCategoryRequest request,
+                                                      @PathVariable final Long categoryId) {
+        contestCategoryCommandService.updateCategory(categoryId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{categoryId}")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> deleteContestCategory(@PathVariable final Long categoryId) {
+        contestCategoryCommandService.deleteCategory(categoryId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ContestCategoryResponse>> getAllContestCategories() {
+        List<ContestCategoryResponse> response = contestCategoryQueryService.getAllContestCategories();
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -35,10 +35,8 @@ public class ContestController {
 
     @PostMapping
     @Secured("ROLE_관리자")
-    public ResponseEntity<Void> createContest(
-            @Valid @RequestBody final ContestRequest request
-    ) {
-        contestCommandService.createContest(request.contestName());
+    public ResponseEntity<Void> createContest(@Valid @RequestBody final ContestRequest request) {
+        contestCommandService.createContest(request);
         return ResponseEntity.status(CREATED).build();
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -1,11 +1,63 @@
 package com.opus.opus.modules.contest.api;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
+import com.opus.opus.modules.contest.application.ContestCommandService;
+import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
-@RestController
+@RestController("/contests")
 @RequiredArgsConstructor
 public class ContestController {
+    private final ContestQueryService contestQueryService;
+    private final ContestCommandService contestCommandService;
+
+    @GetMapping
+    public ResponseEntity<List<ContestResponse>> getAllContests() {
+        List<ContestResponse> responses = contestQueryService.getAllContests();
+        return ResponseEntity.ok(responses);
+    }
+
+    @PostMapping
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> createContest(
+            @Valid @RequestBody final ContestRequest request
+    ) {
+        contestCommandService.createContest(request.contestName());
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    @PatchMapping("/{contestId}")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> updateContest(
+            @PathVariable final Long contestId,
+            @Valid @RequestBody final ContestRequest request
+    ) {
+        contestCommandService.updateContest(contestId, request.contestName());
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{contestId}")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> deleteContest(
+            @PathVariable final Long contestId
+    ) {
+        contestCommandService.deleteContest(contestId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -50,9 +50,7 @@ public class ContestController {
 
     @DeleteMapping("/{contestId}")
     @Secured("ROLE_관리자")
-    public ResponseEntity<Void> deleteContest(
-            @PathVariable final Long contestId
-    ) {
+    public ResponseEntity<Void> deleteContest(@PathVariable final Long contestId) {
         contestCommandService.deleteContest(contestId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -42,11 +42,9 @@ public class ContestController {
 
     @PatchMapping("/{contestId}")
     @Secured("ROLE_관리자")
-    public ResponseEntity<Void> updateContest(
-            @PathVariable final Long contestId,
-            @Valid @RequestBody final ContestRequest request
-    ) {
-        contestCommandService.updateContest(contestId, request.contestName());
+    public ResponseEntity<Void> updateContest(@PathVariable final Long contestId,
+                                              @Valid @RequestBody final ContestRequest request) {
+        contestCommandService.updateContest(contestId, request);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryCommandService.java
@@ -1,0 +1,41 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.dto.request.ContestCategoryRequest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ContestCategoryCommandService {
+
+    private final ContestCategoryRepository contestCategoryRepository;
+    private final ContestCategoryConvenience contestCategoryConvenience;
+
+    private final ContestConvenience contestConvenience;
+
+    public void createCategory(final ContestCategoryRequest request) {
+        contestCategoryConvenience.validateDuplicateCategoryName(request.categoryName());
+        final ContestCategory contestCategory = ContestCategory.builder()
+                .categoryName(request.categoryName())
+                .build();
+        contestCategoryRepository.save(contestCategory);
+    }
+
+    public void updateCategory(final Long categoryId, final ContestCategoryRequest request) {
+        contestCategoryConvenience.validateDuplicateCategoryName(request.categoryName());
+        final ContestCategory contestCategory = contestCategoryConvenience.getValidateExistCategory(categoryId);
+        contestCategory.updateCategory(request.categoryName());
+    }
+
+    public void deleteCategory(final Long categoryId) {
+        final ContestCategory contestCategory = contestCategoryConvenience.getValidateExistCategory(categoryId);
+        contestConvenience.validateAllContestsDeleted(categoryId);
+        contestCategoryRepository.delete(contestCategory);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryQueryService.java
@@ -1,0 +1,28 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.dto.response.ContestCategoryResponse;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestCategoryQueryService {
+    private final ContestCategoryRepository contestCategoryRepository;
+
+    public List<ContestCategoryResponse> getAllContestCategories() {
+        List<ContestCategory> ContestCategories = contestCategoryRepository.findAll();
+
+        return ContestCategories.stream()
+                .map(contestcategory -> new ContestCategoryResponse(
+                        contestcategory.getId(),
+                        contestcategory.getCategoryName(),
+                        contestcategory.getUpdatedAt()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -5,6 +5,7 @@ import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class ContestCommandService {
     private final ContestRepository contestRepository;
     private final ContestConvenience contestConvenience;
     private final ContestCategoryConvenience contestCategoryConvenience;
+    private final TeamConvenience teamConvenience;
 
     public void createContest(final ContestRequest request) {
         contestConvenience.validateDuplicateContestName(request.contestName());
@@ -33,5 +35,11 @@ public class ContestCommandService {
         contestCategoryConvenience.getValidateExistCategory(request.categoryId());
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         contest.updateContest(request.categoryId(), request.contestName());
+    }
+
+    public void deleteContest(final Long contestId) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        teamConvenience.validateAllTeamsDeleted(contestId);
+        contestRepository.delete(contest);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -1,5 +1,10 @@
 package com.opus.opus.modules.contest.application;
 
+import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +13,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class ContestCommandService {
+
+    private final ContestRepository contestRepository;
+    private final ContestConvenience contestConvenience;
+    private final ContestCategoryConvenience contestCategoryConvenience;
+
+    public void createContest(final ContestRequest request) {
+        contestConvenience.validateDuplicateContestName(request.contestName());
+        contestCategoryConvenience.getValidateExistCategory(request.categoryId());
+        final Contest contest = Contest.builder()
+                .contestName(request.contestName())
+                .categoryId(request.categoryId())
+                .build();
+        contestRepository.save(contest);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -27,4 +27,11 @@ public class ContestCommandService {
                 .build();
         contestRepository.save(contest);
     }
+
+    public void updateContest(final Long contestId, final ContestRequest request) {
+        contestConvenience.validateDuplicateContestName(request.contestName());
+        contestCategoryConvenience.getValidateExistCategory(request.categoryId());
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        contest.updateContest(request.categoryId(), request.contestName());
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -1,5 +1,11 @@
 package com.opus.opus.modules.contest.application;
 
+import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
+import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +14,27 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContestQueryService {
+
+    private final ContestRepository contestRepository;
+    private final ContestCategoryConvenience contestCategoryConvenience;
+
+    public List<ContestResponse> getAllContests() {
+        List<Contest> contests = contestRepository.findAll();
+
+        return contests.stream()
+                .map(contest -> {
+                    ContestCategory category = contestCategoryConvenience.getValidateExistCategory(
+                            contest.getCategoryId());
+
+                    return new ContestResponse(
+                            contest.getId(),
+                            contest.getContestName(),
+                            contest.getCategoryId(),
+                            category.getCategoryName(),
+                            contest.getIsCurrent(),
+                            contest.getUpdatedAt()
+                    );
+                })
+                .toList();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestCategoryConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestCategoryConvenience.java
@@ -1,0 +1,29 @@
+package com.opus.opus.modules.contest.application.convenience;
+
+import static com.opus.opus.modules.contest.exception.ContestCategoryExceptionType.CATEGORY_NAME_ALREADY_EXIST;
+import static com.opus.opus.modules.contest.exception.ContestCategoryExceptionType.NOT_FOUND_CATEGORY;
+
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.exception.ContestCategoryException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestCategoryConvenience {
+    private final ContestCategoryRepository contestCategoryRepository;
+
+    public ContestCategory getValidateExistCategory(final Long categoryId) {
+        return contestCategoryRepository.findById(categoryId)
+                .orElseThrow(() -> new ContestCategoryException(NOT_FOUND_CATEGORY));
+    }
+
+    public void validateDuplicateCategoryName(String categoryName) {
+        if (contestCategoryRepository.existsByCategoryName(categoryName)) {
+            throw new ContestCategoryException(CATEGORY_NAME_ALREADY_EXIST);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -2,7 +2,9 @@ package com.opus.opus.modules.contest.application.convenience;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CATEGORY_HAS_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CONTEST_NAME_ALREADY_EXIST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 
+import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import lombok.RequiredArgsConstructor;
@@ -25,5 +27,10 @@ public class ContestConvenience {
         if (contestRepository.existsByContestName(contestName)) {
             throw new ContestException(CONTEST_NAME_ALREADY_EXIST);
         }
+    }
+
+    public Contest getValidateExistContest(final Long contestId) {
+        return contestRepository.findById(contestId)
+                .orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -1,0 +1,22 @@
+package com.opus.opus.modules.contest.application.convenience;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.CATEGORY_HAS_CONTEST;
+
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestConvenience {
+    private final ContestRepository contestCRepository;
+
+    public void validateAllContestsDeleted(final Long categoryId) {
+        if (contestCRepository.existsByCategoryId(categoryId)) {
+            throw new ContestException(CATEGORY_HAS_CONTEST);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.contest.application.convenience;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CATEGORY_HAS_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.CONTEST_NAME_ALREADY_EXIST;
 
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
@@ -12,11 +13,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContestConvenience {
-    private final ContestRepository contestCRepository;
+    private final ContestRepository contestRepository;
 
     public void validateAllContestsDeleted(final Long categoryId) {
-        if (contestCRepository.existsByCategoryId(categoryId)) {
+        if (contestRepository.existsByCategoryId(categoryId)) {
             throw new ContestException(CATEGORY_HAS_CONTEST);
+        }
+    }
+
+    public void validateDuplicateContestName(final String contestName) {
+        if (contestRepository.existsByContestName(contestName)) {
+            throw new ContestException(CONTEST_NAME_ALREADY_EXIST);
         }
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestCategoryRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestCategoryRequest.java
@@ -1,0 +1,9 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ContestCategoryRequest(
+        @NotBlank(message = "카테고리명을 입력해주세요.")
+        String categoryName
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
@@ -1,0 +1,9 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ContestRequest(
+        @NotBlank(message = "대회명은 비어 있을 수 없습니다.")
+        String contestName
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 
 public record ContestRequest(
         @NotBlank(message = "대회명은 비어 있을 수 없습니다.")
-        String contestName
+        String contestName,
+        @NotBlank(message = "카테고리ID는 비어 있을 수 없습니다.")
+        Long categoryId
 ) {
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCategoryResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCategoryResponse.java
@@ -1,0 +1,10 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ContestCategoryResponse(
+        Long categoryId,
+        String categoryName,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestResponse.java
@@ -5,6 +5,9 @@ import java.time.LocalDateTime;
 public record ContestResponse(
         Long contestId,
         String contestName,
+        Long categoryId,
+        String categoryName,
+        Boolean isCurrent,
         LocalDateTime updatedAt
 ) {
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestResponse.java
@@ -1,0 +1,10 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ContestResponse(
+        Long contestId,
+        String contestName,
+        LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
@@ -57,4 +57,8 @@ public class Contest extends BaseEntity {
         this.maxVotesLimit = 0;
     }
 
+    public void updateContest(final Long categoryId, final String contestName) {
+        this.categoryId = categoryId;
+        this.contestName = contestName;
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
@@ -47,15 +47,14 @@ public class Contest extends BaseEntity {
     private Integer maxVotesLimit;
 
     @Builder
-    private Contest(final String contestName, final Long categoryId, final Boolean isCurrent,
-                    final Integer maxVotesLimit) {
+    private Contest(final String contestName, final Long categoryId) {
         this.contestName = contestName;
         this.categoryId = categoryId;
-        this.isCurrent = isCurrent;
+        this.isCurrent = false;
         this.isDeleted = false;
         this.voteStartAt = LocalDateTime.now();
         this.voteEndAt = LocalDateTime.now();
-        this.maxVotesLimit = maxVotesLimit;
+        this.maxVotesLimit = 0;
     }
 
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
@@ -35,4 +35,8 @@ public class ContestCategory extends BaseEntity {
         this.categoryName = categoryName;
         this.isDeleted = false;
     }
+
+    public void updateCategory(final String categoryName) {
+        this.categoryName = categoryName;
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
@@ -6,7 +6,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,43 +18,21 @@ import org.hibernate.annotations.SQLRestriction;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
 @SQLDelete(sql = "UPDATE contest SET is_deleted = true where id = ?")
-public class Contest extends BaseEntity {
-
+public class ContestCategory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false)
-    private String contestName;
-
-    @Column(nullable = false)
-    private Long categoryId;
-
-    @Column(nullable = false)
-    private Boolean isCurrent;
+    private String categoryName;
 
     @Column(nullable = false)
     private Boolean isDeleted;
 
-    @Column(nullable = false)
-    private LocalDateTime voteStartAt;
-
-    @Column(nullable = false)
-    private LocalDateTime voteEndAt;
-
-    @Column(nullable = false)
-    private Integer maxVotesLimit;
 
     @Builder
-    private Contest(final String contestName, final Long categoryId, final Boolean isCurrent,
-                    final Integer maxVotesLimit) {
-        this.contestName = contestName;
-        this.categoryId = categoryId;
-        this.isCurrent = isCurrent;
+    private ContestCategory(final String categoryName) {
+        this.categoryName = categoryName;
         this.isDeleted = false;
-        this.voteStartAt = LocalDateTime.now();
-        this.voteEndAt = LocalDateTime.now();
-        this.maxVotesLimit = maxVotesLimit;
     }
-
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestCategoryRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestCategoryRepository.java
@@ -4,4 +4,5 @@ import com.opus.opus.modules.contest.domain.ContestCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestCategoryRepository extends JpaRepository<ContestCategory, Long> {
+    boolean existsByCategoryName(String categoryName);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestCategoryRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.opus.opus.modules.contest.domain.dao;
+
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestCategoryRepository extends JpaRepository<ContestCategory, Long> {
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
@@ -4,4 +4,5 @@ import com.opus.opus.modules.contest.domain.Contest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
+    boolean existsByCategoryId(final Long categoryId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
     boolean existsByCategoryId(final Long categoryId);
+
+    boolean existsByContestName(final String contestName);
 }

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestCategoryException.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestCategoryException.java
@@ -1,0 +1,23 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class ContestCategoryException extends BaseException {
+    private final ContestCategoryExceptionType exceptionType;
+
+    public ContestCategoryException(final ContestCategoryExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public ContestCategoryException(final ContestCategoryExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestCategoryExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestCategoryExceptionType.java
@@ -3,13 +3,15 @@ package com.opus.opus.modules.contest.exception;
 import com.opus.opus.global.base.BaseExceptionType;
 import org.springframework.http.HttpStatus;
 
-public enum ContestExceptionType implements BaseExceptionType {
+public enum ContestCategoryExceptionType implements BaseExceptionType {
 
-    CATEGORY_HAS_CONTEST(HttpStatus.CONFLICT, "해당 카테고리에 속한 대회가 존재합니다.");
+    NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "존재하지 않는 카테고리입니다."),
+    CATEGORY_NAME_ALREADY_EXIST(HttpStatus.CONFLICT, "동일한 카테고리명이 있습니다.");
+
     private final HttpStatus httpStatus;
     private final String errorMessage;
 
-    ContestExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+    ContestCategoryExceptionType(final HttpStatus httpStatus, final String errorMessage) {
         this.httpStatus = httpStatus;
         this.errorMessage = errorMessage;
     }

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ContestExceptionType implements BaseExceptionType {
 
-    CATEGORY_HAS_CONTEST(HttpStatus.CONFLICT, "해당 카테고리에 속한 대회가 존재합니다.");
+    CATEGORY_HAS_CONTEST(HttpStatus.CONFLICT, "해당 카테고리에 속한 대회가 존재합니다."),
+    CONTEST_NAME_ALREADY_EXIST(HttpStatus.CONFLICT, "동일한 대회명이 있습니다.");
+
     private final HttpStatus httpStatus;
     private final String errorMessage;
 

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ContestExceptionType implements BaseExceptionType {
 
+    NOT_FOUND_CONTEST(HttpStatus.NOT_FOUND, "존재하지 않는 대회입니다."),
     CATEGORY_HAS_CONTEST(HttpStatus.CONFLICT, "해당 카테고리에 속한 대회가 존재합니다."),
     CONTEST_NAME_ALREADY_EXIST(HttpStatus.CONFLICT, "동일한 대회명이 있습니다.");
 

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -1,0 +1,22 @@
+package com.opus.opus.modules.team.application.convenience;
+
+import static com.opus.opus.modules.team.exception.TeamExceptionType.CONTEST_HAS_TEAM;
+
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamConvenience {
+    private final TeamRepository teamRepository;
+
+    public void validateAllTeamsDeleted(final Long contestId) {
+        if (teamRepository.existsByContestId(contestId)) {
+            throw new TeamException(CONTEST_HAS_TEAM);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamRepository.java
@@ -1,0 +1,8 @@
+package com.opus.opus.modules.team.domain.dao;
+
+import com.opus.opus.modules.team.domain.Team;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamRepository extends JpaRepository<Team, Long> {
+    boolean existsByContestId(final Long contestId);
+}

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
@@ -5,8 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum TeamExceptionType implements BaseExceptionType {
 
-
-    ;
+    CONTEST_HAS_TEAM(HttpStatus.CONFLICT, "해당 대회에 속한 팀이 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #13 

- 브랜치 이름에 대소문자가 혼용되어 동일 이슈에 대한 PR을 중복으로 올려버렸습니다.ㅜㅜ 이 PR은 삭제 요청해두었습니다!

- 대회 CRUD API를 개발했습니다.
  - 대회 생성
  - 대회 전체 조회
  - 대회 수정
  - 대회 삭제

## 💬 리뷰 요구사항

- 수정해야할 부분 있다면 말씀해주세요

## ✨ 기타

- 브랜치 이름에 대소문자가 혼용되어 동일 이슈에 대한 PR을 중복으로 올려버렸습니다.ㅜㅜ 이 PR은 삭제 요청해두었습니다!
