### PR TITLE
Feature/#12 분과 엔티티 생성 및 crud api 구현

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
@@ -1,8 +1,12 @@
 package com.opus.opus.modules.contest.api;
 
+import com.opus.opus.modules.contest.application.ContestTrackCommandService;
+import com.opus.opus.modules.contest.application.ContestTrackQueryService;
+import com.opus.opus.modules.contest.application.dto.request.ContestTrackRequest;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
@@ -27,11 +31,11 @@ public class ContestTrackController {
 
     @PostMapping
     @Secured("ROLE_관리자")
-    public ResponseEntity<ContestTrackResponse> createContestTrack(
+    public ResponseEntity<Void> createContestTrack(
             @Valid @RequestBody final ContestTrackRequest request,
             @PathVariable final Long contestId) {
-        ContestTrackResponse response = contestTrackCommandService.createTrack(contestId, request);
-        return ResponseEntity.ok(response);
+        contestTrackCommandService.createTrack(contestId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @PatchMapping("/{trackId}")

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
@@ -32,9 +32,8 @@ public class ContestTrackController {
 
     @PostMapping
     @Secured("ROLE_관리자")
-    public ResponseEntity<Void> createContestTrack(
-            @Valid @RequestBody final ContestTrackRequest request,
-            @PathVariable final Long contestId) {
+    public ResponseEntity<Void> createContestTrack(@Valid @RequestBody final ContestTrackRequest request,
+                                                   @PathVariable final Long contestId) {
         contestTrackCommandService.createTrack(contestId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.contest.api;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestTrackRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestTrackResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
@@ -1,0 +1,59 @@
+package com.opus.opus.modules.contest.api;
+
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/contest/{contestId}/tracks")
+public class ContestTrackController {
+
+    private final ContestTrackCommandService contestTrackCommandService;
+    private final ContestTrackQueryService contestTrackQueryService;
+
+    @PostMapping
+    @Secured("ROLE_관리자")
+    public ResponseEntity<ContestTrackResponse> createContestTrack(
+            @Valid @RequestBody final ContestTrackRequest request,
+            @PathVariable final Long contestId) {
+        ContestTrackResponse response = contestTrackCommandService.createTrack(contestId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{trackId}")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> updateContestTrack(@Valid @RequestBody final ContestTrackRequest request,
+                                                   @PathVariable final Long contestId,
+                                                   @PathVariable final Long trackId) {
+        contestTrackCommandService.updateTrack(contestId, trackId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{trackId}")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> deleteContestTrack(@PathVariable final Long contestId,
+                                                   @PathVariable final Long trackId) {
+        contestTrackCommandService.deleteTrack(contestId, trackId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ContestTrackResponse>> getAllContestTracks(@PathVariable final Long contestId) {
+        List<ContestTrackResponse> response = contestTrackQueryService.getAllContestTracks(contestId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
@@ -1,0 +1,31 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
+import com.opus.opus.modules.contest.application.dto.request.ContestTrackRequest;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ContestTrackCommandService {
+    private final ContestTrackRepository contestTrackRepository;
+
+    private final ContestTrackConvenience contestTrackConvenience;
+    private final ContestConvenience contestConvenience;
+
+
+    public void createTrack(final Long contestId, final ContestTrackRequest request) {
+        contestConvenience.getValidateExistContest(contestId);
+        contestTrackConvenience.validateDuplicateTrackName(contestId, request.trackName());
+        final ContestTrack contestTrack = ContestTrack.builder()
+                .trackName(request.trackName())
+                .contestId(contestId)
+                .build();
+        contestTrackRepository.save(contestTrack);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
@@ -5,6 +5,7 @@ import com.opus.opus.modules.contest.application.convenience.ContestTrackConveni
 import com.opus.opus.modules.contest.application.dto.request.ContestTrackRequest;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +18,7 @@ public class ContestTrackCommandService {
 
     private final ContestTrackConvenience contestTrackConvenience;
     private final ContestConvenience contestConvenience;
+    private final TeamConvenience teamConvenience;
 
     public void createTrack(final Long contestId, final ContestTrackRequest request) {
         contestConvenience.getValidateExistContest(contestId);
@@ -34,5 +36,12 @@ public class ContestTrackCommandService {
 
         final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
         contestTrack.updateTrack(contestId, request.trackName());
+    }
+
+    public void deleteTrack(final Long contestId, final Long trackId) {
+        contestConvenience.getValidateExistContest(contestId);
+        final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
+        teamConvenience.validateAllTeamsDeletedInTrack(trackId);
+        contestTrackRepository.delete(contestTrack);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.contest.application;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestTrackRequest;
+import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @RequiredArgsConstructor
 public class ContestTrackCommandService {
+
     private final ContestTrackRepository contestTrackRepository;
 
     private final ContestTrackConvenience contestTrackConvenience;
@@ -21,19 +23,20 @@ public class ContestTrackCommandService {
     private final TeamConvenience teamConvenience;
 
     public void createTrack(final Long contestId, final ContestTrackRequest request) {
-        contestConvenience.getValidateExistContest(contestId);
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
         contestTrackConvenience.validateDuplicateTrackName(contestId, request.trackName());
         final ContestTrack contestTrack = ContestTrack.builder()
                 .trackName(request.trackName())
-                .contestId(contestId)
+                .contest(contest)
                 .build();
         contestTrackRepository.save(contestTrack);
     }
 
     public void updateTrack(final Long contestId, final Long trackId, final ContestTrackRequest request) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
         contestTrackConvenience.validateDuplicateTrackName(contestId, request.trackName());
         final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
-        contestTrack.updateTrack(contestId, request.trackName());
+        contestTrack.updateTrack(contest, request.trackName());
     }
 
     public void deleteTrack(final Long contestId, final Long trackId) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
@@ -31,15 +31,12 @@ public class ContestTrackCommandService {
     }
 
     public void updateTrack(final Long contestId, final Long trackId, final ContestTrackRequest request) {
-        contestConvenience.getValidateExistContest(contestId);
         contestTrackConvenience.validateDuplicateTrackName(contestId, request.trackName());
-
         final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
         contestTrack.updateTrack(contestId, request.trackName());
     }
 
     public void deleteTrack(final Long contestId, final Long trackId) {
-        contestConvenience.getValidateExistContest(contestId);
         final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
         teamConvenience.validateAllTeamsDeletedInTrack(trackId);
         contestTrackRepository.delete(contestTrack);

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
@@ -18,7 +18,6 @@ public class ContestTrackCommandService {
     private final ContestTrackConvenience contestTrackConvenience;
     private final ContestConvenience contestConvenience;
 
-
     public void createTrack(final Long contestId, final ContestTrackRequest request) {
         contestConvenience.getValidateExistContest(contestId);
         contestTrackConvenience.validateDuplicateTrackName(contestId, request.trackName());
@@ -27,5 +26,13 @@ public class ContestTrackCommandService {
                 .contestId(contestId)
                 .build();
         contestTrackRepository.save(contestTrack);
+    }
+
+    public void updateTrack(final Long contestId, final Long trackId, final ContestTrackRequest request) {
+        contestConvenience.getValidateExistContest(contestId);
+        contestTrackConvenience.validateDuplicateTrackName(contestId, request.trackName());
+
+        final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
+        contestTrack.updateTrack(contestId, request.trackName());
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackQueryService.java
@@ -1,5 +1,9 @@
 package com.opus.opus.modules.contest.application;
 
+import com.opus.opus.modules.contest.application.dto.response.ContestTrackResponse;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -8,4 +12,12 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContestTrackQueryService {
+    private final ContestTrackRepository contestTrackRepository;
+
+    public List<ContestTrackResponse> getAllContestTracks(final Long contestId) {
+        List<ContestTrack> contestTracks = contestTrackRepository.findAllByContestId(contestId);
+        return contestTracks.stream()
+                .map(ContestTrackResponse::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackQueryService.java
@@ -1,0 +1,11 @@
+package com.opus.opus.modules.contest.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestTrackQueryService {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -2,6 +2,7 @@ package com.opus.opus.modules.contest.application.convenience;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CATEGORY_HAS_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CONTEST_NAME_ALREADY_EXIST;
+
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 
 import com.opus.opus.modules.contest.domain.Contest;

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestTrackConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestTrackConvenience.java
@@ -1,0 +1,22 @@
+package com.opus.opus.modules.contest.application.convenience;
+
+import static com.opus.opus.modules.contest.exception.ContestTrackExceptionType.TRACKNAME_DUPLICATED;
+
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import com.opus.opus.modules.contest.exception.ContestTrackException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestTrackConvenience {
+    private final ContestTrackRepository contestTrackRepository;
+
+    public void validateDuplicateTrackName(final Long contestId, final String trackName) {
+        if (contestTrackRepository.existsByContestIdAndTrackName(contestId, trackName)) {
+            throw new ContestTrackException(TRACKNAME_DUPLICATED);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestTrackConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestTrackConvenience.java
@@ -1,7 +1,9 @@
 package com.opus.opus.modules.contest.application.convenience;
 
+import static com.opus.opus.modules.contest.exception.ContestTrackExceptionType.NOT_FOUND_TRACK;
 import static com.opus.opus.modules.contest.exception.ContestTrackExceptionType.TRACKNAME_DUPLICATED;
 
+import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestTrackException;
 import lombok.RequiredArgsConstructor;
@@ -18,5 +20,10 @@ public class ContestTrackConvenience {
         if (contestTrackRepository.existsByContestIdAndTrackName(contestId, trackName)) {
             throw new ContestTrackException(TRACKNAME_DUPLICATED);
         }
+    }
+
+    public ContestTrack getValidateExistTrack(final Long contestId, final Long trackId) {
+        return contestTrackRepository.findByIdAndContestId(trackId, contestId)
+                .orElseThrow(() -> new ContestTrackException(NOT_FOUND_TRACK));
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestTrackRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestTrackRequest.java
@@ -1,0 +1,10 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record ContestTrackRequest(
+        @NotBlank(message = "분과명은 비어 있을 수 없습니다.")
+        String trackName
+) {
+
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestTrackResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestTrackResponse.java
@@ -1,0 +1,19 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import java.time.LocalDateTime;
+
+public record ContestTrackResponse(
+        Long trackId,
+        String trackName,
+        LocalDateTime updatedAt
+
+) {
+    public static ContestTrackResponse from(ContestTrack contestTrack) {
+        return new ContestTrackResponse(
+                contestTrack.getId(),
+                contestTrack.getTrackName(),
+                contestTrack.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
@@ -1,11 +1,15 @@
 package com.opus.opus.modules.contest.domain;
 
+import static jakarta.persistence.FetchType.LAZY;
+
 import com.opus.opus.global.base.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -26,21 +30,22 @@ public class ContestTrack extends BaseEntity {
     @Column(nullable = false)
     private String trackName;
 
-    @Column(nullable = false)
-    private Long contestId;
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    private Contest contest;
 
     @Column(nullable = false)
     private Boolean isDeleted;
 
     @Builder
-    private ContestTrack(final String trackName, final Long contestId) {
+    private ContestTrack(final String trackName, final Contest contest) {
         this.trackName = trackName;
-        this.contestId = contestId;
+        this.contest = contest;
         this.isDeleted = false;
     }
 
-    public void updateTrack(final Long contestId, final String trackName) {
-        this.contestId = contestId;
+    public void updateTrack(final Contest contest, final String trackName) {
+        this.contest = contest;
         this.trackName = trackName;
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
@@ -1,0 +1,41 @@
+package com.opus.opus.modules.contest.domain;
+
+import com.opus.opus.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE contest SET is_deleted = true where id = ?")
+public class ContestTrack extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String trackName;
+
+    @Column(nullable = false)
+    private Long contestId;
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
+    @Builder
+    private ContestTrack(final String trackName, final Long contestId) {
+        this.trackName = trackName;
+        this.contestId = contestId;
+        this.isDeleted = false;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
@@ -38,4 +38,9 @@ public class ContestTrack extends BaseEntity {
         this.contestId = contestId;
         this.isDeleted = false;
     }
+
+    public void updateTrack(final Long contestId, final String trackName) {
+        this.contestId = contestId;
+        this.trackName = trackName;
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
@@ -1,11 +1,14 @@
 package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.ContestTrack;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestTrackRepository extends JpaRepository<ContestTrack, Long> {
     boolean existsByContestIdAndTrackName(final Long contestId, final String trackName);
 
-    Optional<ContestTrack> findByIdAndContestId(Long trackId, Long contestId);
+    Optional<ContestTrack> findByIdAndContestId(final Long trackId, final Long contestId);
+
+    List<ContestTrack> findAllByContestId(final Long contestId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
@@ -1,8 +1,11 @@
 package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.ContestTrack;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestTrackRepository extends JpaRepository<ContestTrack, Long> {
     boolean existsByContestIdAndTrackName(final Long contestId, final String trackName);
+
+    Optional<ContestTrack> findByIdAndContestId(Long trackId, Long contestId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
@@ -1,0 +1,8 @@
+package com.opus.opus.modules.contest.domain.dao;
+
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestTrackRepository extends JpaRepository<ContestTrack, Long> {
+    boolean existsByContestIdAndTrackName(final Long contestId, final String trackName);
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestTrackException.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestTrackException.java
@@ -1,0 +1,23 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class ContestTrackException extends BaseException {
+    private final ContestTrackExceptionType exceptionType;
+
+    public ContestTrackException(final ContestTrackExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public ContestTrackException(final ContestTrackExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestTrackExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestTrackExceptionType.java
@@ -1,0 +1,26 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ContestTrackExceptionType implements BaseExceptionType {
+
+    TRACKNAME_DUPLICATED(HttpStatus.CONFLICT, "해당 대회에 동일한 트랙명이 있습니다.");
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    ContestTrackExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestTrackExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestTrackExceptionType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum ContestTrackExceptionType implements BaseExceptionType {
 
-    TRACKNAME_DUPLICATED(HttpStatus.CONFLICT, "해당 대회에 동일한 트랙명이 있습니다.");
+    TRACKNAME_DUPLICATED(HttpStatus.CONFLICT, "해당 대회에 동일한 트랙명이 있습니다."),
+    NOT_FOUND_TRACK(HttpStatus.NOT_FOUND, "존재하지 않는 분과입니다.");
     private final HttpStatus httpStatus;
     private final String errorMessage;
 

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.team.application.convenience;
 
 import static com.opus.opus.modules.team.exception.TeamExceptionType.CONTEST_HAS_TEAM;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.TRACK_HAS_TEAM;
 
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.exception.TeamException;
@@ -14,9 +15,15 @@ import org.springframework.transaction.annotation.Transactional;
 public class TeamConvenience {
     private final TeamRepository teamRepository;
 
-    public void validateAllTeamsDeleted(final Long contestId) {
+    public void validateAllTeamsDeletedInContest(final Long contestId) {
         if (teamRepository.existsByContestId(contestId)) {
             throw new TeamException(CONTEST_HAS_TEAM);
+        }
+    }
+
+    public void validateAllTeamsDeletedInTrack(final Long trackId) {
+        if (teamRepository.existsByTrackId(trackId)) {
+            throw new TeamException(TRACK_HAS_TEAM);
         }
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/domain/Team.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/Team.java
@@ -53,7 +53,7 @@ public class Team extends BaseEntity {
     @Column(nullable = false)
     private Long contestId;
 
-    @Column(nullable = false)
+    @Column
     private Long trackId;
 
     @Column(nullable = false)

--- a/src/main/java/com/opus/opus/modules/team/domain/Team.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/Team.java
@@ -54,6 +54,9 @@ public class Team extends BaseEntity {
     private Long contestId;
 
     @Column(nullable = false)
+    private Long trackId;
+
+    @Column(nullable = false)
     private Integer itemOrder;
 
     @Column(nullable = false)
@@ -76,9 +79,8 @@ public class Team extends BaseEntity {
 
     @Builder
     private Team(final String teamName, final String projectName, final String professorName, final String overview,
-                 final String githubPath,
-                 final String productionPath, final String youTubePath, final Long contestId, final Integer itemOrder,
-                 final List<TeamMember> teamMembers) {
+                 final String githubPath, final String productionPath, final String youTubePath, final Long contestId,
+                 final Long trackId, final Integer itemOrder, final List<TeamMember> teamMembers) {
         this.teamName = teamName;
         this.projectName = projectName;
         this.professorName = professorName;
@@ -87,6 +89,7 @@ public class Team extends BaseEntity {
         this.productionPath = productionPath;
         this.youTubePath = youTubePath;
         this.contestId = contestId;
+        this.trackId = trackId;
         this.itemOrder = itemOrder;
         this.isDeleted = false;
         this.isSubmitted = false;

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TeamRepository extends JpaRepository<Team, Long> {
     boolean existsByContestId(final Long contestId);
+
+    boolean existsByTrackId(final Long trackId);
 }

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
@@ -5,7 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum TeamExceptionType implements BaseExceptionType {
 
-    CONTEST_HAS_TEAM(HttpStatus.CONFLICT, "해당 대회에 속한 팀이 존재합니다.");
+    CONTEST_HAS_TEAM(HttpStatus.CONFLICT, "해당 대회에 속한 팀이 존재합니다."),
+    TRACK_HAS_TEAM(HttpStatus.CONFLICT, "해당 분과에 속한 팀이 존재합니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #12 

## 📜 작업 내용

- 분과 엔티티를 생성했습니다.
- 팀 엔티티에 분과id 필드를 추가했습니다.
- 분과 CRUD API를 개발했습니다.
  - 분과 등록
  - 해당 대회의 분과 전체 조회
  - 분과 수정
  - 분과 삭제

## 💬 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요.

## ✨ 기타

- 오늘의 한마디
