### PR TITLE
Feature/#19 대회 진행 상태 토글 및 현재 진행 중인 대회 조회 api 구현

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -2,6 +2,8 @@ package com.opus.opus.modules.contest.api;
 
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.ContestCommandService;
+import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
@@ -62,7 +64,7 @@ public class ContestController {
     @Secured("ROLE_관리자")
     public ResponseEntity<ContestCurrentToggleResponse> toggleCurrent(@PathVariable final Long contestId,
                                                                       @Valid @RequestBody final ContestCurrentToggleRequest request) {
-        ContestCurrentToggleResponse response = contestCommandService.toggleCurrent(contestId, request);
+        ContestCurrentToggleResponse response = contestCommandService.toggleCurrent(contestId, request.isCurrent());
         return ResponseEntity.ok(response);
     }
 
@@ -71,4 +73,5 @@ public class ContestController {
         List<ContestCurrentResponse> responses = contestQueryService.getCurrentContests();
         return ResponseEntity.ok(responses);
     }
+
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -54,4 +54,18 @@ public class ContestController {
         contestCommandService.deleteContest(contestId);
         return ResponseEntity.noContent().build();
     }
+
+    @PatchMapping("/{contestId}/current")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<ContestCurrentToggleResponse> toggleCurrent(@PathVariable final Long contestId,
+                                                                      @Valid @RequestBody final ContestCurrentToggleRequest request) {
+        ContestCurrentToggleResponse response = contestCommandService.toggleCurrent(contestId, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/current")
+    public ResponseEntity<List<ContestCurrentResponse>> getAllCurrentContests() {
+        List<ContestCurrentResponse> responses = contestQueryService.getAllCurrentContests();
+        return ResponseEntity.ok(responses);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -4,6 +4,9 @@ import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
+import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -64,8 +67,8 @@ public class ContestController {
     }
 
     @GetMapping("/current")
-    public ResponseEntity<List<ContestCurrentResponse>> getAllCurrentContests() {
-        List<ContestCurrentResponse> responses = contestQueryService.getAllCurrentContests();
+    public ResponseEntity<List<ContestCurrentResponse>> getCurrentContests() {
+        List<ContestCurrentResponse> responses = contestQueryService.getCurrentContests();
         return ResponseEntity.ok(responses);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -1,5 +1,13 @@
 package com.opus.opus.modules.contest.application;
 
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.ALREADY_CURRENT_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.ALREADY_NOT_CURRENT_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.CURRENT_CONTEST_LIMIT_EXCEEDED;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
@@ -8,6 +16,8 @@ import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.exception.ContestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,8 +27,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ContestCommandService {
 
+    private static final int MAX_CURRENT_CONTEST_COUNT = 2;
+
     private final ContestRepository contestRepository;
-    
+
     private final ContestConvenience contestConvenience;
     private final ContestCategoryConvenience contestCategoryConvenience;
     private final TeamConvenience teamConvenience;
@@ -46,5 +58,36 @@ public class ContestCommandService {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         teamConvenience.validateAllTeamsDeleted(contestId);
         contestRepository.delete(contest);
+    }
+
+    public ContestCurrentToggleResponse toggleCurrent(final Long contestId, final Boolean isCurrent) {
+        Contest contest = contestConvenience.getValidateExistContest(contestId);
+        // 기존과 동일한 값 요청이면 예외
+        validateSameCurrentRequest(contest.getIsCurrent(), isCurrent);
+        // 현재 대회로 등록하는 경우, 현재 진행 중인 대회 최대 개수 검사
+        if (isCurrent) {
+            long currentCount = contestConvenience.countCurrentContests();
+            validateCurrentContestLimit(currentCount);
+        }
+        // 변경
+        contest.updateIsCurrent(isCurrent);
+        String message = isCurrent ? "현재 대회로 등록되었습니다." : "현재 대회 지정이 해제되었습니다.";
+        return ContestCurrentToggleResponse.of(contest.getId(), isCurrent, message);
+    }
+
+    private void validateSameCurrentRequest(final Boolean currentValue, final Boolean requestValue) {
+        if (currentValue.equals(requestValue)) {
+            if (currentValue) {
+                throw new ContestException(ALREADY_CURRENT_CONTEST);
+            } else {
+                throw new ContestException(ALREADY_NOT_CURRENT_CONTEST);
+            }
+        }
+    }
+
+    private void validateCurrentContestLimit(final long currentCount) {
+        if (currentCount >= MAX_CURRENT_CONTEST_COUNT) {
+            throw new ContestException(CURRENT_CONTEST_LIMIT_EXCEEDED);
+        }
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -4,10 +4,16 @@ import static com.opus.opus.modules.contest.exception.ContestExceptionType.ALREA
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.ALREADY_NOT_CURRENT_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CURRENT_CONTEST_LIMIT_EXCEEDED;
 
+import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
@@ -56,7 +62,7 @@ public class ContestCommandService {
 
     public void deleteContest(final Long contestId) {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
-        teamConvenience.validateAllTeamsDeleted(contestId);
+        teamConvenience.validateAllTeamsDeletedInContest(contestId);
         contestRepository.delete(contest);
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -14,16 +14,6 @@ import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
-import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
-import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
-import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
-import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
-import com.opus.opus.modules.contest.domain.Contest;
-import com.opus.opus.modules.contest.domain.ContestCategory;
-import com.opus.opus.modules.contest.domain.dao.ContestRepository;
-import com.opus.opus.modules.team.application.convenience.TeamConvenience;
-import com.opus.opus.modules.contest.domain.Contest;
-import com.opus.opus.modules.contest.exception.ContestException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -77,17 +67,12 @@ public class ContestCommandService {
         }
         // 변경
         contest.updateIsCurrent(isCurrent);
-        String message = isCurrent ? "현재 대회로 등록되었습니다." : "현재 대회 지정이 해제되었습니다.";
-        return ContestCurrentToggleResponse.of(contest.getId(), isCurrent, message);
+        return ContestCurrentToggleResponse.of(contest.getId(), isCurrent);
     }
 
     private void validateSameCurrentRequest(final Boolean currentValue, final Boolean requestValue) {
-        if (currentValue.equals(requestValue)) {
-            if (currentValue) {
-                throw new ContestException(ALREADY_CURRENT_CONTEST);
-            } else {
-                throw new ContestException(ALREADY_NOT_CURRENT_CONTEST);
-            }
+        if (currentValue == requestValue) {
+            throw new ContestException(currentValue ? ALREADY_CURRENT_CONTEST : ALREADY_NOT_CURRENT_CONTEST);
         }
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -1,6 +1,9 @@
 package com.opus.opus.modules.contest.application;
 
+import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
+import com.opus.opus.modules.contest.domain.Contest;
 import java.util.List;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
@@ -16,8 +19,20 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContestQueryService {
-    public List<ContestCurrentResponse> getCurrentContests()
-        return;
+
+    private final ContestConvenience contestConvenience;
+    private final ContestCategoryConvenience contestCategoryConvenience;
+
+    public List<ContestCurrentResponse> getCurrentContests() {
+        List<Contest> contests = contestConvenience.getCurrentContests();
+
+        return contests.stream()
+                .map(contest -> {
+                    String categoryName = contestCategoryConvenience.getValidateExistCategory(contest.getCategoryId())
+                            .getCategoryName();
+                    return ContestCurrentResponse.of(contest, categoryName);
+                })
+                .toList();
     }
 
     private final ContestRepository contestRepository;

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -1,5 +1,7 @@
 package com.opus.opus.modules.contest.application;
 
+import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
+import java.util.List;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.domain.Contest;
@@ -14,6 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContestQueryService {
+    public List<ContestCurrentResponse> getCurrentContests()
+        return;
+    }
 
     private final ContestRepository contestRepository;
     private final ContestCategoryConvenience contestCategoryConvenience;

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -3,9 +3,6 @@ package com.opus.opus.modules.contest.application;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
-import com.opus.opus.modules.contest.domain.Contest;
-import java.util.List;
-import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
@@ -19,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ContestQueryService {
+
+    private final ContestRepository contestRepository;
 
     private final ContestConvenience contestConvenience;
     private final ContestCategoryConvenience contestCategoryConvenience;
@@ -34,9 +33,6 @@ public class ContestQueryService {
                 })
                 .toList();
     }
-
-    private final ContestRepository contestRepository;
-    private final ContestCategoryConvenience contestCategoryConvenience;
 
     public List<ContestResponse> getAllContests() {
         List<Contest> contests = contestRepository.findAll();

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -8,6 +8,7 @@ import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_F
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,5 +38,9 @@ public class ContestConvenience {
 
     public long countCurrentContests() {
         return contestRepository.countByIsCurrentTrue();
+    }
+
+    public List<Contest> getCurrentContests() {
+        return contestRepository.findAllByIsCurrentTrue();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -34,4 +34,8 @@ public class ContestConvenience {
         return contestRepository.findById(contestId)
                 .orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
+
+    public long countCurrentContests() {
+        return contestRepository.countByIsCurrentTrue();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestCurrentToggleRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestCurrentToggleRequest.java
@@ -1,0 +1,8 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record ContestCurrentToggleRequest(
+        @NotNull Boolean isCurrent
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestCurrentToggleRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestCurrentToggleRequest.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.contest.application.dto.request;
 import jakarta.validation.constraints.NotNull;
 
 public record ContestCurrentToggleRequest(
-        @NotNull Boolean isCurrent
+        @NotNull
+        Boolean isCurrent
 ) {
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentResponse.java
@@ -8,8 +8,7 @@ public record ContestCurrentResponse(
         String categoryName,
         String contestName,
         LocalDateTime voteStartAt,
-        LocalDateTime voteEndAt,
-        Long bannerId
+        LocalDateTime voteEndAt
 ) {
     public static ContestCurrentResponse of(
             Contest contest,
@@ -20,8 +19,7 @@ public record ContestCurrentResponse(
                 categoryName,
                 contest.getContestName(),
                 contest.getVoteStartAt(),
-                contest.getVoteEndAt(),
-                contest.getBannerId()
+                contest.getVoteEndAt()
         );
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentResponse.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.contest.application.dto.response;
 
+import com.opus.opus.modules.contest.domain.Contest;
 import java.time.LocalDateTime;
 
 public record ContestCurrentResponse(
@@ -10,4 +11,17 @@ public record ContestCurrentResponse(
         LocalDateTime voteEndAt,
         Long bannerId
 ) {
+    public static ContestCurrentResponse of(
+            Contest contest,
+            String categoryName
+    ) {
+        return new ContestCurrentResponse(
+                contest.getId(),
+                categoryName,
+                contest.getContestName(),
+                contest.getVoteStartAt(),
+                contest.getVoteEndAt(),
+                contest.getBannerId()
+        );
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentResponse.java
@@ -1,0 +1,13 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ContestCurrentResponse(
+        Long contestId,
+        String categoryName,
+        String contestName,
+        LocalDateTime voteStartAt,
+        LocalDateTime voteEndAt,
+        Long bannerId
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentToggleResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentToggleResponse.java
@@ -5,4 +5,7 @@ public record ContestCurrentToggleResponse(
         Boolean isCurrent,
         String message
 ) {
+    public static ContestCurrentToggleResponse of(Long id, Boolean isCurrent, String message) {
+        return new ContestCurrentToggleResponse(id, isCurrent, message);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentToggleResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentToggleResponse.java
@@ -2,10 +2,14 @@ package com.opus.opus.modules.contest.application.dto.response;
 
 public record ContestCurrentToggleResponse(
         Long contestId,
-        Boolean isCurrent,
+        boolean isCurrent,
         String message
 ) {
-    public static ContestCurrentToggleResponse of(Long id, Boolean isCurrent, String message) {
-        return new ContestCurrentToggleResponse(id, isCurrent, message);
+    public static ContestCurrentToggleResponse of(Long contestId, boolean isCurrent) {
+        String message = isCurrent
+                ? "현재 대회로 등록되었습니다."
+                : "현재 대회 지정이 해제되었습니다.";
+
+        return new ContestCurrentToggleResponse(contestId, isCurrent, message);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentToggleResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestCurrentToggleResponse.java
@@ -1,0 +1,8 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+public record ContestCurrentToggleResponse(
+        Long contestId,
+        Boolean isCurrent,
+        String message
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
@@ -46,9 +46,6 @@ public class Contest extends BaseEntity {
     @Column(nullable = false)
     private Integer maxVotesLimit;
 
-    @Column
-    private Long bannerId;
-
     @Builder
     private Contest(final String contestName, final Long categoryId) {
         this.contestName = contestName;
@@ -58,7 +55,6 @@ public class Contest extends BaseEntity {
         this.voteStartAt = LocalDateTime.now();
         this.voteEndAt = LocalDateTime.now();
         this.maxVotesLimit = 0;
-        this.bannerId = null;
         this.maxVotesLimit = 0;
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
@@ -46,6 +46,9 @@ public class Contest extends BaseEntity {
     @Column(nullable = false)
     private Integer maxVotesLimit;
 
+    @Column
+    private Long bannerId;
+
     @Builder
     private Contest(final String contestName, final Long categoryId) {
         this.contestName = contestName;
@@ -54,6 +57,8 @@ public class Contest extends BaseEntity {
         this.isDeleted = false;
         this.voteStartAt = LocalDateTime.now();
         this.voteEndAt = LocalDateTime.now();
+        this.maxVotesLimit = 0;
+        this.bannerId = null;
         this.maxVotesLimit = 0;
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
@@ -57,6 +57,10 @@ public class Contest extends BaseEntity {
         this.maxVotesLimit = 0;
     }
 
+    public void updateIsCurrent(final Boolean isCurrent) {
+        this.isCurrent = isCurrent;
+    }
+
     public void updateContest(final Long categoryId, final String contestName) {
         this.categoryId = categoryId;
         this.contestName = contestName;

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
@@ -29,6 +29,7 @@ public class ContestCategory extends BaseEntity {
     @Column(nullable = false)
     private Boolean isDeleted;
 
+
     @Builder
     private ContestCategory(final String categoryName) {
         this.categoryName = categoryName;

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.Contest;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
@@ -9,4 +10,6 @@ public interface ContestRepository extends JpaRepository<Contest, Long> {
     boolean existsByCategoryId(final Long categoryId);
 
     boolean existsByContestName(final String contestName);
+
+    List<Contest> findAllByIsCurrentTrue();
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestRepository.java
@@ -4,6 +4,8 @@ import com.opus.opus.modules.contest.domain.Contest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestRepository extends JpaRepository<Contest, Long> {
+    long countByIsCurrentTrue();
+
     boolean existsByCategoryId(final Long categoryId);
 
     boolean existsByContestName(final String contestName);

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 public enum ContestExceptionType implements BaseExceptionType {
 
     NOT_FOUND_CONTEST(HttpStatus.NOT_FOUND, "존재하지 않는 대회입니다."),
+    CURRENT_CONTEST_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "현재 진행 중인 대회는 최대 2개까지 설정할 수 있습니다."),
+    ALREADY_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회입니다."),
+    ALREADY_NOT_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회가 아닙니다."),
     CATEGORY_HAS_CONTEST(HttpStatus.CONFLICT, "해당 카테고리에 속한 대회가 존재합니다."),
     CONTEST_NAME_ALREADY_EXIST(HttpStatus.CONFLICT, "동일한 대회명이 있습니다.");
 


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #19 

## 📜 작업 내용

- 대회 진행 상태 토글 api를 구현했습니다.
- 현재 진행 중인 대회 조회 api를 구현했습니다.
- Contest 엔티티에 bannerId를 추가했습니다. 성재님이 대회 배너 구현해주실 때 수정해야할 부분 있다면 수정해주시면 될 것 같습니다!

## 💬 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요.

## ✨ 기타

- 오늘의 한마디
