### PR TITLE
Feature/#47 대회 팀 상세보기 템플릿 기능 개발

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="temp" alt="OPUS Service Overview(추가 예정)" width="900">
+  <img width="700" height="432" alt="Image" src="https://github.com/user-attachments/assets/3c21ae9b-834b-41b0-b103-29e5e7f81754" />
 </p>
 
 <h1 align="center">🎓 OPUS (SW프로젝트관리시스템)</h1>
@@ -13,7 +13,8 @@
 <p align="center">
   <a href="https://opus.pusan.ac.kr/">🌐 운영 서비스 이동</a> | 
   <a href="https://github.com/PNUops/opus-backend">🧩 Production Repo 이동</a> | 
-  <a href="#">📄 Spring Rest Docs(예정)</a> | 
+  <a href="https://opus.pnu.app/api/docs/">📄 Spring Rest Docs </a> | 
+  <a href="https://opus.pnu.app">🔨 개발 서버 </a> | 
   <a href="https://github.com/PNUops/ops-mvp-back">📦 MVP Backend</a>
 </p>
 

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest.adoc
@@ -1,0 +1,126 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= CONTEST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:../opus.html[API 목록으로 돌아가기]
+
+== 투표 기간 관련
+=== `GET`: 투표 기간 조회
+
+.HTTP Request
+include::{snippets}/get-vote-period/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-vote-period/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/get-vote-period/path-parameters.adoc[]
+
+.Response Fields
+include::{snippets}/get-vote-period/response-fields.adoc[]
+
+
+=== `PUT`: 투표 기간 수정
+
+.HTTP Request
+include::{snippets}/update-vote-period/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/update-vote-period/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/update-vote-period/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/update-vote-period/request-headers.adoc[]
+
+.Request Fields
+include::{snippets}/update-vote-period/request-fields.adoc[]
+
+
+== 최대 투표 개수 관리
+
+=== `PATCH`: 최대 투표 개수 설정
+
+.Path Parameters
+include::{snippets}/update-max-votes-limit/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/update-max-votes-limit/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/update-max-votes-limit/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/update-max-votes-limit/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/update-max-votes-limit/request-fields.adoc[]
+
+==== ⚠️ 실패 케이스
+
+.❌ Case 1: 존재하지 않는 대회
+
+[%collapsible]
+
+====
+
+include::{snippets}/update-max-votes-limit-fail-not-found/http-request.adoc[]
+
+include::{snippets}/update-max-votes-limit-fail-not-found/http-response.adoc[]
+
+====
+
+.❌ Case 2: 투표 진행 중
+
+[%collapsible]
+
+====
+
+include::{snippets}/update-max-votes-limit-fail-voting-period/http-request.adoc[]
+
+include::{snippets}/update-max-votes-limit-fail-voting-period/http-response.adoc[]
+
+====
+
+=== `GET`: 최대 투표 개수 조회
+
+.Path Parameters
+include::{snippets}/get-max-votes-limit/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/get-max-votes-limit/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/get-max-votes-limit/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-max-votes-limit/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-max-votes-limit/response-fields.adoc[]
+
+==== ⚠️ 실패 케이스
+
+.❌ Case 1: 존재하지 않는 대회
+
+[%collapsible]
+
+====
+
+include::{snippets}/get-max-votes-limit-fail-not-found/http-request.adoc[]
+
+include::{snippets}/get-max-votes-limit-fail-not-found/http-response.adoc[]
+
+====
+

--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 == API 목록
 
-link:../opus.html[API 목록으로 돌아가기]
+link:./opus.html[API 목록으로 돌아가기]
 
 == `POST`: 회원가입 이메일 인증
 
@@ -36,6 +36,8 @@ include::{snippets}/signup-auth/request-fields.adoc[]
 include::{snippets}/signup-auth-fail/http-request.adoc[]
 
 include::{snippets}/signup-auth-fail/http-response.adoc[]
+
+include::{snippets}/signup-auth-fail/request-fields.adoc[]
 
 ====
 
@@ -62,6 +64,8 @@ include::{snippets}/signup-auth-confirm-fail/http-request.adoc[]
 
 include::{snippets}/signup-auth-confirm-fail/http-response.adoc[]
 
+include::{snippets}/signup-auth-confirm-fail/request-fields.adoc[]
+
 ====
 
 .❌ Case 2: 만료된 인증코드
@@ -73,6 +77,8 @@ include::{snippets}/signup-auth-confirm-fail/http-response.adoc[]
 include::{snippets}/signup-auth-confirm-fail2/http-request.adoc[]
 
 include::{snippets}/signup-auth-confirm-fail2/http-response.adoc[]
+
+include::{snippets}/signup-auth-confirm-fail2/request-fields.adoc[]
 
 ====
 
@@ -152,3 +158,55 @@ include::{snippets}/get-password/path-parameters.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-password/response-fields.adoc[]
+
+== `GET`: Google OAuth 로그인 리다이렉트
+
+NOTE: 사용자를 Google OAuth 인증 페이지로 리다이렉트합니다. CSRF 공격 방지를 위한 `state` 파라미터가 세션 ID와 함께 Redis에 저장됩니다. (TTL: 5분)
+
+.HTTP Request
+include::{snippets}/oauth-google-redirect/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/oauth-google-redirect/http-response.adoc[]
+
+== `GET`: Google OAuth 콜백
+
+NOTE: Google OAuth 인증 완료 후 호출되는 콜백 엔드포인트입니다. 기존 회원이면 로그인 처리, 신규 회원이면 자동 가입 후 JWT 토큰을 발급합니다.
+
+.HTTP Request
+include::{snippets}/oauth-google-callback/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/oauth-google-callback/http-response.adoc[]
+
+.Query Parameters
+include::{snippets}/oauth-google-callback/query-parameters.adoc[]
+
+.Response Body's Fields
+include::{snippets}/oauth-google-callback/response-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: state 누락/불일치/만료
+
+[%collapsible]
+
+====
+
+include::{snippets}/oauth-google-callback-fail-state/http-request.adoc[]
+
+include::{snippets}/oauth-google-callback-fail-state/http-response.adoc[]
+
+====
+
+.❌ Case 2: 사용자 권한 거부
+
+[%collapsible]
+
+====
+
+include::{snippets}/oauth-google-callback-fail-denied/http-request.adoc[]
+
+include::{snippets}/oauth-google-callback-fail-denied/http-response.adoc[]
+
+====

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -12,9 +12,11 @@ endif::[]
 
 == API 목록
 
-link:../opus.html[API 목록으로 돌아가기]
+link:./opus.html[API 목록으로 돌아가기]
 
 == `POST`: 전체 공지사항 생성
+
+NOTE: 전체 공지사항의 contestId는 null 입니다.
 
 .HTTP Request Headers
 include::{snippets}/create-notice/request-headers.adoc[]
@@ -80,3 +82,76 @@ include::{snippets}/get-all-notices/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-all-notices/response-fields.adoc[]
+
+== `POST`: 대회별 공지사항 생성
+
+.HTTP Request Headers
+include::{snippets}/create-contest-notice/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/create-contest-notice/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/create-contest-notice/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/create-contest-notice/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/create-contest-notice/request-fields.adoc[]
+
+== `PATCH`: 대회별 공지사항 수정
+
+.HTTP Request Headers
+include::{snippets}/update-contest-notice/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/update-contest-notice/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/update-contest-notice/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/update-contest-notice/request-fields.adoc[]
+
+.Path Parameters
+include::{snippets}/update-contest-notice/path-parameters.adoc[]
+
+== `DELETE`: 대회별 공지사항 삭제
+
+.HTTP Request Headers
+include::{snippets}/delete-contest-notice/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/delete-contest-notice/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-contest-notice/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-contest-notice/path-parameters.adoc[]
+
+== `GET`: 대회별 공지사항 상세 조회
+
+.HTTP Request
+include::{snippets}/get-contest-notice/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-contest-notice/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/get-contest-notice/path-parameters.adoc[]
+
+== `GET`: 대회별 공지사항 목록 조회
+
+.HTTP Request
+include::{snippets}/get-all-contest-notices/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/get-all-contest-notices/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/get-all-contest-notices/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-all-contest-notices/response-fields.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -11,3 +11,17 @@ endif::[]
 
 == 멤버 관련 API
 link:./member.html[회원 API]
+
+== 팀 관련 API
+
+link:./team.html[팀 API]
+
+link:./team-comment.html[팀 댓글 API]
+
+link:./team-member.html[팀원 API]
+
+== 공지 관련 API
+link:./notice.html[공지 API]
+
+== 대회 관련 API
+link:./contest.html[대회 API]

--- a/src/main/java/com/opus/opus/docs/asciidoc/team-comment.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/team-comment.adoc
@@ -1,0 +1,122 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= TEAM COMMENT API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:./opus.html[API 목록으로 돌아가기]
+
+== `POST`: 팀 댓글 등록
+
+.Path Parameters
+include::{snippets}/create-team-comment/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/create-team-comment/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/create-team-comment/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/create-team-comment/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/create-team-comment/request-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 존재하지 않는 팀
+
+[%collapsible]
+
+====
+
+include::{snippets}/create-team-comment-fail-not-found/http-request.adoc[]
+
+include::{snippets}/create-team-comment-fail-not-found/http-response.adoc[]
+
+====
+
+== `GET`: 팀 댓글 목록 조회
+
+.Path Parameters
+include::{snippets}/get-team-comments/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/get-team-comments/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/get-team-comments/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-team-comments/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-team-comments/response-fields.adoc[]
+
+== `PATCH`: 팀 댓글 수정
+
+.Path Parameters
+include::{snippets}/update-team-comment/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/update-team-comment/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/update-team-comment/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/update-team-comment/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/update-team-comment/request-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 본인이 작성하지 않은 댓글
+
+[%collapsible]
+
+====
+
+include::{snippets}/update-team-comment-fail-not-owner/http-request.adoc[]
+
+include::{snippets}/update-team-comment-fail-not-owner/http-response.adoc[]
+
+====
+
+== `DELETE`: 팀 댓글 삭제
+
+.Path Parameters
+include::{snippets}/delete-team-comment/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/delete-team-comment/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/delete-team-comment/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-team-comment/http-response.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 본인이 작성하지 않은 댓글
+
+[%collapsible]
+
+====
+
+include::{snippets}/delete-team-comment-fail-not-owner/http-request.adoc[]
+
+include::{snippets}/delete-team-comment-fail-not-owner/http-response.adoc[]
+
+====

--- a/src/main/java/com/opus/opus/docs/asciidoc/team-member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/team-member.adoc
@@ -1,0 +1,162 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= TEAM MEMBER API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:./opus.html[API 목록으로 돌아가기]
+
+== `POST`: 팀원 추가
+
+.Path Parameters
+include::{snippets}/add-team-member/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/add-team-member/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/add-team-member/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/add-team-member/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/add-team-member/request-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 팀원명이 비어있음
+
+[%collapsible]
+
+====
+
+include::{snippets}/add-team-member-fail-empty-name/http-request.adoc[]
+
+include::{snippets}/add-team-member-fail-empty-name/http-response.adoc[]
+
+include::{snippets}/add-team-member-fail-empty-name/request-fields.adoc[]
+
+====
+
+.❌ Case 2: 팀원학번이 비어있음
+
+[%collapsible]
+
+====
+
+include::{snippets}/add-team-member-fail-empty-student-id/http-request.adoc[]
+
+include::{snippets}/add-team-member-fail-empty-student-id/http-response.adoc[]
+
+include::{snippets}/add-team-member-fail-empty-student-id/request-fields.adoc[]
+
+====
+
+.❌ Case 3: 존재하지 않는 팀 ID
+
+[%collapsible]
+
+====
+
+include::{snippets}/add-team-member-fail-team-not-found/http-request.adoc[]
+
+include::{snippets}/add-team-member-fail-team-not-found/http-response.adoc[]
+
+include::{snippets}/add-team-member-fail-team-not-found/request-fields.adoc[]
+
+====
+
+.❌ Case 4: 팀원명과 팀원학번이 맞지 않음
+
+[%collapsible]
+
+====
+
+include::{snippets}/add-team-member-fail-mismatch/http-request.adoc[]
+
+include::{snippets}/add-team-member-fail-mismatch/http-response.adoc[]
+
+include::{snippets}/add-team-member-fail-mismatch/request-fields.adoc[]
+
+====
+
+.❌ Case 5: 동일한 참가자명 + 학번이 해당 팀에 이미 존재
+
+[%collapsible]
+
+====
+
+include::{snippets}/add-team-member-fail-already-exists/http-request.adoc[]
+
+include::{snippets}/add-team-member-fail-already-exists/http-response.adoc[]
+
+include::{snippets}/add-team-member-fail-already-exists/request-fields.adoc[]
+
+====
+
+== `DELETE`: 팀원 삭제
+
+.Path Parameters
+include::{snippets}/delete-team-member/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/delete-team-member/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/delete-team-member/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-team-member/http-response.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 존재하지 않는 팀 ID
+
+[%collapsible]
+
+====
+
+include::{snippets}/delete-team-member-fail-team-not-found/http-request.adoc[]
+
+include::{snippets}/delete-team-member-fail-team-not-found/http-response.adoc[]
+
+include::{snippets}/delete-team-member-fail-team-not-found/path-parameters.adoc[]
+
+====
+
+.❌ Case 2: 존재하지 않는 멤버 ID
+
+[%collapsible]
+
+====
+
+include::{snippets}/delete-team-member-fail-member-not-found/http-request.adoc[]
+
+include::{snippets}/delete-team-member-fail-member-not-found/http-response.adoc[]
+
+include::{snippets}/delete-team-member-fail-member-not-found/path-parameters.adoc[]
+
+====
+
+.❌ Case 3: 삭제 대상 팀원이 해당 팀에 없음
+
+[%collapsible]
+
+====
+
+include::{snippets}/delete-team-member-fail-not-in-team/http-request.adoc[]
+
+include::{snippets}/delete-team-member-fail-not-in-team/http-response.adoc[]
+
+include::{snippets}/delete-team-member-fail-not-in-team/path-parameters.adoc[]
+
+====

--- a/src/main/java/com/opus/opus/docs/asciidoc/team.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/team.adoc
@@ -1,0 +1,57 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= TEAM API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:../opus.html[API 목록으로 돌아가기]
+
+== `GET`: 팀 포스터 이미지 조회
+
+.HTTP Request
+include::{snippets}/get-team-poster/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-team-poster/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/get-team-poster/path-parameters.adoc[]
+
+== `POST`: 팀 포스터 이미지 등록
+
+.HTTP Request
+include::{snippets}/save-team-poster/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/save-team-poster/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/save-team-poster/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/save-team-poster/request-headers.adoc[]
+
+.Request Parts
+include::{snippets}/save-team-poster/request-parts.adoc[]
+
+== `DELETE`: 팀 포스터 이미지 삭제
+
+.HTTP Request
+include::{snippets}/delete-team-poster/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-team-poster/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-team-poster/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/delete-team-poster/request-headers.adoc[]

--- a/src/main/java/com/opus/opus/global/config/WebMvcConfig.java
+++ b/src/main/java/com/opus/opus/global/config/WebMvcConfig.java
@@ -1,0 +1,19 @@
+package com.opus.opus.global.config;
+
+import com.opus.opus.global.security.annotation.MemberArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+    private final MemberArgumentResolver memberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(memberArgumentResolver);
+    }
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -1,0 +1,253 @@
+package com.opus.opus.global.util.oauth.component;
+
+
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_ACCESS_TOKEN;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opus.opus.global.util.AuthRedisUtil;
+import com.opus.opus.global.util.oauth.dto.GoogleOAuthToken;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleOauth implements SocialOauth {
+
+    @Value("${spring.oauth2.google.url}")
+    private String GOOGLE_SNS_URL;
+
+    @Value("${spring.oauth2.google.client-id}")
+    private String GOOGLE_SNS_CLIENT_ID;
+
+    @Value("${spring.oauth2.google.callback-login-url}")
+    private String GOOGLE_SNS_CALLBACK_LOGIN_URL;
+
+    @Value("${spring.oauth2.google.frontend-local-callback-login-url}")
+    private String GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
+
+    @Value("${spring.oauth2.google.client-secret}")
+    private String GOOGLE_SNS_CLIENT_SECRET;
+
+    @Value("${spring.oauth2.google.scope}")
+    private String GOOGLE_DATA_ACCESS_SCOPE;
+
+    private static final long OAUTH_STATE_TTL = 5L;
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    private final AuthRedisUtil authRedisUtil;
+
+    @Override
+    public String getOauthRedirectURL() {
+        final String callbackUrl = determineCallbackUrl();
+
+        final HttpServletRequest request = getCurrentHttpRequest();
+        final String sessionId = request.getSession().getId();
+        final String state = UUID.randomUUID().toString();
+        final String stateKey = createOAuthStateKey(sessionId, state);
+        authRedisUtil.set(stateKey, "valid", OAUTH_STATE_TTL, TimeUnit.MINUTES);
+
+        return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)
+                .queryParam("scope", GOOGLE_DATA_ACCESS_SCOPE)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", GOOGLE_SNS_CLIENT_ID)
+                .queryParam("redirect_uri", callbackUrl)
+                .queryParam("state", state)
+                .build()
+                .toUriString();
+    }
+
+    @Override
+    public <T> OAuthResult<T> getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
+        ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
+        GoogleOAuthToken oAuthToken = getAccessToken(accessTokenResponse);
+        ResponseEntity<String> userInfoResponse = requestUserInfo(oAuthToken);
+        T userInfo = getUserInfo(userInfoResponse, userType);
+
+        return new OAuthResult<>(userInfo, oAuthToken.accessToken(), oAuthToken.refreshToken());
+    }
+
+    public String createOAuthStateKey(final String sessionId, final String state) {
+        return "oauth:state:" + sessionId + ":" + state;
+    }
+
+    public boolean revokeToken(final String token) {
+        final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("token", token);
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_REVOKE_URL, requestEntity, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                log.debug("Google 토큰 연동 해제 성공");
+                return true;
+            }
+            return false;
+        } catch (RestClientException e) {
+            log.error("Google 토큰 연동 해제 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public String refreshAccessToken(final String refreshToken) {
+        final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("refresh_token", refreshToken);
+        params.add("grant_type", "refresh_token");
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_TOKEN_URL, requestEntity, String.class);
+            GoogleOAuthToken newToken = objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
+            return newToken.accessToken();
+        } catch (Exception e) {
+            log.error("Google Access Token 갱신 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private String determineCallbackUrl() {
+        try {
+            final HttpServletRequest request = getCurrentHttpRequest();
+            final String origin = request.getHeader("Origin");
+            log.debug("감지된 Origin 헤더: {}", origin);
+
+            if (origin != null && origin.contains("localhost:5173")) {
+                return GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
+            }
+
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+
+        } catch (Exception e) {
+            log.error("콜백 URL 결정 중 오류 발생", e);
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+        }
+    }
+
+    private HttpServletRequest getCurrentHttpRequest() {
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            log.error("OAuth 인증 요청이 HTTP 요청 컨텍스트 외부에서 호출됨");
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+        return attributes.getRequest();
+    }
+
+    private ResponseEntity<String> requestAccessToken(String code) {
+        final String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
+
+        final String callbackUrl = determineCallbackUrl();
+
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("redirect_uri", callbackUrl);
+        params.add("grant_type", "authorization_code");
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> responseEntity =
+                    restTemplate.postForEntity(
+                            GOOGLE_TOKEN_REQUEST_URL, requestEntity, String.class);
+
+            if (responseEntity.getStatusCode() == HttpStatus.OK) {
+                return responseEntity;
+            } else {
+                log.error("Google Access Token Request Failed with status: {}", responseEntity.getStatusCode());
+                throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
+            }
+        } catch (RestClientException e) {
+            log.error("Google Access Token Request Server Error: {}", e.getMessage());
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private GoogleOAuthToken getAccessToken(ResponseEntity<String> response) {
+        try {
+            GoogleOAuthToken oAuthToken =
+                    objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
+            if (oAuthToken == null || oAuthToken.accessToken() == null) {
+                throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+            }
+            return oAuthToken;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google OAuth Token: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+        }
+    }
+
+    private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
+        final String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+
+        final HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        try {
+            return restTemplate.exchange(
+                    GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
+        } catch (RestClientException e) {
+            log.error("Google User Info Request Server Error: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
+
+    private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
+        try {
+            final T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
+            if (googleUser == null) {
+                throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+            }
+            return googleUser;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google User Info: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/component/SocialOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/SocialOauth.java
@@ -1,0 +1,23 @@
+package com.opus.opus.global.util.oauth.component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
+
+public interface SocialOauth {
+
+    /**
+     * 각 소셜 로그인 페이지로 리다이렉트할 URL을 빌드합니다.
+     * 사용자로부터 로그인 요청을 받아 소셜 로그인 서버 인증용 코드를 요청합니다.
+     */
+    String getOauthRedirectURL();
+
+    /**
+     * 인가 코드를 사용하여 사용자 정보와 토큰을 가져옵니다.
+     * 내부적으로 액세스 토큰 요청 -> 사용자 정보 요청 과정을 처리합니다.
+     * @param code 인가 코드
+     * @param userType 반환할 사용자 객체 클래스 (예: GoogleUser.class)
+     * @return 사용자 정보와 토큰을 담은 OAuthResult
+     * @throws JsonProcessingException JSON 파싱 실패 시 발생
+     */
+    <T> OAuthResult<T> getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException;
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleOAuthToken.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleOAuthToken.java
@@ -1,0 +1,12 @@
+package com.opus.opus.global.util.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleOAuthToken(
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("refresh_token")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleUser.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleUser.java
@@ -1,0 +1,7 @@
+package com.opus.opus.global.util.oauth.dto;
+
+public record GoogleUser(
+	String email,
+	String name
+) {
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/OAuthResult.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/OAuthResult.java
@@ -1,0 +1,8 @@
+package com.opus.opus.global.util.oauth.dto;
+
+public record OAuthResult<T>(
+        T userInfo,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthException.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthException.java
@@ -1,0 +1,25 @@
+package com.opus.opus.global.util.oauth.exception;
+
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class OAuthException extends BaseException {
+
+	private final OAuthExceptionType exceptionType;
+
+	public OAuthException(final OAuthExceptionType exceptionType) {
+		super(exceptionType.errorMessage());
+		this.exceptionType = exceptionType;
+	}
+
+	public OAuthException(final OAuthExceptionType exceptionType, final String message) {
+		super(message);
+		this.exceptionType = exceptionType;
+	}
+
+	@Override
+	public BaseExceptionType exceptionType() {
+		return exceptionType;
+	}
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthExceptionType.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthExceptionType.java
@@ -1,0 +1,35 @@
+package com.opus.opus.global.util.oauth.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum OAuthExceptionType implements BaseExceptionType {
+
+	SOCIAL_LOGIN_FAILED_AUTH_CODE(HttpStatus.BAD_REQUEST, "소셜 로그인 인증 코드가 유효하지 않습니다."),
+	SOCIAL_LOGIN_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 서버와의 통신에 실패했습니다."),
+	FAILED_TO_GET_ACCESS_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "액세스 토큰을 가져오는데 실패했습니다."),
+	FAILED_TO_GET_SOCIAL_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 사용자 정보를 가져오는데 실패했습니다."),
+	INVALID_OAUTH_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth 토큰 타입입니다."),
+	OAUTH_AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증에 실패했습니다."),
+    USER_DENIED_AUTHORIZATION(HttpStatus.BAD_REQUEST, "사용자가 권한 요청을 거부했습니다."),
+	UNSUPPORTED_SOCIAL_LOGIN_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	OAuthExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+		this.httpStatus = httpStatus;
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public HttpStatus httpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String errorMessage() {
+		return errorMessage;
+	}
+}

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestCategoryController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestCategoryController.java
@@ -29,24 +29,24 @@ public class ContestCategoryController {
     private final ContestCategoryCommandService contestCategoryCommandService;
     private final ContestCategoryQueryService contestCategoryQueryService;
 
-    @PostMapping
     @Secured("ROLE_관리자")
+    @PostMapping
     public ResponseEntity<Void> createContestCategory(
             @Valid @RequestBody final ContestCategoryRequest request) {
         contestCategoryCommandService.createCategory(request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PatchMapping("/{categoryId}")
     @Secured("ROLE_관리자")
+    @PatchMapping("/{categoryId}")
     public ResponseEntity<Void> updateContestCategory(@Valid @RequestBody final ContestCategoryRequest request,
                                                       @PathVariable final Long categoryId) {
         contestCategoryCommandService.updateCategory(categoryId, request);
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{categoryId}")
     @Secured("ROLE_관리자")
+    @DeleteMapping("/{categoryId}")
     public ResponseEntity<Void> deleteContestCategory(@PathVariable final Long categoryId) {
         contestCategoryCommandService.deleteCategory(categoryId);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -3,12 +3,14 @@ package com.opus.opus.modules.contest.api;
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestTeamTemplateCommandService;
+import com.opus.opus.modules.contest.application.ContestTeamTemplateQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.request.TeamTemplateRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
+import com.opus.opus.modules.contest.application.dto.response.TeamTemplateResponse;
 import com.opus.opus.modules.team.application.dto.ImageResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -39,6 +41,7 @@ public class ContestController {
     private final ContestCommandService contestCommandService;
     private final ContestQueryService contestQueryService;
     private final ContestTeamTemplateCommandService contestTeamTemplateCommandService;
+    private final ContestTeamTemplateQueryService contestTeamTemplateQueryService;
 
     @GetMapping("/{contestId}/image/banner")
     public ResponseEntity<Resource> getContestBanner(@PathVariable final Long contestId) {
@@ -106,11 +109,17 @@ public class ContestController {
         return ResponseEntity.ok(responses);
     }
 
+    @GetMapping("/{contestId}/team-detail-template")
+    public ResponseEntity<TeamTemplateResponse> getTeamDetailTemplate(@PathVariable final Long contestId) {
+        TeamTemplateResponse response = contestTeamTemplateQueryService.getTeamTemplate(contestId);
+        return ResponseEntity.ok(response);
+    }
+
     @PutMapping("/{contestId}/team-detail-template")
     @Secured("ROLE_관리자")
     public ResponseEntity<Void> updateTeamDetailTemplate(@PathVariable final Long contestId,
                                                          @Valid @RequestBody final TeamTemplateRequest request) {
-        contestTeamTemplateCommandService.updateTemplate(contestId, request);
+        contestTeamTemplateCommandService.updateTeamTemplate(contestId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -11,6 +11,10 @@ import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResp
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.application.dto.response.TeamTemplateResponse;
+import com.opus.opus.modules.contest.application.dto.request.ContestVotesLimitRequest;
+import com.opus.opus.modules.contest.application.dto.request.VoteUpdateRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
+import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
 import com.opus.opus.modules.team.application.dto.ImageResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -73,30 +77,30 @@ public class ContestController {
         return ResponseEntity.ok(responses);
     }
 
-    @PostMapping
     @Secured("ROLE_관리자")
+    @PostMapping
     public ResponseEntity<ContestResponse> createContest(@Valid @RequestBody final ContestRequest request) {
         ContestResponse response = contestCommandService.createContest(request);
         return ResponseEntity.ok(response);
     }
 
-    @PatchMapping("/{contestId}")
     @Secured("ROLE_관리자")
+    @PatchMapping("/{contestId}")
     public ResponseEntity<Void> updateContest(@PathVariable final Long contestId,
                                               @Valid @RequestBody final ContestRequest request) {
         contestCommandService.updateContest(contestId, request);
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{contestId}")
     @Secured("ROLE_관리자")
+    @DeleteMapping("/{contestId}")
     public ResponseEntity<Void> deleteContest(@PathVariable final Long contestId) {
         contestCommandService.deleteContest(contestId);
         return ResponseEntity.noContent().build();
     }
 
-    @PatchMapping("/{contestId}/current")
     @Secured("ROLE_관리자")
+    @PatchMapping("/{contestId}/current")
     public ResponseEntity<ContestCurrentToggleResponse> toggleCurrent(@PathVariable final Long contestId,
                                                                       @Valid @RequestBody final ContestCurrentToggleRequest request) {
         ContestCurrentToggleResponse response = contestCommandService.toggleCurrent(contestId, request.isCurrent());
@@ -121,5 +125,33 @@ public class ContestController {
                                                          @Valid @RequestBody final TeamTemplateRequest request) {
         contestTeamTemplateCommandService.updateTeamTemplate(contestId, request);
         return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/{contestId}/vote")
+    public ResponseEntity<VotePeriodResponse> getVotePeriod(@PathVariable final Long contestId) {
+        return ResponseEntity.ok(contestQueryService.getVotePeriod(contestId));
+    }
+
+    @Secured("ROLE_관리자")
+    @PutMapping("/{contestId}/vote")
+    public ResponseEntity<Void> updateVotePeriod(@PathVariable final Long contestId,
+                                                 @Valid @RequestBody final VoteUpdateRequest voteRequest) {
+        contestCommandService.updateVotePeriod(contestId, voteRequest);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @PatchMapping("/{contestId}/votes")
+    public ResponseEntity<Void> updateMaxVotesLimit(@PathVariable final Long contestId,
+                                                    @Valid @RequestBody final ContestVotesLimitRequest request) {
+        contestCommandService.updateMaxVotesLimit(contestId, request.maxVotesLimit());
+        return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @GetMapping("/{contestId}/votes")
+    public ResponseEntity<ContestVotesLimitResponse> getMaxVotesLimit(@PathVariable final Long contestId) {
+        final ContestVotesLimitResponse response = contestQueryService.getMaxVotesLimit(contestId);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -2,8 +2,10 @@ package com.opus.opus.modules.contest.api;
 
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.ContestTeamDetailTemplateCommandService;
 import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
+import com.opus.opus.modules.contest.application.dto.request.TeamDetailTemplateRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -35,6 +38,7 @@ public class ContestController {
 
     private final ContestCommandService contestCommandService;
     private final ContestQueryService contestQueryService;
+    private final ContestTeamDetailTemplateCommandService contestTeamDetailTemplateCommandService;
 
     @GetMapping("/{contestId}/image/banner")
     public ResponseEntity<Resource> getContestBanner(@PathVariable final Long contestId) {
@@ -100,5 +104,13 @@ public class ContestController {
     public ResponseEntity<List<ContestCurrentResponse>> getCurrentContests() {
         List<ContestCurrentResponse> responses = contestQueryService.getCurrentContests();
         return ResponseEntity.ok(responses);
+    }
+
+    @PutMapping("/{contestId}/team-detail-template")
+    @Secured("ROLE_관리자")
+    public ResponseEntity<Void> updateTeamDetailTemplate(@PathVariable final Long contestId,
+                                                         @Valid @RequestBody final TeamDetailTemplateRequest request) {
+        contestTeamDetailTemplateCommandService.updateTemplate(contestId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -2,10 +2,10 @@ package com.opus.opus.modules.contest.api;
 
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
-import com.opus.opus.modules.contest.application.ContestTeamDetailTemplateCommandService;
+import com.opus.opus.modules.contest.application.ContestTeamTemplateCommandService;
 import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
-import com.opus.opus.modules.contest.application.dto.request.TeamDetailTemplateRequest;
+import com.opus.opus.modules.contest.application.dto.request.TeamTemplateRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
@@ -38,7 +38,7 @@ public class ContestController {
 
     private final ContestCommandService contestCommandService;
     private final ContestQueryService contestQueryService;
-    private final ContestTeamDetailTemplateCommandService contestTeamDetailTemplateCommandService;
+    private final ContestTeamTemplateCommandService contestTeamTemplateCommandService;
 
     @GetMapping("/{contestId}/image/banner")
     public ResponseEntity<Resource> getContestBanner(@PathVariable final Long contestId) {
@@ -109,8 +109,8 @@ public class ContestController {
     @PutMapping("/{contestId}/team-detail-template")
     @Secured("ROLE_관리자")
     public ResponseEntity<Void> updateTeamDetailTemplate(@PathVariable final Long contestId,
-                                                         @Valid @RequestBody final TeamDetailTemplateRequest request) {
-        contestTeamDetailTemplateCommandService.updateTemplate(contestId, request);
+                                                         @Valid @RequestBody final TeamTemplateRequest request) {
+        contestTeamTemplateCommandService.updateTemplate(contestId, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
@@ -24,22 +24,22 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/contest/{contestId}/tracks")
+@RequestMapping("/contests/{contestId}/tracks")
 public class ContestTrackController {
 
     private final ContestTrackCommandService contestTrackCommandService;
     private final ContestTrackQueryService contestTrackQueryService;
 
-    @PostMapping
     @Secured("ROLE_관리자")
+    @PostMapping
     public ResponseEntity<Void> createContestTrack(@Valid @RequestBody final ContestTrackRequest request,
                                                    @PathVariable final Long contestId) {
         contestTrackCommandService.createTrack(contestId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PatchMapping("/{trackId}")
     @Secured("ROLE_관리자")
+    @PatchMapping("/{trackId}")
     public ResponseEntity<Void> updateContestTrack(@Valid @RequestBody final ContestTrackRequest request,
                                                    @PathVariable final Long contestId,
                                                    @PathVariable final Long trackId) {
@@ -47,8 +47,8 @@ public class ContestTrackController {
         return ResponseEntity.noContent().build();
     }
 
-    @DeleteMapping("/{trackId}")
     @Secured("ROLE_관리자")
+    @DeleteMapping("/{trackId}")
     public ResponseEntity<Void> deleteContestTrack(@PathVariable final Long contestId,
                                                    @PathVariable final Long trackId) {
         contestTrackCommandService.deleteTrack(contestId, trackId);

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -11,6 +11,7 @@ import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_WEBP_CO
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestTeamTemplateConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
@@ -40,6 +41,7 @@ public class ContestCommandService {
     private final ContestConvenience contestConvenience;
     private final ContestCategoryConvenience contestCategoryConvenience;
     private final TeamConvenience teamConvenience;
+    private final ContestTeamTemplateConvenience contestTeamTemplateConvenience;
 
     private final FileStorageUtil fileStorageUtil;
 
@@ -70,6 +72,9 @@ public class ContestCommandService {
                 .categoryId(request.categoryId())
                 .build();
         contestRepository.save(contest);
+
+        // 템플릿 자동 생성
+        contestTeamTemplateConvenience.createTemplate(contest, contestCategory.getCategoryName());
 
         return ContestResponse.from(contest, contestCategory.getCategoryName());
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -1,8 +1,10 @@
 package com.opus.opus.modules.contest.application;
 
 
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.*;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.ALREADY_CURRENT_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.ALREADY_NOT_CURRENT_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.CURRENT_CONTEST_LIMIT_EXCEEDED;
 import static com.opus.opus.modules.file.domain.FileImageType.BANNER;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.CONTEST;
@@ -13,12 +15,15 @@ import com.opus.opus.modules.contest.application.convenience.ContestCategoryConv
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTeamTemplateConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
+import com.opus.opus.modules.contest.application.dto.request.VoteUpdateRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentToggleResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
+import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestExceptionType;
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.file.exception.FileException;
@@ -104,6 +109,33 @@ public class ContestCommandService {
         // 변경
         contest.updateIsCurrent(isCurrent);
         return ContestCurrentToggleResponse.of(contest.getId(), isCurrent);
+    }
+
+    public void updateVotePeriod(final Long contestId, final VoteUpdateRequest voteRequest) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        checkVoteRange(voteRequest);
+        contest.updateVotePeriod(voteRequest.voteStartAt(), voteRequest.voteEndAt());
+    }
+
+    private void checkVoteRange(final VoteUpdateRequest voteRequest) {
+        final int compare = voteRequest.voteStartAt().compareTo(voteRequest.voteEndAt());
+        if (compare > 0) {
+            throw new ContestException(VOTE_END_PRECEDE_VOTE_START);
+        }
+    }
+
+    public void updateMaxVotesLimit(final Long contestId, final Integer maxVotesLimit) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+
+        validateNotInVotingPeriod(contest);
+
+        contest.updateMaxVotesLimit(maxVotesLimit);
+    }
+
+    private void validateNotInVotingPeriod(final Contest contest) {
+        if (contest.isVotingPeriod()) {
+            throw new ContestException(CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD);
+        }
     }
 
     private void checkWebpConverted(File existingFile) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -10,6 +10,8 @@ import com.opus.opus.modules.contest.application.convenience.ContestCategoryConv
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
+import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
@@ -70,6 +72,16 @@ public class ContestQueryService {
                     return ContestResponse.from(contest, category.getCategoryName());
                 })
                 .toList();
+    }
+
+    public VotePeriodResponse getVotePeriod(final Long contestId) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        return new VotePeriodResponse(contest.getVoteStartAt(), contest.getVoteEndAt());
+    }
+
+    public ContestVotesLimitResponse getMaxVotesLimit(final Long contestId) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        return ContestVotesLimitResponse.from(contest.getMaxVotesLimit());
     }
 
     private void checkImageConverted(final File findFile) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTeamTemplateCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTeamTemplateCommandService.java
@@ -16,7 +16,7 @@ public class ContestTeamTemplateCommandService {
     private final ContestConvenience contestConvenience;
     private final ContestTeamTemplateConvenience contestTeamTemplateConvenience;
 
-    public void updateTemplate(final Long contestId, final TeamTemplateRequest request) {
+    public void updateTeamTemplate(final Long contestId, final TeamTemplateRequest request) {
 
         contestConvenience.getValidateExistContest(contestId);
         final ContestTeamTemplate template = contestTeamTemplateConvenience.getValidateExistTemplate(

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTeamTemplateCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTeamTemplateCommandService.java
@@ -1,0 +1,40 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestTeamTemplateConvenience;
+import com.opus.opus.modules.contest.application.dto.request.TeamTemplateRequest;
+import com.opus.opus.modules.contest.domain.ContestTeamTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ContestTeamTemplateCommandService {
+
+    private final ContestConvenience contestConvenience;
+    private final ContestTeamTemplateConvenience contestTeamTemplateConvenience;
+
+    public void updateTemplate(final Long contestId, final TeamTemplateRequest request) {
+
+        contestConvenience.getValidateExistContest(contestId);
+        final ContestTeamTemplate template = contestTeamTemplateConvenience.getValidateExistTemplate(
+                contestId);
+
+        template.updateTemplate(
+                request.division(),
+                request.projectName(),
+                request.teamName(),
+                request.leader(),
+                request.teamMembers(),
+                request.professor(),
+                request.githubPath(),
+                request.youtubePath(),
+                request.productionPath(),
+                request.overview(),
+                request.poster(),
+                request.images()
+        );
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTeamTemplateQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTeamTemplateQueryService.java
@@ -1,0 +1,24 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestTeamTemplateConvenience;
+import com.opus.opus.modules.contest.application.dto.response.TeamTemplateResponse;
+import com.opus.opus.modules.contest.domain.ContestTeamTemplate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestTeamTemplateQueryService {
+
+    private final ContestConvenience contestConvenience;
+    private final ContestTeamTemplateConvenience contestTeamTemplateConvenience;
+
+    public TeamTemplateResponse getTeamTemplate(final Long contestId) {
+        contestConvenience.getValidateExistContest(contestId);
+        final ContestTeamTemplate template = contestTeamTemplateConvenience.getValidateExistTemplate(contestId);
+        return TeamTemplateResponse.from(template);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -24,6 +24,10 @@ public class ContestConvenience {
         return contestRepository.findById(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 
+    public void validateExistContest(final Long contestId) {
+        contestRepository.findById(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
+    }
+
     public void validateAllContestsDeletedInCategory(final Long categoryId) {
         if (contestRepository.existsByCategoryId(categoryId)) {
             throw new ContestException(CATEGORY_HAS_CONTEST);

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestTeamTemplateConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestTeamTemplateConvenience.java
@@ -1,0 +1,102 @@
+package com.opus.opus.modules.contest.application.convenience;
+
+import static com.opus.opus.modules.contest.domain.ContestTeamTemplateFieldType.HIDDEN;
+import static com.opus.opus.modules.contest.domain.ContestTeamTemplateFieldType.OPTIONAL;
+import static com.opus.opus.modules.contest.domain.ContestTeamTemplateFieldType.REQUIRED;
+import static com.opus.opus.modules.contest.exception.ContestTeamTemplateExceptionType.NOT_FOUND_TEMPLATE;
+
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestTeamTemplate;
+import com.opus.opus.modules.contest.domain.ContestTeamTemplateFieldType;
+import com.opus.opus.modules.contest.domain.dao.ContestTeamTemplateRepository;
+import com.opus.opus.modules.contest.exception.ContestTeamTemplateException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestTeamTemplateConvenience {
+
+    private final ContestTeamTemplateRepository contestTeamTemplateRepository;
+
+    public ContestTeamTemplate getValidateExistTemplate(final Long contestId) {
+        return contestTeamTemplateRepository.findByContestId(contestId)
+                .orElseThrow(() -> new ContestTeamTemplateException(NOT_FOUND_TEMPLATE));
+    }
+
+    public void createTemplate(final Contest contest, final String categoryName) {
+        final Map<String, ContestTeamTemplateFieldType> settings = getTemplateDefaultSettings(categoryName);
+
+        ContestTeamTemplate template = ContestTeamTemplate.builder()
+                .contest(contest)
+                .division(settings.get("division"))
+                .projectName(settings.get("projectName"))
+                .teamName(settings.get("teamName"))
+                .leader(settings.get("leader"))
+                .teamMembers(settings.get("teamMembers"))
+                .professor(settings.get("professor"))
+                .githubPath(settings.get("githubPath"))
+                .youtubePath(settings.get("youtubePath"))
+                .productionPath(settings.get("productionPath"))
+                .overview(settings.get("overview"))
+                .poster(settings.get("poster"))
+                .images(settings.get("images"))
+                .build();
+
+        contestTeamTemplateRepository.save(template);
+    }
+
+    private Map<String, ContestTeamTemplateFieldType> getTemplateDefaultSettings(final String categoryName) {
+
+        Map<String, ContestTeamTemplateFieldType> map = new HashMap<>();
+
+        if (categoryName.contains("창의융합")) {
+            map.put("division", REQUIRED);
+            map.put("projectName", REQUIRED);
+            map.put("teamName", REQUIRED);
+            map.put("leader", REQUIRED);
+            map.put("teamMembers", REQUIRED);
+            map.put("professor", HIDDEN);
+            map.put("githubPath", REQUIRED);
+            map.put("youtubePath", OPTIONAL);
+            map.put("productionPath", OPTIONAL);
+            map.put("overview", REQUIRED);
+            map.put("poster", REQUIRED);
+            map.put("images", REQUIRED);
+
+        } else if (categoryName.contains("캡스톤")) {
+            map.put("division", REQUIRED);
+            map.put("projectName", REQUIRED);
+            map.put("teamName", REQUIRED);
+            map.put("leader", REQUIRED);
+            map.put("teamMembers", REQUIRED);
+            map.put("professor", REQUIRED);
+            map.put("githubPath", REQUIRED);
+            map.put("youtubePath", REQUIRED);
+            map.put("productionPath", OPTIONAL);
+            map.put("overview", REQUIRED);
+            map.put("poster", OPTIONAL);
+            map.put("images", REQUIRED);
+
+        } else {
+            map.put("division", OPTIONAL);
+            map.put("projectName", OPTIONAL);
+            map.put("teamName", OPTIONAL);
+            map.put("leader", OPTIONAL);
+            map.put("teamMembers", OPTIONAL);
+            map.put("professor", OPTIONAL);
+            map.put("githubPath", OPTIONAL);
+            map.put("youtubePath", OPTIONAL);
+            map.put("productionPath", OPTIONAL);
+            map.put("overview", OPTIONAL);
+            map.put("poster", OPTIONAL);
+            map.put("images", OPTIONAL);
+        }
+        return map;
+    }
+
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
@@ -1,11 +1,12 @@
 package com.opus.opus.modules.contest.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record ContestRequest(
         @NotBlank(message = "대회명은 비어 있을 수 없습니다.")
         String contestName,
-        @NotBlank(message = "카테고리ID는 비어 있을 수 없습니다.")
+        @NotNull(message = "카테고리ID는 비어 있을 수 없습니다.")
         Long categoryId
 ) {
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestVotesLimitRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestVotesLimitRequest.java
@@ -1,0 +1,11 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ContestVotesLimitRequest(
+        @NotNull(message = "최대 투표 개수는 필수입니다.")
+        @Min(value = 0, message = "최대 투표 개수는 0 이상이어야 합니다.")
+        Integer maxVotesLimit
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/TeamTemplateRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/TeamTemplateRequest.java
@@ -1,0 +1,33 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import com.opus.opus.modules.contest.domain.ContestTeamTemplateFieldType;
+import jakarta.validation.constraints.NotNull;
+
+public record TeamTemplateRequest(
+        @NotNull(message = "분과 설정은 필수입니다.")
+        ContestTeamTemplateFieldType division,
+        @NotNull(message = "프로젝트명 설정은 필수입니다.")
+        ContestTeamTemplateFieldType projectName,
+        @NotNull(message = "팀명 설정은 필수입니다.")
+        ContestTeamTemplateFieldType teamName,
+        @NotNull(message = "팀장 설정은 필수입니다.")
+        ContestTeamTemplateFieldType leader,
+        @NotNull(message = "팀원 설정은 필수입니다.")
+        ContestTeamTemplateFieldType teamMembers,
+        @NotNull(message = "지도 교수 설정은 필수입니다.")
+        ContestTeamTemplateFieldType professor,
+        @NotNull(message = "GitHub 링크 설정은 필수입니다.")
+        ContestTeamTemplateFieldType githubPath,
+        @NotNull(message = "YouTube 링크 설정은 필수입니다.")
+        ContestTeamTemplateFieldType youtubePath,
+        @NotNull(message = "배포 링크 설정은 필수입니다.")
+        ContestTeamTemplateFieldType productionPath,
+        @NotNull(message = "프로젝트 개요 설정은 필수입니다.")
+        ContestTeamTemplateFieldType overview,
+        @NotNull(message = "포스터 설정은 필수입니다.")
+        ContestTeamTemplateFieldType poster,
+        @NotNull(message = "이미지 설정은 필수입니다.")
+        ContestTeamTemplateFieldType images
+) {
+}
+

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/VoteUpdateRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/VoteUpdateRequest.java
@@ -1,0 +1,12 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+
+public record VoteUpdateRequest(
+        @NotNull(message = "투표 시작 시각을 정해야 합니다")
+        LocalDateTime voteStartAt,
+        @NotNull(message = "투표 종료 시각을 정해야 합니다")
+        LocalDateTime voteEndAt
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestVotesLimitResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestVotesLimitResponse.java
@@ -1,0 +1,9 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+public record ContestVotesLimitResponse(
+        Integer maxVotesLimit
+) {
+    public static ContestVotesLimitResponse from(final Integer maxVotesLimit) {
+        return new ContestVotesLimitResponse(maxVotesLimit);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/TeamTemplateResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/TeamTemplateResponse.java
@@ -1,0 +1,38 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.ContestTeamTemplate;
+import com.opus.opus.modules.contest.domain.ContestTeamTemplateFieldType;
+
+public record TeamTemplateResponse(
+        Long contestId,
+        ContestTeamTemplateFieldType division,
+        ContestTeamTemplateFieldType projectName,
+        ContestTeamTemplateFieldType teamName,
+        ContestTeamTemplateFieldType leader,
+        ContestTeamTemplateFieldType teamMembers,
+        ContestTeamTemplateFieldType professor,
+        ContestTeamTemplateFieldType githubPath,
+        ContestTeamTemplateFieldType youtubePath,
+        ContestTeamTemplateFieldType productionPath,
+        ContestTeamTemplateFieldType overview,
+        ContestTeamTemplateFieldType poster,
+        ContestTeamTemplateFieldType images
+) {
+    public static TeamTemplateResponse from(final ContestTeamTemplate template) {
+        return new TeamTemplateResponse(
+                template.getContest().getId(),
+                template.getDivision(),
+                template.getProjectName(),
+                template.getTeamName(),
+                template.getLeader(),
+                template.getTeamMembers(),
+                template.getProfessor(),
+                template.getGithubPath(),
+                template.getYoutubePath(),
+                template.getProductionPath(),
+                template.getOverview(),
+                template.getPoster(),
+                template.getImages()
+        );
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/VotePeriodResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/VotePeriodResponse.java
@@ -1,0 +1,9 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import java.time.LocalDateTime;
+
+public record VotePeriodResponse(
+        LocalDateTime voteStartAt,
+        LocalDateTime voteEndAt
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/Contest.java
@@ -71,4 +71,18 @@ public class Contest extends BaseEntity {
         this.categoryId = categoryId;
         this.contestName = contestName;
     }
+
+    public void updateMaxVotesLimit(final Integer maxVotesLimit) {
+        this.maxVotesLimit = maxVotesLimit;
+    }
+
+    public boolean isVotingPeriod() {
+        final LocalDateTime now = LocalDateTime.now();
+        return !now.isBefore(voteStartAt) && !now.isAfter(voteEndAt);
+    }
+
+    public void updateVotePeriod(final LocalDateTime voteStartAt, final LocalDateTime voteEndAt) {
+        this.voteStartAt = voteStartAt;
+        this.voteEndAt = voteEndAt;
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
@@ -17,7 +17,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
-@SQLDelete(sql = "UPDATE contest SET is_deleted = true where id = ?")
+@SQLDelete(sql = "UPDATE contest_category SET is_deleted = true WHERE id = ?")
 public class ContestCategory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +28,7 @@ public class ContestCategory extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean isDeleted;
-    
+
     @Builder
     private ContestCategory(final String categoryName) {
         this.categoryName = categoryName;

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTeamTemplate.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTeamTemplate.java
@@ -1,0 +1,145 @@
+package com.opus.opus.modules.contest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.opus.opus.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE contest_team_template SET is_deleted = true WHERE id = ?")
+public class ContestTeamTemplate extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "contest_id", nullable = false, unique = true)
+    private Contest contest;
+
+    @Column(name = "division", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType division;
+
+    @Column(name = "project_name", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType projectName;
+
+    @Column(name = "team_name", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType teamName;
+
+    @Column(name = "leader", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType leader;
+
+    @Column(name = "team_members", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType teamMembers;
+
+    @Column(name = "professor", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType professor;
+
+    @Column(name = "github_path", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType githubPath;
+
+    @Column(name = "youtube_path", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType youtubePath;
+
+    @Column(name = "production_path", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType productionPath;
+
+    @Column(name = "overview", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType overview;
+
+    @Column(name = "poster", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType poster;
+
+    @Column(name = "images", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ContestTeamTemplateFieldType images;
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
+    @Builder
+    private ContestTeamTemplate(
+            final Contest contest,
+            final ContestTeamTemplateFieldType division,
+            final ContestTeamTemplateFieldType projectName,
+            final ContestTeamTemplateFieldType teamName,
+            final ContestTeamTemplateFieldType leader,
+            final ContestTeamTemplateFieldType teamMembers,
+            final ContestTeamTemplateFieldType professor,
+            final ContestTeamTemplateFieldType githubPath,
+            final ContestTeamTemplateFieldType youtubePath,
+            final ContestTeamTemplateFieldType productionPath,
+            final ContestTeamTemplateFieldType overview,
+            final ContestTeamTemplateFieldType poster,
+            final ContestTeamTemplateFieldType images) {
+        this.contest = contest;
+        this.division = division;
+        this.projectName = projectName;
+        this.teamName = teamName;
+        this.leader = leader;
+        this.teamMembers = teamMembers;
+        this.professor = professor;
+        this.githubPath = githubPath;
+        this.youtubePath = youtubePath;
+        this.productionPath = productionPath;
+        this.overview = overview;
+        this.poster = poster;
+        this.images = images;
+        this.isDeleted = false;
+    }
+
+    public void updateTemplate(
+            final ContestTeamTemplateFieldType division,
+            final ContestTeamTemplateFieldType projectName,
+            final ContestTeamTemplateFieldType teamName,
+            final ContestTeamTemplateFieldType leader,
+            final ContestTeamTemplateFieldType teamMembers,
+            final ContestTeamTemplateFieldType professor,
+            final ContestTeamTemplateFieldType githubPath,
+            final ContestTeamTemplateFieldType youtubePath,
+            final ContestTeamTemplateFieldType productionPath,
+            final ContestTeamTemplateFieldType overview,
+            final ContestTeamTemplateFieldType poster,
+            final ContestTeamTemplateFieldType images) {
+        this.division = division;
+        this.projectName = projectName;
+        this.teamName = teamName;
+        this.leader = leader;
+        this.teamMembers = teamMembers;
+        this.professor = professor;
+        this.githubPath = githubPath;
+        this.youtubePath = youtubePath;
+        this.productionPath = productionPath;
+        this.overview = overview;
+        this.poster = poster;
+        this.images = images;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTeamTemplateFieldType.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTeamTemplateFieldType.java
@@ -1,0 +1,18 @@
+package com.opus.opus.modules.contest.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ContestTeamTemplateFieldType {
+    REQUIRED(1),
+    OPTIONAL(2),
+    HIDDEN(3),
+    ;
+
+    private final long id;
+
+    ContestTeamTemplateFieldType(final long id) {
+        this.id = id;
+    }
+}
+

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
-@SQLDelete(sql = "UPDATE contest SET is_deleted = true where id = ?")
+@SQLDelete(sql = "UPDATE contest_track SET is_deleted = true WHERE id = ?")
 public class ContestTrack extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTeamTemplateRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTeamTemplateRepository.java
@@ -1,0 +1,11 @@
+package com.opus.opus.modules.contest.domain.dao;
+
+import com.opus.opus.modules.contest.domain.ContestTeamTemplate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestTeamTemplateRepository extends JpaRepository<ContestTeamTemplate, Long> {
+
+    Optional<ContestTeamTemplate> findByContestId(final Long contestId);
+
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -10,7 +10,10 @@ public enum ContestExceptionType implements BaseExceptionType {
     ALREADY_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회입니다."),
     ALREADY_NOT_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회가 아닙니다."),
     CATEGORY_HAS_CONTEST(HttpStatus.CONFLICT, "해당 카테고리에 속한 대회가 존재합니다."),
-    CONTEST_NAME_ALREADY_EXIST(HttpStatus.CONFLICT, "동일한 대회명이 있습니다.");
+    CONTEST_NAME_ALREADY_EXIST(HttpStatus.CONFLICT, "동일한 대회명이 있습니다."),
+    VOTE_END_PRECEDE_VOTE_START(HttpStatus.BAD_REQUEST, "투표 종료가 투표 시작보다 빠를 수 없습니다."),
+    CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD(HttpStatus.BAD_REQUEST, "투표 진행중에는 최대 투표 개수를 변경할 수 없습니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestTeamTemplateException.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestTeamTemplateException.java
@@ -1,0 +1,24 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class ContestTeamTemplateException extends BaseException {
+    private final ContestTeamTemplateExceptionType exceptionType;
+
+    public ContestTeamTemplateException(final ContestTeamTemplateExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public ContestTeamTemplateException(final ContestTeamTemplateExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}
+

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestTeamTemplateExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestTeamTemplateExceptionType.java
@@ -1,0 +1,27 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ContestTeamTemplateExceptionType implements BaseExceptionType {
+    NOT_FOUND_TEMPLATE(HttpStatus.NOT_FOUND, "템플릿을 찾을 수 없습니다."),
+    INVALID_TEMPLATE_FIELD_TYPE(HttpStatus.BAD_REQUEST, "TemplateFieldType은 REQUIRED, OPTIONAL, HIDDEN 중 하나입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    ContestTeamTemplateExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/file/application/convenience/FileConvenience.java
+++ b/src/main/java/com/opus/opus/modules/file/application/convenience/FileConvenience.java
@@ -1,8 +1,6 @@
 package com.opus.opus.modules.file.application.convenience;
 
-import static com.opus.opus.modules.file.domain.FileImageType.THUMBNAIL;
-import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
-import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_THUMBNAIL;
+import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_MATCHING_IMAGE_ID;
 
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.FileImageType;
@@ -23,7 +21,7 @@ public class FileConvenience {
     public File findByReferenceIdAndReferenceTypeAndImageType(final Long teamId,
                                                               final ReferenceDomainType referenceType,
                                                               final FileImageType imageType) {
-        return fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
-                .orElseThrow(() -> new FileException(NOT_EXISTS_THUMBNAIL));
+        return fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, referenceType, imageType)
+                .orElseThrow(() -> new FileException(NOT_EXISTS_MATCHING_IMAGE_ID));
     }
 }

--- a/src/main/java/com/opus/opus/modules/file/domain/FileImageType.java
+++ b/src/main/java/com/opus/opus/modules/file/domain/FileImageType.java
@@ -5,5 +5,6 @@ public enum FileImageType {
     PREVIEW,
     THUMBNAIL,
     BANNER,
+    POSTER,
 }
 

--- a/src/main/java/com/opus/opus/modules/file/exception/FileExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/file/exception/FileExceptionType.java
@@ -5,12 +5,11 @@ import org.springframework.http.HttpStatus;
 
 public enum FileExceptionType implements BaseExceptionType {
     NOT_EXISTS_MATCHING_IMAGE_ID(HttpStatus.NOT_FOUND, "아이디와 일치하는 이미지가 없습니다"),
-    NOT_EXISTS_THUMBNAIL(HttpStatus.NOT_FOUND, "팀 썸네일이 존재하지 않습니다"),
+    NOT_EXISTS_MATCHING_IMAGE_ID_AND_TYPE(HttpStatus.NOT_FOUND, "아이디, 타입과 일치하는 이미지가 없습니다"),
     NOT_EXISTS_PREVIEW(HttpStatus.NOT_FOUND, "존재하지 않는 팀 프리뷰 ID 를 요청하였습니다"),
     EXCEED_PREVIEW_LIMIT(HttpStatus.BAD_REQUEST, "프리뷰 이미지는 6장 이하입니다"),
     NOT_EXISTS_PHYSICAL_FILE(HttpStatus.NOT_FOUND, "물리적 파일이 존재하지 않습니다"),
     NOT_WEBP_CONVERTED(HttpStatus.ACCEPTED, "이미지 변환중 입니다"),
-    NOT_EXISTS_BANNER(HttpStatus.BAD_REQUEST, "배너가 존재하지 않습니다")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -13,7 +13,9 @@ import com.opus.opus.modules.member.application.dto.request.SignUpRequest;
 import com.opus.opus.modules.member.application.dto.response.EmailFindResponse;
 import com.opus.opus.modules.member.application.dto.response.SignInResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Validated
 @RestController
@@ -78,6 +81,25 @@ public class MemberController {
     @GetMapping("/sign-in/{studentId}/email-find")
     public ResponseEntity<EmailFindResponse> getMyEmail(@PathVariable final String studentId) {
         final EmailFindResponse response = memberQueryService.getMyEmail(studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/oauth/google")
+    public ResponseEntity<Void> googleOAuthRedirect() {
+        final String redirectURL = memberCommandService.getGoogleOAuthRedirectURL();
+
+        URI uri = UriComponentsBuilder.fromUriString(redirectURL).encode().build().toUri();
+
+        return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();
+    }
+
+    @GetMapping("/oauth/google/callback")
+    public ResponseEntity<SignInResponse> googleOAuthCallback(
+            final String code,
+            final String state,
+            final String error
+    ) {
+        final SignInResponse response = memberCommandService.getGoogleOAuthCallback(code, state, error);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -1,5 +1,10 @@
 package com.opus.opus.modules.member.application;
 
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.USER_DENIED_AUTHORIZATION;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_CHANGE_SAME_PASSWORD;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
@@ -7,9 +12,14 @@ import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_VERIFIED_EMAIL_AUTH;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.opus.opus.global.security.JwtProvider;
 import com.opus.opus.global.util.AuthRedisUtil;
 import com.opus.opus.global.util.MailUtil;
+import com.opus.opus.global.util.oauth.component.GoogleOauth;
+import com.opus.opus.global.util.oauth.dto.GoogleUser;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthRequest;
@@ -21,16 +31,20 @@ import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.MemberRoleType;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
 import com.opus.opus.modules.member.exception.MemberException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Service
 @Transactional
@@ -45,13 +59,17 @@ public class MemberCommandService {
     private final JwtProvider jwtProvider;
     private final MailUtil mailUtil;
     private final AuthRedisUtil authRedisUtil;
+    private final GoogleOauth googleOauth;
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final int AUTH_CODE_LENGTH = 10;
     private static final char[] AUTH_CODE_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private static final String PASSWORD_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
 
     private static final long SIGNUP_AUTH_CODE_TTL = 5L;
     private static final long SIGNUP_VERIFIED_TTL = 10L;
+    private static final long GOOGLE_TOKEN_TTL = 3L; // 3시간
+    private static final String GOOGLE_TOKEN_KEY_PREFIX = "oauth:google:token:";
     private static final String SIGNUP_EMAIL_AUTH_KEY_PREFIX = "signup:email:auth:";
     private static final String SIGNUP_EMAIL_VERIFIED_KEY_PREFIX = "signup:email:verified:";
 
@@ -140,6 +158,102 @@ public class MemberCommandService {
         authRedisUtil.delete(signInVerifiedKey(email));
     }
 
+    public String getGoogleOAuthRedirectURL() {
+        try {
+            return googleOauth.getOauthRedirectURL();
+        } catch (Exception e) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    public SignInResponse getGoogleOAuthCallback(final String code, final String state, final String error) {
+        try {
+            validateGoogleOAuthRequest(code, state, error);
+
+            final OAuthResult<GoogleUser> result = googleOauth.getUserInfoByCode(code, GoogleUser.class);
+            final GoogleUser googleUser = result.userInfo();
+
+            return memberRepository.findByEmail(googleUser.email())
+                    .map(member -> processExistingMemberLogin(member, result))
+                    .orElseGet(() -> processNewMemberSignUp(googleUser, result));
+
+        } catch (OAuthException e) {
+            throw e;
+        } catch (JsonProcessingException e) {
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        } catch (Exception e) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    public void unlinkGoogleAccount(final Long memberId) {
+        final String key = GOOGLE_TOKEN_KEY_PREFIX + memberId;
+        final String storedValue = authRedisUtil.get(key);
+
+        if (storedValue == null) { // 구글 로그인하지 않은 회원인 경우
+            return;
+        }
+
+        String[] tokens = storedValue.split(":");
+        final String accessToken = tokens[0];
+        final String refreshToken = tokens[1];
+        boolean success = googleOauth.revokeToken(accessToken);
+
+        if (!success && refreshToken != null) {
+            String newAccessToken = googleOauth.refreshAccessToken(refreshToken);
+            if (newAccessToken != null) {
+                googleOauth.revokeToken(newAccessToken);
+            }
+        }
+
+        authRedisUtil.delete(key);
+    }
+
+    private SignInResponse processExistingMemberLogin(final Member member, final OAuthResult<?> oAuthResult) {
+        saveGoogleToken(member.getId(), oAuthResult);
+
+        final List<String> roles = member.getRoles().stream()
+                .map(MemberRoleType::toString)
+                .toList();
+        final String token = jwtProvider.createToken(String.valueOf(member.getId()), roles, member.getName());
+
+        return SignInResponse.from(member, token);
+    }
+
+    private SignInResponse processNewMemberSignUp(final GoogleUser googleUser, final OAuthResult<?> oAuthResult) {
+        try {
+            final Member newMember = getRegisterNewMember(googleUser.name(), googleUser.email());
+            return processExistingMemberLogin(newMember, oAuthResult);
+
+        } catch (Exception e) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private Member getRegisterNewMember(final String name, final String email) {
+        final String randomPassword = generateRandomPassword();
+        final String uniqueStudentId = "fake_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+
+        return memberRepository.save(Member.builder()
+                .name(name)
+                .studentId(uniqueStudentId)
+                .email(email)
+                .password(randomPassword)
+                .roles(Set.of(ROLE_회원))
+                .build());
+    }
+
+    private String generateRandomPassword() {
+        final int passwordLength = 32;
+
+        StringBuilder password = new StringBuilder();
+        for (int i = 0; i < passwordLength; i++) {
+            password.append(PASSWORD_POOL.charAt(SECURE_RANDOM.nextInt(PASSWORD_POOL.length())));
+        }
+
+        return passwordEncoder.encode(password.toString());
+    }
+
     private void verifyVerifiedKey(final String verifiedKey) {
         if (authRedisUtil.get(verifiedKey) == null) {
             throw new MemberException(NOT_VERIFIED_EMAIL_AUTH);
@@ -219,5 +333,46 @@ public class MemberCommandService {
 
     private static String signInVerifiedKey(final String email) {
         return SIGNIN_EMAIL_VERIFIED_KEY_PREFIX + email;
+    }
+
+    private void validateGoogleOAuthRequest(final String code, final String state, final String error) {
+        validateState(state);
+
+        if (error != null) {
+            throw new OAuthException(USER_DENIED_AUTHORIZATION);
+        }
+
+        if (code == null || code.isBlank()) {
+            throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
+        }
+    }
+
+    private void validateState(final String state) {
+        if (state == null || state.isBlank()) {
+            throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
+        }
+
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+
+        HttpServletRequest request = attributes.getRequest();
+        String sessionId = request.getSession().getId();
+        String stateKey = googleOauth.createOAuthStateKey(sessionId, state);
+        String storedState = authRedisUtil.get(stateKey);
+
+        if (storedState == null) {
+            throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
+        }
+
+        authRedisUtil.delete(stateKey);
+    }
+
+    private void saveGoogleToken(final Long memberId, final OAuthResult<?> oAuthResult) {
+        final String key = GOOGLE_TOKEN_KEY_PREFIX + memberId;
+        final String value = oAuthResult.accessToken() + ":" + oAuthResult.refreshToken();
+        authRedisUtil.set(key, value, GOOGLE_TOKEN_TTL, TimeUnit.HOURS);
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/member/application/convenience/MemberConvenience.java
@@ -1,14 +1,20 @@
 package com.opus.opus.modules.member.application.convenience;
 
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.ALREADY_EXIST_EMAIL;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.ALREADY_EXIST_STUDENT_ID;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.MISMATCH_STUDENT_ID_AND_NAME;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
 
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
 import com.opus.opus.modules.member.exception.MemberException;
+import java.util.List;
+import java.security.SecureRandom;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,7 +23,11 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberConvenience {
 
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String PASSWORD_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
+
     final private MemberRepository memberRepository;
+    private final PasswordEncoder passwordEncoder;
 
     public Member getValidateExistMember(final Long memberId) {
         return memberRepository.findById(memberId)
@@ -52,5 +62,51 @@ public class MemberConvenience {
         if (memberRepository.existsByStudentId(studentId)) {
             throw new MemberException(ALREADY_EXIST_STUDENT_ID);
         }
+    }
+
+    public List<Member> findAllById(final List<Long> memberIds) {
+        return memberRepository.findAllById(memberIds);
+    }
+
+    private void validateNameMatchesStudentId(final String studentId, final String name) {
+        memberRepository.findByStudentId(studentId)
+                .ifPresent(member -> {
+                    if (!member.getName().equals(name)) {
+                        throw new MemberException(MISMATCH_STUDENT_ID_AND_NAME);
+                    }
+                });
+    }
+
+    public Member getOrCreateFakeMember(final String studentId, final String name) {
+        validateNameMatchesStudentId(studentId, name);
+
+        return memberRepository.findByStudentId(studentId)
+                .orElseGet(() -> registerFakeMember(studentId, name));
+    }
+
+    private Member registerFakeMember(final String studentId, final String name) {
+        final String email = "fake_" + studentId + "@pusan.ac.kr";
+        final String randomPassword = generateRandomPassword();
+
+        return memberRepository.save(
+                Member.builder()
+                        .name(name)
+                        .studentId(studentId)
+                        .email(email)
+                        .password(randomPassword)
+                        .roles(Set.of(ROLE_회원))
+                        .build()
+        );
+    }
+
+    private String generateRandomPassword() {
+        final int passwordLength = 32;
+
+        StringBuilder password = new StringBuilder();
+        for (int i = 0; i < passwordLength; i++) {
+            password.append(PASSWORD_POOL.charAt(SECURE_RANDOM.nextInt(PASSWORD_POOL.length())));
+        }
+
+        return passwordEncoder.encode(password.toString());
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/domain/Member.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/Member.java
@@ -1,7 +1,7 @@
 package com.opus.opus.modules.member.domain;
 
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
-
 import com.opus.opus.global.base.BaseEntity;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -47,7 +47,7 @@ public class Member extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String studentId;
 
-    @ElementCollection(fetch = LAZY)
+    @ElementCollection(fetch = EAGER)
     @CollectionTable(name = "member_roles", joinColumns = @JoinColumn(name = "member_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = MAX_ROLE_NAME_LENGTH)

--- a/src/main/java/com/opus/opus/modules/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/member/exception/MemberExceptionType.java
@@ -15,6 +15,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     CANNOT_CHANGE_SAME_PASSWORD(HttpStatus.BAD_REQUEST, "동일한 비밀번호로 변경할 수 없습니다."),
     CANNOT_MATCH_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
     CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "이메일 인증 코드 만료 시간이 초과되었습니다."),
+    MISMATCH_STUDENT_ID_AND_NAME(HttpStatus.BAD_REQUEST, "입력한 학번과 이름이 일치하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -37,8 +37,8 @@ public class NoticeController {
 
     @Secured("ROLE_관리자")
     @PatchMapping("/notices/{noticeId}")
-    public ResponseEntity<Void> updateNotice(@Valid @RequestBody final NoticeRequest request,
-                                             @PathVariable final Long noticeId) {
+    public ResponseEntity<Void> updateNotice(@PathVariable final Long noticeId,
+                                             @Valid @RequestBody final NoticeRequest request) {
         noticeCommandService.updateNotice(request, noticeId);
         return ResponseEntity.noContent().build();
     }
@@ -59,4 +59,41 @@ public class NoticeController {
     public ResponseEntity<List<NoticeSummaryResponse>> getAllNotices() {
         return ResponseEntity.ok(noticeQueryService.getAllNotices());
     }
+
+    @Secured("ROLE_관리자")
+    @PostMapping("/contests/{contestId}/notices")
+    public ResponseEntity<Void> createContestNotice(@PathVariable final Long contestId,
+                                                    @Valid @RequestBody final NoticeRequest request) {
+        noticeCommandService.createContestNotice(contestId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Secured("ROLE_관리자")
+    @PatchMapping("/contests/{contestId}/notices/{noticeId}")
+    public ResponseEntity<Void> updateContestNotice(@PathVariable final Long contestId,
+                                                    @PathVariable final Long noticeId,
+                                                    @Valid @RequestBody final NoticeRequest request) {
+        noticeCommandService.updateContestNotice(request, contestId, noticeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @DeleteMapping("/contests/{contestId}/notices/{noticeId}")
+    public ResponseEntity<Void> deleteContestNotice(@PathVariable final Long contestId,
+                                                    @PathVariable final Long noticeId) {
+        noticeCommandService.deleteContestNotice(contestId, noticeId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @GetMapping("/contests/{contestId}/notices/{noticeId}")
+    public ResponseEntity<NoticeDetailResponse> getContestNotice(@PathVariable final Long contestId,
+                                                                 @PathVariable final Long noticeId) {
+        return ResponseEntity.ok(noticeQueryService.getContestNotice(contestId, noticeId));
+    }
+
+    @GetMapping("/contests/{contestId}/notices")
+    public ResponseEntity<List<NoticeSummaryResponse>> getAllContestNotices(@PathVariable final Long contestId) {
+        return ResponseEntity.ok(noticeQueryService.getAllContestNotices(contestId));
+    }
+
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.notice.application;
 
-import com.opus.opus.modules.notice.application.dto.NoticeConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
 import com.opus.opus.modules.notice.domain.dao.NoticeRepository;
@@ -16,6 +17,7 @@ public class NoticeCommandService {
     private final NoticeRepository noticeRepository;
 
     private final NoticeConvenience noticeConvenience;
+    private final ContestConvenience contestConvenience;
 
     public void createNotice(final NoticeRequest request) {
         noticeRepository.save(Notice.builder()
@@ -25,11 +27,30 @@ public class NoticeCommandService {
     }
 
     public void updateNotice(final NoticeRequest request, final Long noticeId) {
-        final Notice notice = noticeConvenience.getValidateExistNotice(noticeId);
+        final Notice notice = noticeConvenience.getValidateGlobalNotice(noticeId);
         notice.updateNotice(request.title(), request.description());
     }
 
     public void deleteNotice(final Long noticeId) {
-        noticeRepository.delete(noticeConvenience.getValidateExistNotice(noticeId));
+        noticeRepository.delete(noticeConvenience.getValidateGlobalNotice(noticeId));
+    }
+
+    public void createContestNotice(final Long contestId, final NoticeRequest request) {
+        contestConvenience.validateExistContest(contestId);
+
+        noticeRepository.save(Notice.builder()
+                .contestId(contestId)
+                .title(request.title())
+                .description(request.description())
+                .build());
+    }
+
+    public void updateContestNotice(final NoticeRequest request, final Long contestId, final Long noticeId) {
+        final Notice notice = noticeConvenience.getValidateContestNotice(contestId, noticeId);
+        notice.updateNotice(request.title(), request.description());
+    }
+
+    public void deleteContestNotice(final Long contestId, final Long noticeId) {
+        noticeRepository.delete(noticeConvenience.getValidateContestNotice(contestId, noticeId));
     }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.notice.application;
 
-import com.opus.opus.modules.notice.application.dto.NoticeConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.response.NoticeDetailResponse;
 import com.opus.opus.modules.notice.application.dto.response.NoticeSummaryResponse;
 import com.opus.opus.modules.notice.domain.Notice;
@@ -18,14 +19,28 @@ public class NoticeQueryService {
     private final NoticeRepository noticeRepository;
 
     private final NoticeConvenience noticeConvenience;
+    private final ContestConvenience contestConvenience;
 
     public NoticeDetailResponse getNotice(final Long noticeId) {
-        final Notice notice = noticeConvenience.getValidateExistNotice(noticeId);
+        final Notice notice = noticeConvenience.getValidateGlobalNotice(noticeId);
         return NoticeDetailResponse.from(notice);
     }
 
     public List<NoticeSummaryResponse> getAllNotices() {
-        return noticeRepository.findAllByOrderByCreatedAtDesc()
+        return noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc()
+                .stream()
+                .map(NoticeSummaryResponse::from)
+                .toList();
+    }
+
+    public NoticeDetailResponse getContestNotice(final Long contestId, final Long noticeId) {
+        final Notice notice = noticeConvenience.getValidateContestNotice(contestId, noticeId);
+        return NoticeDetailResponse.from(notice);
+    }
+
+    public List<NoticeSummaryResponse> getAllContestNotices(final Long contestId) {
+        contestConvenience.validateExistContest(contestId);
+        return noticeRepository.findAllByContestIdOrderByCreatedAtDesc(contestId)
                 .stream()
                 .map(NoticeSummaryResponse::from)
                 .toList();

--- a/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
@@ -1,4 +1,4 @@
-package com.opus.opus.modules.notice.application.dto;
+package com.opus.opus.modules.notice.application.convenience;
 
 import static com.opus.opus.modules.notice.exception.NoticeExceptionType.NOT_FOUND_NOTICE;
 
@@ -16,8 +16,14 @@ public class NoticeConvenience {
 
     private final NoticeRepository noticeRepository;
 
-    public Notice getValidateExistNotice(final Long noticeId) {
-        return noticeRepository.findById(noticeId).orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
+    public Notice getValidateGlobalNotice(final Long noticeId) {
+        return noticeRepository.findByIdAndContestIdIsNull(noticeId)
+                .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
+    }
+
+    public Notice getValidateContestNotice(final Long contestId, final Long noticeId) {
+        return noticeRepository.findByContestIdAndId(contestId, noticeId)
+                .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
     }
 }
 

--- a/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
+++ b/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
@@ -2,9 +2,16 @@ package com.opus.opus.modules.notice.domain.dao;
 
 import com.opus.opus.modules.notice.domain.Notice;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    List<Notice> findAllByOrderByCreatedAtDesc();
+    List<Notice> findAllByContestIdIsNullOrderByCreatedAtDesc();
+
+    List<Notice> findAllByContestIdOrderByCreatedAtDesc(final Long contestId);
+
+    Optional<Notice> findByContestIdAndId(final Long contestId, final Long id);
+
+    Optional<Notice> findByIdAndContestIdIsNull(final Long id);
 }

--- a/src/main/java/com/opus/opus/modules/team/api/TeamCommentController.java
+++ b/src/main/java/com/opus/opus/modules/team/api/TeamCommentController.java
@@ -1,0 +1,72 @@
+package com.opus.opus.modules.team.api;
+
+import com.opus.opus.global.security.annotation.LoginMember;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.TeamCommentCommandService;
+import com.opus.opus.modules.team.application.TeamCommentQueryService;
+import com.opus.opus.modules.team.application.dto.request.TeamCommentCreateRequest;
+import com.opus.opus.modules.team.application.dto.request.TeamCommentUpdateRequest;
+import com.opus.opus.modules.team.application.dto.response.TeamCommentResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teams/{teamId}/comments")
+@Secured({"ROLE_회원", "ROLE_관리자"})
+public class TeamCommentController {
+
+    private final TeamCommentCommandService teamCommentCommandService;
+    private final TeamCommentQueryService teamCommentQueryService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTeamComment(
+            @PathVariable final Long teamId,
+            @Valid @RequestBody final TeamCommentCreateRequest request,
+            @LoginMember final Member member
+    ) {
+        teamCommentCommandService.createComment(teamId, member.getId(), request.description());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<List<TeamCommentResponse>> getTeamComments(
+            @PathVariable final Long teamId
+    ) {
+        List<TeamCommentResponse> response = teamCommentQueryService.getComments(teamId);
+        return ResponseEntity.ok(response);
+    }
+
+    @PatchMapping("/{commentId}")
+    public ResponseEntity<Void> updateTeamComment(
+            @PathVariable final Long teamId,
+            @PathVariable final Long commentId,
+            @Valid @RequestBody final TeamCommentUpdateRequest request,
+            @LoginMember final Member member
+    ) {
+        teamCommentCommandService.updateComment(teamId, commentId, member.getId(), request.description());
+        return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping("/{commentId}")
+    public ResponseEntity<Void> deleteTeamComment(
+            @PathVariable final Long teamId,
+            @PathVariable final Long commentId,
+            @LoginMember final Member member
+    ) {
+        teamCommentCommandService.deleteComment(teamId, commentId, member.getId());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/team/api/TeamController.java
+++ b/src/main/java/com/opus/opus/modules/team/api/TeamController.java
@@ -79,4 +79,28 @@ public class TeamController {
         teamCommandService.deleteThumbnailImage(teamId);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/{teamId}/image/posters")
+    public ResponseEntity<Resource> getPosterImage(@PathVariable final Long teamId) {
+        final ImageResponse imageResponse = teamQueryService.getPosterImage(teamId);
+
+        return ResponseEntity.ok()
+                .contentType(imageResponse.getMediaType())
+                .body(imageResponse.resource());
+    }
+
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
+    @PostMapping("/{teamId}/image/posters")
+    public ResponseEntity<Void> savePosterImage(@PathVariable final Long teamId,
+                                                @RequestPart("image") final MultipartFile image) {
+        teamCommandService.savePosterImage(teamId, image);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
+    @DeleteMapping("/{teamId}/image/posters")
+    public ResponseEntity<Void> deletePosterImage(@PathVariable final Long teamId) {
+        teamCommandService.deletePosterImage(teamId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/team/api/TeamMemberController.java
+++ b/src/main/java/com/opus/opus/modules/team/api/TeamMemberController.java
@@ -1,0 +1,41 @@
+package com.opus.opus.modules.team.api;
+
+import com.opus.opus.modules.team.application.TeamMemberCommandService;
+import com.opus.opus.modules.team.application.dto.request.TeamMemberCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teams/{teamId}/members")
+@Secured("ROLE_관리자")
+public class TeamMemberController {
+
+    private final TeamMemberCommandService teamMemberCommandService;
+
+    @PostMapping
+    public ResponseEntity<Void> createTeamMember(@PathVariable final Long teamId,
+                                                 @Valid @RequestBody final TeamMemberCreateRequest request) {
+        teamMemberCommandService.createTeamMember(teamId, request.memberStudentId(), request.memberName(),
+                request.roleType());
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @DeleteMapping("/{memberId}")
+    public ResponseEntity<Void> deleteTeamMember(@PathVariable final Long teamId,
+                                                 @PathVariable final Long memberId) {
+        teamMemberCommandService.deleteTeamMember(teamId, memberId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.team.application;
 
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
 import static com.opus.opus.modules.file.domain.FileImageType.PREVIEW;
 import static com.opus.opus.modules.file.domain.FileImageType.THUMBNAIL;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
@@ -8,6 +9,7 @@ import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_WEBP_CO
 
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileImageType;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
@@ -38,39 +40,40 @@ public class TeamCommandService {
 
     public void deletePreviewImages(final Long teamId, final List<Long> ids) {
         teamConvenience.validateExistTeam(teamId);
-        ids.forEach(fileId -> {
-            fileRepository.findById(fileId).ifPresent(this::checkWebpConverted);
-            fileStorageUtil.deleteFile(fileId);
-        });
+        ids.forEach(fileStorageUtil::deleteFile);
     }
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL).ifPresent(existingFile -> {
-            checkWebpConverted(existingFile);
-            fileStorageUtil.deleteFile(existingFile.getId());
-        });
+        deleteIfExists(teamId, THUMBNAIL);
         fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
     }
 
     public void deleteThumbnailImage(final Long teamId) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL).ifPresent(existingFile -> {
-            checkWebpConverted(existingFile);
-            fileStorageUtil.deleteFile(existingFile.getId());
-        });
+        deleteIfExists(teamId, THUMBNAIL);
+    }
+
+    public void savePosterImage(final Long teamId, final MultipartFile image) {
+        teamConvenience.validateExistTeam(teamId);
+        deleteIfExists(teamId, POSTER);
+        fileStorageUtil.storeFile(image, teamId, TEAM, POSTER);
+    }
+
+    public void deletePosterImage(final Long teamId) {
+        teamConvenience.validateExistTeam(teamId);
+        deleteIfExists(teamId, POSTER);
+    }
+
+    private void deleteIfExists(final Long teamId, final FileImageType imageType) {
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, imageType)
+                .ifPresent(existingFile -> fileStorageUtil.deleteFile(existingFile.getId()));
     }
 
     private void checkPreviewLimit(final Long teamId, final List<MultipartFile> images) {
         long savedCount = fileRepository.countByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, PREVIEW);
         if (savedCount + images.size() > 5) {
             throw new FileException(EXCEED_PREVIEW_LIMIT);
-        }
-    }
-
-    private void checkWebpConverted(final File existingFile) {
-        if (!existingFile.getIsWebpConverted()) {
-            throw new FileException(NOT_WEBP_CONVERTED);
         }
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommentCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommentCommandService.java
@@ -1,0 +1,71 @@
+package com.opus.opus.modules.team.application;
+
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.COMMENT_NOT_BELONG_TO_TEAM;
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.NOT_FOUND_COMMENT;
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.NOT_OWNER_COMMENT;
+
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamComment;
+import com.opus.opus.modules.team.domain.dao.TeamCommentRepository;
+import com.opus.opus.modules.team.exception.TeamCommentException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class TeamCommentCommandService {
+
+    private final TeamCommentRepository teamCommentRepository;
+
+    private final TeamConvenience teamConvenience;
+
+    public void createComment(final Long teamId, final Long memberId, final String description) {
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
+
+        teamCommentRepository.save(TeamComment.builder()
+                .description(description)
+                .memberId(memberId)
+                .team(team)
+                .build());
+    }
+
+    public void updateComment(final Long teamId, final Long commentId, final Long memberId, final String newDescription) {
+        teamConvenience.validateExistTeam(teamId);
+        final TeamComment comment = getValidateExistComment(commentId);
+
+        validateCommentBelongsToTeam(comment, teamId);
+        isMine(comment, memberId);
+
+        comment.updateDescription(newDescription);
+    }
+
+    public void deleteComment(final Long teamId, final Long commentId, final Long memberId) {
+        teamConvenience.validateExistTeam(teamId);
+        final TeamComment comment = getValidateExistComment(commentId);
+
+        validateCommentBelongsToTeam(comment, teamId);
+        isMine(comment, memberId);
+
+        teamCommentRepository.delete(comment);
+    }
+
+    private void isMine(final TeamComment comment, final Long memberId) {
+        if (!comment.isMine(memberId)) {
+            throw new TeamCommentException(NOT_OWNER_COMMENT);
+        }
+    }
+
+    private TeamComment getValidateExistComment(final Long commentId) {
+        return teamCommentRepository.findById(commentId).orElseThrow(() -> new TeamCommentException(NOT_FOUND_COMMENT));
+    }
+
+    private void validateCommentBelongsToTeam(final TeamComment comment, final Long teamId) {
+        if (!comment.getTeam().getId().equals(teamId)) {
+            throw new TeamCommentException(COMMENT_NOT_BELONG_TO_TEAM);
+        }
+    }
+}
+

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommentQueryService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommentQueryService.java
@@ -1,0 +1,52 @@
+package com.opus.opus.modules.team.application;
+
+import static java.util.stream.Collectors.toMap;
+
+import com.opus.opus.modules.member.application.convenience.MemberConvenience;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.application.dto.response.TeamCommentResponse;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamComment;
+import com.opus.opus.modules.team.domain.dao.TeamCommentRepository;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class TeamCommentQueryService {
+
+    private final TeamCommentRepository teamCommentRepository;
+
+    private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
+
+    public List<TeamCommentResponse> getComments(final Long teamId) {
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
+        final List<TeamComment> comments = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId());
+
+        final List<Long> memberIds = comments.stream()
+                .map(TeamComment::getMemberId)
+                .distinct()
+                .toList();
+
+        final Map<Long, String> memberIdNameMap = memberConvenience.findAllById(memberIds)
+                .stream()
+                .collect(toMap(Member::getId, Member::getName));
+
+        return comments.stream()
+                .map(comment -> new TeamCommentResponse(
+                        comment.getId(),
+                        comment.getDescription(),
+                        comment.getMemberId(),
+                        memberIdNameMap.get(comment.getMemberId()),
+                        team.getId()
+                ))
+                .toList();
+    }
+}
+

--- a/src/main/java/com/opus/opus/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamMemberCommandService.java
@@ -1,0 +1,46 @@
+package com.opus.opus.modules.team.application;
+
+import com.opus.opus.modules.member.application.convenience.MemberConvenience;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TeamMemberCommandService {
+
+    private final TeamMemberRepository teamMemberRepository;
+
+    private final TeamConvenience teamConvenience;
+    private final TeamMemberConvenience teamMemberConvenience;
+    private final MemberConvenience memberConvenience;
+
+    public void createTeamMember(final Long teamId, final String studentId, final String name,
+                                 final TeamMemberRoleType roleType) {
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
+        final Member member = memberConvenience.getOrCreateFakeMember(studentId, name);
+        teamMemberConvenience.checkIsDuplicateTeamMember(teamId, member.getId());
+        teamMemberRepository.save(
+                TeamMember.builder()
+                        .memberId(member.getId())
+                        .team(team)
+                        .roles(Set.of(roleType))
+                        .build()
+        );
+    }
+
+    public void deleteTeamMember(final Long teamId, final Long memberId) {
+        teamConvenience.getValidateExistTeam(teamId);
+        final TeamMember teamMember = teamMemberConvenience.getValidateExistTeamMember(teamId, memberId);
+        teamMemberRepository.delete(teamMember);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamQueryService.java
@@ -1,5 +1,7 @@
 package com.opus.opus.modules.team.application;
 
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.FileImageType.PREVIEW;
 import static com.opus.opus.modules.file.domain.FileImageType.THUMBNAIL;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
 import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_PREVIEW;
@@ -8,6 +10,7 @@ import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_WEBP_CO
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.modules.file.application.convenience.FileConvenience;
 import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileImageType;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
@@ -37,8 +40,16 @@ public class TeamQueryService {
     }
 
     public ImageResponse getThumbnailImage(final Long teamId) {
+        return getImage(teamId, THUMBNAIL);
+    }
+
+    public ImageResponse getPosterImage(final Long teamId) {
+        return getImage(teamId, POSTER);
+    }
+
+    private ImageResponse getImage(final Long teamId, final FileImageType fileImageType) {
         teamConvenience.validateExistTeam(teamId);
-        final File findFile = fileConvenience.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL);
+        final File findFile = fileConvenience.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, fileImageType);
         checkImageConverted(findFile);
         final Pair<Resource, String> storageResult = fileStorageUtil.findFileAndType(findFile.getId());
         return new ImageResponse(storageResult.a, storageResult.b);

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
@@ -1,0 +1,30 @@
+package com.opus.opus.modules.team.application.convenience;
+
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_ALREADY_EXISTS;
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
+
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamMemberConvenience {
+
+    private final TeamMemberRepository teamMemberRepository;
+
+    public void checkIsDuplicateTeamMember(final Long teamId, final Long memberId) {
+        if (teamMemberRepository.existsByTeamIdAndMemberId(teamId, memberId)) {
+            throw new TeamMemberException(TEAM_MEMBER_ALREADY_EXISTS);
+        }
+    }
+
+    public TeamMember getValidateExistTeamMember(final Long teamId, final Long memberId) {
+        return teamMemberRepository.findByTeamIdAndMemberId(teamId, memberId)
+                .orElseThrow(() -> new TeamMemberException(TEAM_MEMBER_NOT_FOUND_IN_TEAM));
+    }
+}

--- a/src/main/java/com/opus/opus/modules/team/application/dto/request/TeamCommentCreateRequest.java
+++ b/src/main/java/com/opus/opus/modules/team/application/dto/request/TeamCommentCreateRequest.java
@@ -1,0 +1,9 @@
+package com.opus.opus.modules.team.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamCommentCreateRequest(
+
+        @NotBlank(message = "작성할 댓글 내용은 필수입니다.")
+        String description
+) {}

--- a/src/main/java/com/opus/opus/modules/team/application/dto/request/TeamCommentUpdateRequest.java
+++ b/src/main/java/com/opus/opus/modules/team/application/dto/request/TeamCommentUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.opus.opus.modules.team.application.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TeamCommentUpdateRequest(
+
+        @NotBlank(message = "수정할 댓글 내용은 비어 있을 수 없습니다.")
+        String description
+) {
+}

--- a/src/main/java/com/opus/opus/modules/team/application/dto/request/TeamMemberCreateRequest.java
+++ b/src/main/java/com/opus/opus/modules/team/application/dto/request/TeamMemberCreateRequest.java
@@ -1,0 +1,20 @@
+package com.opus.opus.modules.team.application.dto.request;
+
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record TeamMemberCreateRequest(
+
+        @NotBlank(message = "추가할 팀원명은 비어 있을 수 없습니다.")
+        String memberName,
+
+        @NotBlank(message = "추가할 팀원학번은 비어 있을 수 없습니다.")
+        @Pattern(regexp = "^\\d{9}$", message = "학번은 9자리 숫자여야 합니다.")
+        String memberStudentId,
+
+        @NotNull(message = "권한을 입력해 주세요.")
+        TeamMemberRoleType roleType
+) {
+}

--- a/src/main/java/com/opus/opus/modules/team/application/dto/response/TeamCommentResponse.java
+++ b/src/main/java/com/opus/opus/modules/team/application/dto/response/TeamCommentResponse.java
@@ -1,0 +1,11 @@
+package com.opus.opus.modules.team.application.dto.response;
+
+public record TeamCommentResponse(
+
+        Long commentId,
+        String description,
+        Long memberId,
+        String memberName,
+        Long teamId
+) {
+}

--- a/src/main/java/com/opus/opus/modules/team/domain/TeamComment.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/TeamComment.java
@@ -49,4 +49,11 @@ public class TeamComment extends BaseEntity {
         this.isDeleted = false;
     }
 
+    public void updateDescription(final String newDescription) {
+        this.description = newDescription;
+    }
+
+    public boolean isMine(Long memberId) {
+        return this.memberId.equals(memberId);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/team/domain/TeamMember.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/TeamMember.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.team.domain;
 
+import static jakarta.persistence.FetchType.EAGER;
 import static jakarta.persistence.FetchType.LAZY;
 
 import com.opus.opus.global.base.BaseEntity;
@@ -43,7 +44,7 @@ public class TeamMember extends BaseEntity {
     @JoinColumn(name = "team_id", nullable = false)
     private Team team;
 
-    @ElementCollection(fetch = LAZY)
+    @ElementCollection(fetch = EAGER)
     @CollectionTable(name = "team_member_roles", joinColumns = @JoinColumn(name = "team_member_id"))
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false, length = MAX_ROLE_NAME_LENGTH)

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamCommentRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamCommentRepository.java
@@ -1,0 +1,11 @@
+package com.opus.opus.modules.team.domain.dao;
+
+import com.opus.opus.modules.team.domain.TeamComment;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamCommentRepository extends JpaRepository<TeamComment, Long> {
+    List<TeamComment> findAllByTeamIdOrderByIdDesc(Long id);
+
+    void deleteAllByTeamId(Long teamId);
+}

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamMemberRepository.java
@@ -1,0 +1,12 @@
+package com.opus.opus.modules.team.domain.dao;
+
+import com.opus.opus.modules.team.domain.TeamMember;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
+
+    boolean existsByTeamIdAndMemberId(final Long teamId, final Long memberId);
+
+    Optional<TeamMember> findByTeamIdAndMemberId(final Long teamId, final Long memberId);
+}

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamCommentException.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamCommentException.java
@@ -1,0 +1,26 @@
+package com.opus.opus.modules.team.exception;
+
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class TeamCommentException extends BaseException {
+
+	private final TeamCommentExceptionType exceptionType;
+
+	public TeamCommentException(final TeamCommentExceptionType exceptionType) {
+		super(exceptionType.errorMessage());
+		this.exceptionType = exceptionType;
+	}
+
+	public TeamCommentException(final TeamCommentExceptionType exceptionType, final String message) {
+		super(message);
+		this.exceptionType = exceptionType;
+	}
+
+	@Override
+	public BaseExceptionType exceptionType() {
+		return exceptionType;
+	}
+}
+

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamCommentExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamCommentExceptionType.java
@@ -1,0 +1,30 @@
+package com.opus.opus.modules.team.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum TeamCommentExceptionType implements BaseExceptionType {
+
+	NOT_FOUND_COMMENT(HttpStatus.NOT_FOUND, "존재하지 않는 댓글입니다."),
+	NOT_OWNER_COMMENT(HttpStatus.FORBIDDEN, "댓글 작성자가 아닙니다."),
+    COMMENT_NOT_BELONG_TO_TEAM(HttpStatus.BAD_REQUEST, "댓글이 해당 팀에 속해있지 않습니다.")
+    ;
+
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	TeamCommentExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+		this.httpStatus = httpStatus;
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public HttpStatus httpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String errorMessage() {
+		return errorMessage;
+	}
+}

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamMemberException.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamMemberException.java
@@ -1,0 +1,25 @@
+package com.opus.opus.modules.team.exception;
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class TeamMemberException extends BaseException {
+
+    private final TeamMemberExceptionType exceptionType;
+
+    public TeamMemberException(final TeamMemberExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public TeamMemberException(final TeamMemberExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}
+

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamMemberExceptionType.java
@@ -1,0 +1,28 @@
+package com.opus.opus.modules.team.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum TeamMemberExceptionType implements BaseExceptionType {
+
+    TEAM_MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 팀에 등록된 팀원입니다."),
+    TEAM_MEMBER_NOT_FOUND_IN_TEAM(HttpStatus.NOT_FOUND, "해당 팀의 팀원이 아닙니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    TeamMemberExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,4 +24,3 @@ cors:
   allow:
     origins: https://test.url
     methods: GET, POST, PUT, DELETE, PATCH, OPTIONS
-

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,6 +3,7 @@ USE opus;
 DROP TABLE IF EXISTS `contest`;
 DROP TABLE IF EXISTS `contest_award`;
 DROP TABLE IF EXISTS `contest_category`;
+DROP TABLE IF EXISTS `contest_team_template`;
 DROP TABLE IF EXISTS `contest_track`;
 DROP TABLE IF EXISTS `file`;
 DROP TABLE IF EXISTS `member`;
@@ -48,6 +49,28 @@ CREATE TABLE `contest_category` (
   `category_name` varchar(255) NOT NULL,
   `is_deleted` bit(1) NOT NULL,
   PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `contest_team_template` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `contest_id` bigint NOT NULL,
+  `division` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `project_name` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `team_name` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `leader` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `team_members` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `professor` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `github_path` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `youtube_path` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `production_path` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `overview` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `poster` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `images` enum('REQUIRED','OPTIONAL','HIDDEN') NOT NULL,
+  `is_deleted` bit(1) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_contest_team_template_contest_id` (`contest_id`)
 );
 
 CREATE TABLE `contest_track` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -88,7 +88,7 @@ CREATE TABLE `file` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `file_path` varchar(255) NOT NULL,
-  `image_type` enum('BANNER','PREVIEW','THUMBNAIL') NOT NULL,
+  `image_type` enum('BANNER','PREVIEW','THUMBNAIL','POSTER') NOT NULL,
   `is_webp_converted` bit(1) NOT NULL,
   `name` varchar(255) NOT NULL,
   `reference_id` bigint NOT NULL,

--- a/src/test/java/com/opus/opus/contest/ContestCategoryFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestCategoryFixture.java
@@ -1,0 +1,12 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.ContestCategory;
+
+public class ContestCategoryFixture {
+
+    public static ContestCategory createContestCategory() {
+        return ContestCategory.builder()
+                .categoryName("테스트 카테고리")
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/contest/ContestFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestFixture.java
@@ -1,0 +1,21 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.Contest;
+
+public class ContestFixture {
+
+
+    public static Contest createContest() {
+        return Contest.builder()
+                .contestName("제 1회 테스트 대회")
+                .categoryId(1L)
+                .build();
+    }
+
+    public static Contest createContestWithCategoryId(final Long categoryId) {
+        return Contest.builder()
+                .contestName("테스트 대회")
+                .categoryId(categoryId)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestCommandServiceTest.java
@@ -1,0 +1,128 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.VOTE_END_PRECEDE_VOTE_START;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestCommandService;
+import com.opus.opus.modules.contest.application.dto.request.VoteUpdateRequest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContestCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestCommandService contestCommandService;
+
+    @Autowired
+    private ContestRepository contestRepository;
+
+    private Contest contest;
+    private static final Integer MAX_VOTES_LIMIT = 5;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContestWithCategoryId(1L));
+    }
+
+    @Test
+    @DisplayName("[성공] 투표 기간 수정 시 시작일과 종료일이 정상적으로 업데이트된다.")
+    void 투표_기간_수정_시_시작일과_종료일이_정상적으로_업데이트된다() {
+        // given
+        final LocalDateTime originalStartAt = contest.getVoteStartAt();
+        final LocalDateTime originalEndAt = contest.getVoteEndAt();
+
+        final LocalDateTime newStartAt = LocalDateTime.now().plusDays(1);
+        final LocalDateTime newEndAt = LocalDateTime.now().plusDays(5);
+        final VoteUpdateRequest request = new VoteUpdateRequest(newStartAt, newEndAt);
+
+        // when
+        contestCommandService.updateVotePeriod(contest.getId(), request);
+
+        // then
+        final Contest updatedContest = contestRepository.findById(contest.getId()).orElseThrow();
+        assertThat(updatedContest.getVoteStartAt()).isNotEqualTo(originalStartAt);
+        assertThat(updatedContest.getVoteEndAt()).isNotEqualTo(originalEndAt);
+
+        assertThat(updatedContest.getVoteStartAt()).isEqualTo(newStartAt);
+        assertThat(updatedContest.getVoteEndAt()).isEqualTo(newEndAt);
+    }
+
+    @Test
+    @DisplayName("[실패] 투표 종료일이 시작일보다 앞서면 예외가 발생한다.")
+    void 투표_종료일이_시작일보다_앞서면_예외가_발생한다() {
+        final LocalDateTime startAt = LocalDateTime.now().plusDays(5);
+        final LocalDateTime endAt = LocalDateTime.now().plusDays(1);
+        final VoteUpdateRequest request = new VoteUpdateRequest(startAt, endAt);
+
+        assertThatThrownBy(() -> {contestCommandService.updateVotePeriod(contest.getId(), request);})
+                .isInstanceOf(ContestException.class)
+                .hasMessage(VOTE_END_PRECEDE_VOTE_START.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 최대 투표 개수가 정상적으로 설정된다.")
+    void 최대_투표_개수가_정상적으로_설정된다() {
+        contestCommandService.updateMaxVotesLimit(contest.getId(), MAX_VOTES_LIMIT);
+
+        final Contest updatedContest = contestRepository.findById(contest.getId()).orElseThrow();
+        assertThat(updatedContest.getMaxVotesLimit()).isEqualTo(MAX_VOTES_LIMIT);
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회의 최대 투표 개수는 설정할 수 없다.")
+    void 존재하지_않는_대회의_최대_투표_개수는_설정할_수_없다() {
+        final Long invalidContestId = 999L;
+
+        assertThatThrownBy(() -> {
+            contestCommandService.updateMaxVotesLimit(invalidContestId, MAX_VOTES_LIMIT);
+        }).isInstanceOf(ContestException.class).hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 투표 진행 중에는 최대 투표 개수를 변경할 수 있다.")
+    void 투표_진행_중에는_최대_투표_개수를_변경할_수_있다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contest.updateVotePeriod(now.minusDays(1), now.plusDays(1));
+
+        assertThatThrownBy(() -> {
+            contestCommandService.updateMaxVotesLimit(contest.getId(), MAX_VOTES_LIMIT);
+        }).isInstanceOf(ContestException.class)
+                .hasMessage(CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 투표 시작 전에는 최대 투표 개수를 변경할 수 있다.")
+    void 투표_시작_전에는_최대_투표_개수를_변경할_수_있다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contest.updateVotePeriod(now.plusDays(1), now.plusDays(2));
+
+        contestCommandService.updateMaxVotesLimit(contest.getId(), MAX_VOTES_LIMIT);
+
+        final Contest updatedContest = contestRepository.findById(contest.getId()).orElseThrow();
+        assertThat(updatedContest.getMaxVotesLimit()).isEqualTo(MAX_VOTES_LIMIT);
+    }
+
+    @Test
+    @DisplayName("[성공] 투표 종료 후에는 최대 투표 개수를 변경할 수 있다.")
+    void 투표_종료_후에는_최대_투표_개수를_변경할_수_있다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contest.updateVotePeriod(now.minusDays(2), now.minusDays(1));
+        assertThat(contest.getMaxVotesLimit()).isEqualTo(0); // 변경 전 값 검증
+
+        contestCommandService.updateMaxVotesLimit(contest.getId(), MAX_VOTES_LIMIT);
+
+        final Contest updatedContest = contestRepository.findById(contest.getId()).orElseThrow(); // 변경 후 값 검증
+        assertThat(updatedContest.getMaxVotesLimit()).isEqualTo(MAX_VOTES_LIMIT);
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestQueryServiceTest.java
@@ -1,0 +1,77 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
+import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContestQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestQueryService contestQueryService;
+
+    @Autowired
+    private ContestRepository contestRepository;
+
+    private Contest contest;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContestWithCategoryId(1L));
+    }
+
+    @Test
+    @DisplayName("[성공] 투표 기간 조회 시 저장된 기간을 반환한다.")
+    void 투표_기간_조회_시_저장된_기간을_반환한다() {
+        LocalDateTime startAt = LocalDateTime.now().plusDays(2);
+        LocalDateTime endAt = LocalDateTime.now().plusDays(7);
+        contest.updateVotePeriod(startAt, endAt);
+
+        VotePeriodResponse response = contestQueryService.getVotePeriod(contest.getId());
+
+        assertThat(response.voteStartAt()).isEqualTo(startAt);
+        assertThat(response.voteEndAt()).isEqualTo(endAt);
+    }
+
+    @Test
+    @DisplayName("[성공] 최대 투표 개수를 조회할 수 있다.")
+    void 최대_투표_개수를_조회할_수_있다() {
+        final Integer maxVotesLimit = 5;
+        contest.updateMaxVotesLimit(maxVotesLimit);
+
+        final ContestVotesLimitResponse response = contestQueryService.getMaxVotesLimit(contest.getId());
+
+        assertThat(response.maxVotesLimit()).isEqualTo(maxVotesLimit);
+    }
+
+    @Test
+    @DisplayName("[성공] 기본 최대 투표 개수는 0이다.")
+    void 기본_최대_투표_개수는_0이다() {
+        final ContestVotesLimitResponse response = contestQueryService.getMaxVotesLimit(contest.getId());
+
+        assertThat(response.maxVotesLimit()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회의 최대 투표 개수는 조회할 수 없다.")
+    void 존재하지_않는_대회의_최대_투표_개수는_조회할_수_없다() {
+        final Long invalidContestId = 999L;
+
+        assertThatThrownBy(() -> {
+            contestQueryService.getMaxVotesLimit(invalidContestId);
+        }).isInstanceOf(ContestException.class).hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/helper/IntegrationTest.java
+++ b/src/test/java/com/opus/opus/helper/IntegrationTest.java
@@ -1,8 +1,10 @@
 package com.opus.opus.helper;
 
 import com.opus.opus.global.security.JwtProvider;
+import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.global.util.MailUtil;
 import com.opus.opus.global.util.AuthRedisUtil;
+import com.opus.opus.global.util.oauth.component.GoogleOauth;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,6 +32,12 @@ public abstract class IntegrationTest extends ApiTestHelper {
 
     @MockitoBean
     private MailUtil mailUtil;
+
+    @MockitoBean
+    protected GoogleOauth googleOauth;
+
+    @MockitoBean
+    protected FileStorageUtil fileStorageUtil;
 
     @BeforeEach
     void setUp(final WebApplicationContext context) {

--- a/src/test/java/com/opus/opus/member/MemberFixture.java
+++ b/src/test/java/com/opus/opus/member/MemberFixture.java
@@ -9,10 +9,20 @@ public class MemberFixture {
 
     public static Member createMember() {
         return Member.builder()
-                .name("이옵스")
+                .name("테스트회원")
                 .email("example@pusan.ac.kr")
                 .password("{noop}123456789")
                 .studentId("202612345")
+                .roles(Set.of(ROLE_회원))
+                .build();
+    }
+
+    public static Member createMemberWithUniqueNum(int number) {
+        return Member.builder()
+                .name("테스트회원" + number)
+                .email("example" + number + "@pusan.ac.kr")
+                .password("{noop}123456789")
+                .studentId("20211234" + number)
                 .roles(Set.of(ROLE_회원))
                 .build();
     }

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -1,12 +1,22 @@
 package com.opus.opus.member.application;
 
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.USER_DENIED_AUTHORIZATION;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_VERIFIED_EMAIL_AUTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import com.opus.opus.global.util.oauth.dto.GoogleUser;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.member.application.MemberCommandService;
@@ -24,6 +34,10 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class MemberCommandServiceTest extends IntegrationTest {
 
@@ -35,11 +49,24 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
     private Member teamLeader;
     private EmailAuthRequest emailAuthRequest;
+    private MockHttpServletRequest mockRequest;
 
     @BeforeEach
     void setUp() {
         teamLeader = memberRepository.save(MemberFixture.createMember());
         emailAuthRequest = new EmailAuthRequest("qwer1234@pusan.ac.kr");
+
+        when(googleOauth.createOAuthStateKey(anyString(), anyString())).thenCallRealMethod(); // state key값이 null이 되는 문제 방지하기 위해 실제 메서드 호출
+    }
+
+    private void setUpMockRequest() {
+        mockRequest = new MockHttpServletRequest();
+        mockRequest.setSession(new MockHttpSession());
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+    }
+
+    private String getSessionId() {
+        return mockRequest.getSession().getId();
     }
 
     @Test
@@ -188,5 +215,196 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
         assertThat(response.memberId()).isEqualTo(teamLeader.getId());
         assertThat(response.token()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] state가 null이면 인증 실패한다")
+    void state가_null이면_인증_실패한다() {
+        final String code = "code";
+        final String state = null;
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(code, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] state가 빈 문자열이면 인증 실패한다")
+    void state가_빈_문자열이면_인증_실패한다() {
+        final String code = "code";
+        final String state = "";
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(code, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] Redis에 저장되지 않은 state면 인증 실패한다")
+    void Redis에_저장되지_않은_state면_인증_실패한다() {
+        final String code = "code";
+        final String state = "invalidState";
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(code, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 세션의 state로는 인증 실패한다 (CSRF 방어)")
+    void 다른_세션의_state로는_인증_실패한다() {
+        setUpMockRequest();
+        final String attackerSessionId = "attacker-session-id";
+        final String state = "state";
+        final String attackerStateKey = "oauth:state:" + attackerSessionId + ":" + state;
+        authRedisUtil.set(attackerStateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback("code", state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] error 파라미터가 있으면 사용자 권한 거부로 처리된다")
+    void error_파라미터가_있으면_사용자_권한_거부로_처리된다() {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback("code", state, "access_denied");
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(USER_DENIED_AUTHORIZATION.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] code가 null이면 인증 실패한다")
+    void code가_null이면_인증_실패한다() {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(null, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(SOCIAL_LOGIN_FAILED_AUTH_CODE.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] code가 빈 문자열이면 인증 실패한다")
+    void code가_빈_문자열이면_인증_실패한다() {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback("", state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(SOCIAL_LOGIN_FAILED_AUTH_CODE.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 기존 회원은 OAuth 로그인 처리된다")
+    void 기존_회원은_OAuth_로그인_처리된다() throws Exception {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        final GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockResult);
+
+        SignInResponse response = memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        assertThat(response.memberId()).isEqualTo(teamLeader.getId());
+        assertThat(response.token()).isNotEmpty();
+        assertThat(memberRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("[성공] 신규 회원은 자동 가입 후 OAuth 로그인 처리된다")
+    void 신규_회원은_자동_가입_후_OAuth_로그인_처리된다() throws Exception {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        final GoogleUser mockGoogleUser = new GoogleUser("kty@gmail.com", "김태윤");
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockResult);
+
+        SignInResponse response = memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        assertThat(response.name()).isEqualTo("김태윤");
+        assertThat(response.token()).isNotEmpty();
+        assertThat(memberRepository.count()).isEqualTo(2);
+        Member newMember = memberRepository.findByEmail("kty@gmail.com").orElseThrow();
+        assertThat(newMember.getStudentId()).startsWith("fake_");
+    }
+
+    @Test
+    @DisplayName("[성공] 검증 성공 시 state가 Redis에서 삭제된다")
+    void 검증_성공_시_state가_Redis에서_삭제된다() throws Exception {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        final GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockResult);
+
+        memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        assertThat(authRedisUtil.exists(stateKey)).isFalse();
+    }
+
+    @Test
+    @DisplayName("[성공] OAuth 로그인 시 토큰이 Redis에 저장된다")
+    void OAuth_로그인_시_토큰이_Redis에_저장된다() throws Exception {
+        setUpMockRequest();
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        final GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "testAccessToken", "testRefreshToken");
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockResult);
+
+        memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        final String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        assertThat(authRedisUtil.exists(tokenKey)).isTrue();
+        assertThat(authRedisUtil.get(tokenKey)).isEqualTo("testAccessToken:testRefreshToken");
+    }
+
+    @Test
+    @DisplayName("[성공] 구글 연동 해제 시 Redis 토큰이 삭제된다")
+    void 구글_연동_해제_시_Redis_토큰이_삭제된다() {
+        final String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        authRedisUtil.set(tokenKey, "accessToken:refreshToken", 3L, TimeUnit.HOURS);
+
+        memberCommandService.unlinkGoogleAccount(teamLeader.getId());
+
+        assertThat(authRedisUtil.exists(tokenKey)).isFalse();
+    }
+
+    @Test
+    @DisplayName("[성공] 구글 연동 해제 시 revokeToken이 호출된다")
+    void 구글_연동_해제_시_revokeToken이_호출된다() {
+        final String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        authRedisUtil.set(tokenKey, "testAccessToken:testRefreshToken", 3L, TimeUnit.HOURS);
+
+        memberCommandService.unlinkGoogleAccount(teamLeader.getId());
+
+        verify(googleOauth).revokeToken("testAccessToken");
     }
 }

--- a/src/test/java/com/opus/opus/notice/NoticeFixture.java
+++ b/src/test/java/com/opus/opus/notice/NoticeFixture.java
@@ -4,10 +4,19 @@ import com.opus.opus.modules.notice.domain.Notice;
 
 public class NoticeFixture {
 
-    public static Notice createNotice() {
+    public static Notice createGlobalNotice() {
         return Notice.builder()
-                .title("공지 제목입니다.")
-                .description("공지 내용입니다.")
+                .title("전체 공지 제목입니다.")
+                .contestId(null)
+                .description("전체 공지 내용입니다.")
+                .build();
+    }
+
+    public static Notice createContestNotice(final Long contestId) {
+        return Notice.builder()
+                .title("대회 공지 제목입니다.")
+                .contestId(contestId)
+                .description("대회 공지 내용입니다.")
                 .build();
     }
 }

--- a/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
@@ -2,7 +2,13 @@ package com.opus.opus.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.opus.opus.contest.ContestCategoryFixture;
+import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.notice.application.NoticeCommandService;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
@@ -20,22 +26,32 @@ public class NoticeCommandServiceTest extends IntegrationTest {
 
     @Autowired
     private NoticeRepository noticeRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private ContestCategoryRepository contestCategoryRepository;
 
-    private Notice notice;
+    private Contest contest;
+    private ContestCategory contestCategory;
+    private Notice globalNotice;
+    private Notice contestNotice;
 
     @BeforeEach
     void setUp() {
-        notice = noticeRepository.save(NoticeFixture.createNotice());
+        contestCategory = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        contest = contestRepository.save(ContestFixture.createContestWithCategoryId(contestCategory.getId()));
+        globalNotice = noticeRepository.save(NoticeFixture.createGlobalNotice());
+        contestNotice = noticeRepository.save(NoticeFixture.createContestNotice(contest.getId()));
     }
 
     @Test
     @DisplayName("[성공] 전체 공지사항이 정상적으로 생성된다.")
     void 전체_공지사항이_정상적으로_생성된다() {
-        final NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+        final NoticeRequest request = new NoticeRequest("전체 공지 제목", "전체 공지 내용");
 
         noticeCommandService.createNotice(request);
 
-        final Notice notice = noticeRepository.findAllByOrderByCreatedAtDesc().get(0);
+        final Notice notice = noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc().get(0);
         assertThat(notice.getTitle()).isEqualTo(request.title());
         assertThat(notice.getDescription()).isEqualTo(request.description());
         assertThat(notice.getContestId()).isNull();
@@ -44,13 +60,13 @@ public class NoticeCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 전체 공지사항이 정상적으로 수정된다.")
     void 전체_공지사항이_정상적으로_수정된다() {
-        final String beforeTitle = notice.getTitle();
-        final String beforeDescription = notice.getDescription();
-        final NoticeRequest request = new NoticeRequest("수정 공지 제목", "수정 공지 내용");
+        final String beforeTitle = globalNotice.getTitle();
+        final String beforeDescription = globalNotice.getDescription();
+        final NoticeRequest request = new NoticeRequest("수정 전체 공지 제목", "수정 전체 공지 내용");
 
-        noticeCommandService.updateNotice(request, notice.getId());
+        noticeCommandService.updateNotice(request, globalNotice.getId());
 
-        final Notice updateNotice = noticeRepository.findAllByOrderByCreatedAtDesc().get(0);
+        final Notice updateNotice = noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc().get(0);
         assertThat(updateNotice.getTitle()).isNotEqualTo(beforeTitle);
         assertThat(updateNotice.getDescription()).isNotEqualTo(beforeDescription);
         assertThat(updateNotice.getTitle()).isEqualTo(request.title());
@@ -60,10 +76,50 @@ public class NoticeCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 전체 공지사항이 정상적으로 삭제된다.")
     void 전체_공지사항이_정상적으로_삭제된다() {
+        assertThat(noticeRepository.count()).isEqualTo(2);
+
+        noticeCommandService.deleteNotice(globalNotice.getId());
+
         assertThat(noticeRepository.count()).isEqualTo(1);
+    }
 
-        noticeCommandService.deleteNotice(notice.getId());
+    @Test
+    @DisplayName("[성공] 대회별 공지사항이 정상적으로 생성된다.")
+    void 대회별_공지사항이_정상적으로_생성된다() {
+        final NoticeRequest request = new NoticeRequest("대회별 공지 제목", "대회별 공지 내용");
 
-        assertThat(noticeRepository.count()).isEqualTo(0);
+        noticeCommandService.createContestNotice(contestNotice.getContestId(), request);
+
+        final Notice notice = noticeRepository.findAllByContestIdOrderByCreatedAtDesc(contestNotice.getContestId())
+                .get(0);
+        assertThat(notice.getTitle()).isEqualTo(request.title());
+        assertThat(notice.getDescription()).isEqualTo(request.description());
+    }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항이 정상적으로 수정된다.")
+    void 대회별_공지사항이_정상적으로_수정된다() {
+        final String beforeTitle = contestNotice.getTitle();
+        final String beforeDescription = contestNotice.getDescription();
+        final NoticeRequest request = new NoticeRequest("수정 대회별 공지 제목", "수정 대회별 공지 내용");
+
+        noticeCommandService.updateContestNotice(request, contestNotice.getContestId(), contestNotice.getId());
+
+        final Notice updateNotice = noticeRepository.findAllByContestIdOrderByCreatedAtDesc(
+                contestNotice.getContestId()).get(0);
+        assertThat(updateNotice.getTitle()).isNotEqualTo(beforeTitle);
+        assertThat(updateNotice.getDescription()).isNotEqualTo(beforeDescription);
+        assertThat(updateNotice.getTitle()).isEqualTo(request.title());
+        assertThat(updateNotice.getDescription()).isEqualTo(request.description());
+    }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항이 정상적으로 삭제된다.")
+    void 대회별_공지사항이_정상적으로_삭제된다() {
+        assertThat(noticeRepository.count()).isEqualTo(2);
+
+        noticeCommandService.deleteContestNotice(contestNotice.getContestId(), contestNotice.getId());
+
+        assertThat(noticeRepository.count()).isEqualTo(1);
     }
 }

--- a/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
@@ -2,7 +2,13 @@ package com.opus.opus.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.opus.opus.contest.ContestCategoryFixture;
+import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.notice.application.NoticeQueryService;
 import com.opus.opus.modules.notice.application.dto.response.NoticeDetailResponse;
 import com.opus.opus.modules.notice.application.dto.response.NoticeSummaryResponse;
@@ -22,33 +28,67 @@ public class NoticeQueryServiceTest extends IntegrationTest {
 
     @Autowired
     private NoticeRepository noticeRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private ContestCategoryRepository contestCategoryRepository;
 
-    private Notice notice;
+    private Contest contest;
+    private ContestCategory contestCategory;
+    private Notice globalNotice;
+    private Notice contestNotice;
 
     @BeforeEach
     void setUp() {
-        notice = noticeRepository.save(NoticeFixture.createNotice());
+        contestCategory = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        contest = contestRepository.save(ContestFixture.createContestWithCategoryId(contestCategory.getId()));
+        globalNotice = noticeRepository.save(NoticeFixture.createGlobalNotice());
+        contestNotice = noticeRepository.save(NoticeFixture.createContestNotice(contest.getId()));
     }
 
     @Test
     @DisplayName("[성공] 전체 공지사항을 상세 조회할 수 있다.")
     void 전체_공지사항을_상세_조회할_수_있다() {
-        final NoticeDetailResponse response = noticeQueryService.getNotice(notice.getId());
+        final NoticeDetailResponse response = noticeQueryService.getNotice(globalNotice.getId());
 
-        assertThat(response.title()).isEqualTo(notice.getTitle());
-        assertThat(response.description()).isEqualTo(notice.getDescription());
+        assertThat(response.title()).isEqualTo(globalNotice.getTitle());
+        assertThat(response.description()).isEqualTo(globalNotice.getDescription());
     }
 
     @Test
     @DisplayName("[성공] 전체 공지사항 목록을 조회할 수 있다.")
     void 전체_공지사항_목록을_조회할_수_있다() {
-        final Notice anotherNotice = noticeRepository.save(NoticeFixture.createNotice());
+        final Notice anotherNotice = noticeRepository.save(NoticeFixture.createGlobalNotice());
 
         final List<NoticeSummaryResponse> responses = noticeQueryService.getAllNotices();
 
         assertThat(responses).hasSize(2);
         assertThat(responses)
                 .extracting(NoticeSummaryResponse::noticeId)
-                .containsExactlyInAnyOrder(notice.getId(), anotherNotice.getId());
+                .containsExactlyInAnyOrder(globalNotice.getId(), anotherNotice.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항을 상세 조회할 수 있다.")
+    void 대회별_공지사항을_상세_조회할_수_있다() {
+        final NoticeDetailResponse response = noticeQueryService.getContestNotice(contestNotice.getContestId(),
+                contestNotice.getId());
+
+        assertThat(response.title()).isEqualTo(contestNotice.getTitle());
+        assertThat(response.description()).isEqualTo(contestNotice.getDescription());
+    }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항 목록을 조회할 수 있다.")
+    void 대회별_공지사항_목록을_조회할_수_있다() {
+        final Notice anotherContestNotice = noticeRepository.save(NoticeFixture.createContestNotice(contest.getId()));
+
+        final List<NoticeSummaryResponse> responses = noticeQueryService.getAllContestNotices(
+                anotherContestNotice.getContestId());
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses)
+                .extracting(NoticeSummaryResponse::noticeId)
+                .containsExactlyInAnyOrder(contestNotice.getId(), anotherContestNotice.getId());
     }
 }

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -5,14 +5,28 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import com.opus.opus.global.security.JwtProvider;
+import com.opus.opus.global.security.annotation.MemberArgumentResolver;
 import com.opus.opus.helper.ApiTestHelper;
+import com.opus.opus.modules.contest.api.ContestController;
+import com.opus.opus.modules.contest.application.ContestCommandService;
+import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.ContestTeamTemplateCommandService;
+import com.opus.opus.modules.contest.application.ContestTeamTemplateQueryService;
 import com.opus.opus.modules.member.api.MemberController;
 import com.opus.opus.modules.member.application.MemberCommandService;
 import com.opus.opus.modules.member.application.MemberQueryService;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.api.TeamCommentController;
+import com.opus.opus.modules.team.application.TeamCommentCommandService;
+import com.opus.opus.modules.team.application.TeamCommentQueryService;
 import com.opus.opus.modules.notice.api.NoticeController;
 import com.opus.opus.modules.notice.application.NoticeCommandService;
 import com.opus.opus.modules.notice.application.NoticeQueryService;
+import com.opus.opus.modules.team.api.TeamController;
+import com.opus.opus.modules.team.application.TeamCommandService;
+import com.opus.opus.modules.team.application.TeamQueryService;
+import com.opus.opus.modules.team.api.TeamMemberController;
+import com.opus.opus.modules.team.application.TeamMemberCommandService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +43,11 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest({
         MemberController.class,
-        NoticeController.class
+        NoticeController.class,
+        TeamController.class,
+        TeamMemberController.class,
+        ContestController.class,
+        TeamCommentController.class,
 })
 @Import(RestDocsConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -43,10 +61,37 @@ public abstract class RestDocsTest extends ApiTestHelper {
     protected MemberQueryService memberQueryService;
 
     @MockitoBean
+    protected TeamCommentCommandService teamCommentCommandService;
+
+    @MockitoBean
+    protected TeamCommentQueryService teamCommentQueryService;
+
+    @MockitoBean
+    protected TeamMemberCommandService teamMemberCommandService;
+
+    @MockitoBean
     protected NoticeCommandService noticeCommandService;
 
     @MockitoBean
     protected NoticeQueryService noticeQueryService;
+
+    @MockitoBean
+    protected TeamCommandService teamCommandService;
+
+    @MockitoBean
+    protected TeamQueryService teamQueryService;
+
+    @MockitoBean
+    protected ContestCommandService contestCommandService;
+
+    @MockitoBean
+    protected ContestQueryService contestQueryService;
+
+    @MockitoBean
+    protected ContestTeamTemplateCommandService contestTeamTemplateCommandService;
+
+    @MockitoBean
+    protected ContestTeamTemplateQueryService contestTeamTemplateQueryService;
 
     // Setting
     @Autowired
@@ -57,6 +102,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected MemberRepository memberRepository;
+
+    @MockitoBean
+    protected MemberArgumentResolver memberArgumentResolver;
 
     @BeforeEach
     void setUp(final RestDocumentationContextProvider restDocumentation) {

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
@@ -1,0 +1,211 @@
+package com.opus.opus.restdocs.docs;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.put;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.modules.contest.application.dto.request.ContestVotesLimitRequest;
+import com.opus.opus.modules.contest.application.dto.request.VoteUpdateRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
+import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.restdocs.RestDocsTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class ContestApiDocsTest extends RestDocsTest {
+
+    private static final String ADMIN_TOKEN = "Bearer admin.access.token";
+
+    @Test
+    @DisplayName("[성공] 투표 기간을 조회하면 시작일과 종료일을 반환한다.")
+    void 투표_기간을_조회하면_시작일과_종료일을_반환한다() throws Exception {
+        VotePeriodResponse response = new VotePeriodResponse(
+                LocalDateTime.of(2026, 1, 1, 0, 0, 0),
+                LocalDateTime.of(2026, 1, 2, 0, 0, 0)
+        );
+
+        given(contestQueryService.getVotePeriod(any())).willReturn(response);
+
+        mockMvc.perform(get("/contests/{contestId}/vote", 1L))
+                .andExpect(status().isOk())
+                .andDo(document("get-vote-period",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        responseFields(
+                                dateTimeFieldWithPath("voteStartAt", "투표 시작일"),
+                                dateTimeFieldWithPath("voteEndAt", "투표 종료일")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 최대 투표 개수가 정상적으로 설정된다.")
+    void 유효한_요청이면_최대_투표_개수가_정상적으로_설정된다() throws Exception {
+        final ContestVotesLimitRequest request = new ContestVotesLimitRequest(2);
+
+        doNothing().when(contestCommandService).updateMaxVotesLimit(any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/votes", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-max-votes-limit",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회의 고유 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                numberFieldWithPath("maxVotesLimit", "최대 투표 개수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 관리자는 투표 기간을 수정할 수 있다.")
+    void 관리자는_투표_기간을_수정할_수_있다() throws Exception {
+        VoteUpdateRequest request = new VoteUpdateRequest(
+                LocalDateTime.of(2026, 2, 1, 0, 0, 0),
+                LocalDateTime.of(2026, 2, 10, 0, 0, 0)
+        );
+
+        doNothing().when(contestCommandService).updateVotePeriod(any(), any());
+
+        mockMvc.perform(put("/contests/{contestId}/vote", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-vote-period",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                dateTimeFieldWithPath("voteStartAt", "투표 시작일"),
+                                dateTimeFieldWithPath("voteEndAt", "투표 종료일")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회의 최대 투표 개수 설정 시 404 에러를 반환한다.")
+    void 존재하지_않는_대회의_최대_투표_개수_설정_시_에러를_반환한다() throws Exception {
+        final ContestVotesLimitRequest request = new ContestVotesLimitRequest(2);
+
+        willThrow(new ContestException(NOT_FOUND_CONTEST))
+                .given(contestCommandService)
+                .updateMaxVotesLimit(any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/votes", 999)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andDo(document("update-max-votes-limit-fail-not-found",
+                        pathParameters(
+                                parameterWithName("contestId").description("존재하지 않는 대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                numberFieldWithPath("maxVotesLimit", "최대 투표 개수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 투표 진행 중 최대 투표 개수 변경 시 400 에러를 반환한다.")
+    void 투표_진행_중_최대_투표_개수_변경_시_에러를_반환한다() throws Exception {
+        final ContestVotesLimitRequest request = new ContestVotesLimitRequest(2);
+
+        willThrow(new ContestException(CANNOT_CHANGE_VOTES_DURING_VOTING_PERIOD))
+                .given(contestCommandService)
+                .updateMaxVotesLimit(any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/votes", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("update-max-votes-limit-fail-voting-period",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                numberFieldWithPath("maxVotesLimit", "최대 투표 개수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 최대 투표 개수를 정상적으로 조회할 수 있다.")
+    void 최대_투표_개수를_정상적으로_조회할_수_있다() throws Exception {
+        final ContestVotesLimitResponse response = new ContestVotesLimitResponse(2);
+
+        when(contestQueryService.getMaxVotesLimit(any())).thenReturn(response);
+
+        mockMvc.perform(get("/contests/{contestId}/votes", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("get-max-votes-limit",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회의 고유 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        responseFields(
+                                numberFieldWithPath("maxVotesLimit", "최대 투표 개수")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회의 최대 투표 개수 조회 시 404 에러를 반환한다.")
+    void 존재하지_않는_대회의_최대_투표_개수_조회_시_에러를_반환한다() throws Exception {
+        willThrow(new ContestException(NOT_FOUND_CONTEST))
+                .given(contestQueryService)
+                .getMaxVotesLimit(any());
+
+        mockMvc.perform(get("/contests/{contestId}/votes", 999)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("get-max-votes-limit-fail-not-found",
+                        pathParameters(
+                                parameterWithName("contestId").description("존재하지 않는 대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
@@ -3,6 +3,9 @@ package com.opus.opus.restdocs.docs;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.USER_DENIED_AUTHORIZATION;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
@@ -15,6 +18,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -259,6 +263,81 @@ public class MemberApiDocsTest extends RestDocsTest {
                         ),
                         responseFields(
                                 stringFieldWithPath("email", "가입된 이메일")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] Google OAuth 리다이렉트 URL을 반환한다.")
+    void Google_OAuth_리다이렉트_URL을_반환한다() throws Exception {
+        String redirectURL = "https://accounts.google.com/o/oauth2/v2/auth?client_id=test&redirect_uri=http://localhost:8080/oauth/google/callback&response_type=code&scope=email+profile&state=test-state";
+
+        when(memberCommandService.getGoogleOAuthRedirectURL()).thenReturn(redirectURL);
+
+        mockMvc.perform(get("/oauth/google"))
+                .andExpect(status().isFound())
+                .andDo(document("oauth-google-redirect"));
+    }
+
+    @Test
+    @DisplayName("[성공] Google OAuth 콜백으로 로그인 처리된다.")
+    void Google_OAuth_콜백으로_로그인_처리된다() throws Exception {
+        SignInResponse response = new SignInResponse(member.getId(), member.getName(), "exampleToken", member.getRoles());
+
+        when(memberCommandService.getGoogleOAuthCallback(any(), any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .param("code", "authorization_code")
+                        .param("state", "state_token"))
+                .andExpect(status().isOk())
+                .andDo(document("oauth-google-callback",
+                        queryParameters(
+                                parameterWithName("code").description("Google 인가 코드"),
+                                parameterWithName("state").description("CSRF 방어용 상태 토큰")
+                        ),
+                        responseFields(
+                                numberFieldWithPath("memberId", "회원 고유 식별자"),
+                                stringFieldWithPath("name", "회원 이름"),
+                                stringFieldWithPath("token", "JWT 액세스 토큰"),
+                                arrayFieldWithPath("types", "회원 권한 목록(회원, 관리자)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] Google OAuth 콜백에서 state가 유효하지 않으면 401 에러를 반환한다.")
+    void Google_OAuth_콜백에서_state가_유효하지_않으면_에러를_반환한다() throws Exception {
+        willThrow(new OAuthException(OAUTH_AUTHORIZATION_FAILED))
+                .given(memberCommandService).getGoogleOAuthCallback(any(), any(), any());
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .param("code", "authorization_code")
+                        .param("state", "invalid_state"))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("oauth-google-callback-fail-state",
+                        queryParameters(
+                                parameterWithName("code").description("Google 인가 코드"),
+                                parameterWithName("state").description("유효하지 않은 상태 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] Google OAuth 콜백에서 사용자가 권한을 거부하면 400 에러를 반환한다.")
+    void Google_OAuth_콜백에서_사용자가_권한을_거부하면_에러를_반환한다() throws Exception {
+        willThrow(new OAuthException(USER_DENIED_AUTHORIZATION))
+                .given(memberCommandService).getGoogleOAuthCallback(any(), any(), any());
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .param("code", "authorization_code")
+                        .param("state", "state_token")
+                        .param("error", "access_denied"))
+                .andExpect(status().isBadRequest())
+                .andDo(document("oauth-google-callback-fail-denied",
+                        queryParameters(
+                                parameterWithName("code").description("Google 인가 코드"),
+                                parameterWithName("state").description("상태 토큰"),
+                                parameterWithName("error").description("에러 코드 (사용자 권한 거부)")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
@@ -34,24 +34,23 @@ import org.springframework.http.MediaType;
 public class NoticeApiDocsTest extends RestDocsTest {
 
     private Member admin;
-    private String adminToken;
+    private static final String ADMIN_TOKEN = "Bearer admin.access.token";
 
     @BeforeEach
     void setUp() {
         this.admin = MemberFixture.createMember();
         setField(admin, "id", 1L);
-        adminToken = "mock_admin_access_token";
     }
 
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항이 생성된다.")
     void 유효한_요청이면_정상적으로_전체_공지사항이_생성된다() throws Exception {
-        final NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+        final NoticeRequest request = new NoticeRequest("전체 공지 제목", "전체 공지 내용");
 
         doNothing().when(noticeCommandService).createNotice(any());
 
         mockMvc.perform(post("/notices")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -69,12 +68,12 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항이 수정된다.")
     void 유효한_요청이면_정상적으로_전체_공지사항이_수정된다() throws Exception {
-        final NoticeRequest request = new NoticeRequest("수정된 공지 제목", "수정된 공지 내용");
+        final NoticeRequest request = new NoticeRequest("수정된 전체 공지 제목", "수정된 전체 공지 내용");
 
         doNothing().when(noticeCommandService).updateNotice(any(), any());
 
         mockMvc.perform(patch("/notices/{noticeId}", 1)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNoContent())
@@ -98,7 +97,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
         doNothing().when(noticeCommandService).deleteNotice(any());
 
         mockMvc.perform(delete("/notices/{noticeId}", 1)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-notice",
                         pathParameters(
@@ -113,11 +112,11 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항 상세 조회를 할 수 있다.")
     void 유효한_요청이면_정상적으로_전체_공지사항_상세_조회를_할_수_있다() throws Exception {
-        final NoticeDetailResponse response = new NoticeDetailResponse("공지 제목", "공지 내용", now(), now());
+        final NoticeDetailResponse response = new NoticeDetailResponse("전체 공지 제목", "전체 공지 내용", now(), now());
 
         when(noticeQueryService.getNotice(any())).thenReturn(response);
 
-        mockMvc.perform(get("/notices/{noticeId}", 1L))
+        mockMvc.perform(get("/notices/{noticeId}", 1))
                 .andExpect(status().isOk())
                 .andDo(document("get-notice",
                         pathParameters(
@@ -136,8 +135,8 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항 목록을 조회할 수 있다.")
     void 유효한_요청이면_정상적으로_전체_공지사항_목록을_조회할_수_있다() throws Exception {
         final List<NoticeSummaryResponse> responses = List.of(
-                new NoticeSummaryResponse(1L, "공지 제목 1", now()),
-                new NoticeSummaryResponse(2L, "공지 제목 2", now())
+                new NoticeSummaryResponse(1L, "전체 공지 제목 1", now()),
+                new NoticeSummaryResponse(2L, "전체 공지 제목 2", now())
         );
 
         when(noticeQueryService.getAllNotices()).thenReturn(responses);
@@ -145,6 +144,126 @@ public class NoticeApiDocsTest extends RestDocsTest {
         mockMvc.perform(get("/notices"))
                 .andExpect(status().isOk())
                 .andDo(document("get-all-notices",
+                        responseFields(
+                                arrayFieldWithPath("[]", "공지 목록"),
+                                numberFieldWithPath("[].noticeId", "공지 ID"),
+                                stringFieldWithPath("[].title", "공지 제목"),
+                                dateTimeFieldWithPath("[].createdAt", "공지 생성 시각")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항이 생성된다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항이_생성된다() throws Exception {
+        final NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+
+        doNothing().when(noticeCommandService).createContestNotice(any(), any());
+
+        mockMvc.perform(post("/contests/{contestId}/notices", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("create-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("title", "공지 제목"),
+                                stringFieldWithPath("description", "공지 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항이 수정된다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항이_수정된다() throws Exception {
+        final NoticeRequest request = new NoticeRequest("수정된 대회별 공지 제목", "수정된 대회별 공지 내용");
+
+        doNothing().when(noticeCommandService).updateContestNotice(any(), any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/notices/{noticeId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("noticeId").description("공지 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("title", "수정된 대회별 공지 제목"),
+                                stringFieldWithPath("description", "수정된 대회별 공지 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항이 삭제된다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항이_삭제된다() throws Exception {
+        doNothing().when(noticeCommandService).deleteContestNotice(any(), any());
+
+        mockMvc.perform(delete("/contests/{contestId}/notices/{noticeId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("noticeId").description("공지 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항 상세 조회를 할 수 있다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항_상세_조회를_할_수_있다() throws Exception {
+        final NoticeDetailResponse response = new NoticeDetailResponse("대회별 공지 제목", "대회별 공지 내용", now(), now());
+
+        when(noticeQueryService.getContestNotice(any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/contests/{contestId}/notices/{noticeId}", 1, 1))
+                .andExpect(status().isOk())
+                .andDo(document("get-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("noticeId").description("공지 ID")
+                        ),
+                        responseFields(
+                                stringFieldWithPath("title", "공지 제목"),
+                                stringFieldWithPath("description", "공지 내용"),
+                                dateTimeFieldWithPath("createdAt", "공지 생성 시각"),
+                                dateTimeFieldWithPath("updatedAt", "공지 수정 시각")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항 목록을 조회할 수 있다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항_목록을_조회할_수_있다() throws Exception {
+        final List<NoticeSummaryResponse> responses = List.of(
+                new NoticeSummaryResponse(1L, "대회별 공지 제목 1", now()),
+                new NoticeSummaryResponse(2L, "대회별 공지 제목 2", now())
+        );
+
+        when(noticeQueryService.getAllContestNotices(any())).thenReturn(responses);
+
+        mockMvc.perform(get("/contests/{contestId}/notices", 1))
+                .andExpect(status().isOk())
+                .andDo(document("get-all-contest-notices",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
                         responseFields(
                                 arrayFieldWithPath("[]", "공지 목록"),
                                 numberFieldWithPath("[].noticeId", "공지 ID"),

--- a/src/test/java/com/opus/opus/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/TeamApiDocsTest.java
@@ -1,0 +1,113 @@
+package com.opus.opus.restdocs.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.modules.team.application.dto.ImageResponse;
+import com.opus.opus.restdocs.RestDocsTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class TeamApiDocsTest extends RestDocsTest {
+
+    private String accessToken;
+    private byte[] testImage;
+
+    @BeforeEach
+    void setUp() {
+        accessToken = "Bearer member.access.token";
+        testImage = "test-image-content".getBytes();
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 포스터 이미지를 조회한다.")
+    void 팀의_포스터_이미지를_조회한다() throws Exception {
+        // Given
+        final Long teamId = 1L;
+        final ImageResponse response = new ImageResponse(new ByteArrayResource(testImage), "image/png");
+
+        when(teamQueryService.getPosterImage(any())).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/teams/{teamId}/image/posters", teamId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.IMAGE_PNG))
+                .andDo(document("get-team-poster",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 포스터 이미지를 등록한다.")
+    void 팀의_포스터_이미지를_등록한다() throws Exception {
+        // Given
+        final Long teamId = 1L;
+        final MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "poster.png",
+                MediaType.IMAGE_PNG_VALUE,
+                testImage
+        );
+
+        doNothing().when(teamCommandService).savePosterImage(any(), any());
+
+        // When & Then
+        mockMvc.perform(multipart("/teams/{teamId}/image/posters", teamId)
+                        .file(image)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andDo(document("save-team-poster",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (팀장, 관리자, 팀원 권한)")
+                        ),
+                        requestParts(
+                                partWithName("image").description("등록할 포스터 이미지 (모든 이미지 형식 지원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 포스터 이미지를 삭제한다.")
+    void 팀의_포스터_이미지를_삭제한다() throws Exception {
+        // Given
+        final Long teamId = 1L;
+        doNothing().when(teamCommandService).deletePosterImage(any());
+
+        // When & Then
+        mockMvc.perform(delete("/teams/{teamId}/image/posters", teamId)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-team-poster",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (팀장, 관리자, 팀원 권한)")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/TeamCommentApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/TeamCommentApiDocsTest.java
@@ -1,0 +1,225 @@
+package com.opus.opus.restdocs.docs;
+
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.NOT_OWNER_COMMENT;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.dto.request.TeamCommentCreateRequest;
+import com.opus.opus.modules.team.application.dto.request.TeamCommentUpdateRequest;
+import com.opus.opus.modules.team.application.dto.response.TeamCommentResponse;
+import com.opus.opus.modules.team.exception.TeamCommentException;
+import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.restdocs.RestDocsTest;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class TeamCommentApiDocsTest extends RestDocsTest {
+
+    private static final String MEMBER_TOKEN = "Bearer member.access.token";
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        member = MemberFixture.createMember();
+        setField(member, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 팀 댓글이 정상적으로 등록된다.")
+    void 유효한_요청이면_팀_댓글이_정상적으로_등록된다() throws Exception {
+        final TeamCommentCreateRequest request = new TeamCommentCreateRequest("정말 멋진 프로젝트네요!");
+
+        doNothing().when(teamCommentCommandService).createComment(any(), any(), any());
+
+        mockMvc.perform(post("/teams/{teamId}/comments", 1)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("create-team-comment",
+                        pathParameters(
+                                parameterWithName("teamId").description("댓글을 등록할 팀의 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("description", "댓글 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 팀에 댓글 등록 시 404 에러를 반환한다.")
+    void 존재하지_않는_팀에_댓글_등록_시_에러를_반환한다() throws Exception {
+        final TeamCommentCreateRequest request = new TeamCommentCreateRequest("정말 멋진 프로젝트네요!");
+
+        willThrow(new TeamException(NOT_FOUND_TEAM))
+                .given(teamCommentCommandService)
+                .createComment(any(), any(), any());
+
+        mockMvc.perform(post("/teams/{teamId}/comments", 999)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andDo(document("create-team-comment-fail-not-found",
+                        pathParameters(
+                                parameterWithName("teamId").description("존재하지 않는 팀 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("description", "댓글 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 댓글 목록을 정상적으로 조회할 수 있다.")
+    void 팀의_댓글_목록을_정상적으로_조회할_수_있다() throws Exception {
+        final List<TeamCommentResponse> responses = List.of(
+                new TeamCommentResponse(1L, "정말 멋진 프로젝트네요!", 1L, "이옵스", 1L),
+                new TeamCommentResponse(2L, "고생하셨습니다!", 2L, "김옵스", 1L)
+        );
+
+        when(teamCommentQueryService.getComments(any())).thenReturn(responses);
+
+        mockMvc.perform(get("/teams/{teamId}/comments", 1)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("get-team-comments",
+                        pathParameters(
+                                parameterWithName("teamId").description("댓글을 조회할 팀의 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        ),
+                        responseFields(
+                                arrayFieldWithPath("[]", "댓글 목록"),
+                                numberFieldWithPath("[].commentId", "댓글 ID"),
+                                stringFieldWithPath("[].description", "댓글 내용"),
+                                numberFieldWithPath("[].memberId", "작성자 ID"),
+                                stringFieldWithPath("[].memberName", "작성자 이름"),
+                                numberFieldWithPath("[].teamId", "팀 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 팀 댓글이 정상적으로 수정된다.")
+    void 유효한_요청이면_팀_댓글이_정상적으로_수정된다() throws Exception {
+        final TeamCommentUpdateRequest request = new TeamCommentUpdateRequest("수정된 댓글 내용입니다.");
+
+        doNothing().when(teamCommentCommandService).updateComment(any(), any(), any(), any());
+
+        mockMvc.perform(patch("/teams/{teamId}/comments/{commentId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(document("update-team-comment",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("commentId").description("수정할 댓글 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("description", "수정할 댓글 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 본인이 작성하지 않은 댓글 수정 시 403 에러를 반환한다.")
+    void 본인이_작성하지_않은_댓글_수정_시_에러를_반환한다() throws Exception {
+        final TeamCommentUpdateRequest request = new TeamCommentUpdateRequest("수정된 댓글 내용입니다.");
+
+        willThrow(new TeamCommentException(NOT_OWNER_COMMENT))
+                .given(teamCommentCommandService)
+                .updateComment(any(), any(), any(), any());
+
+        mockMvc.perform(patch("/teams/{teamId}/comments/{commentId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andDo(document("update-team-comment-fail-not-owner",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("commentId").description("다른 사람이 작성한 댓글 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("description", "수정할 댓글 내용")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 댓글이 정상적으로 삭제된다.")
+    void 팀_댓글이_정상적으로_삭제된다() throws Exception {
+        doNothing().when(teamCommentCommandService).deleteComment(any(), any(), any());
+
+        mockMvc.perform(delete("/teams/{teamId}/comments/{commentId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-team-comment",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("commentId").description("삭제할 댓글 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 본인이 작성하지 않은 댓글 삭제 시 403 에러를 반환한다.")
+    void 본인이_작성하지_않은_댓글_삭제_시_에러를_반환한다() throws Exception {
+        willThrow(new TeamCommentException(NOT_OWNER_COMMENT))
+                .given(teamCommentCommandService)
+                .deleteComment(any(), any(), any());
+
+        mockMvc.perform(delete("/teams/{teamId}/comments/{commentId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
+                .andExpect(status().isForbidden())
+                .andDo(document("delete-team-comment-fail-not-owner",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("commentId").description("다른 사람이 작성한 댓글 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken}")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/TeamMemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/TeamMemberApiDocsTest.java
@@ -1,0 +1,305 @@
+package com.opus.opus.restdocs.docs;
+
+import static com.opus.opus.modules.member.exception.MemberExceptionType.MISMATCH_STUDENT_ID_AND_NAME;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
+import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀원;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_ALREADY_EXISTS;
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.exception.MemberException;
+import com.opus.opus.modules.team.application.dto.request.TeamMemberCreateRequest;
+import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import com.opus.opus.restdocs.RestDocsTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class TeamMemberApiDocsTest extends RestDocsTest {
+
+    private static final String ADMIN_TOKEN = "Bearer admin.access.token";
+    private Member admin;
+
+    @BeforeEach
+    void setUp() {
+        admin = MemberFixture.createMember();
+        setField(admin, "id", 1L);
+
+        when(memberArgumentResolver.supportsParameter(any(MethodParameter.class)))
+                .thenReturn(true);
+        when(memberArgumentResolver.resolveArgument(
+                any(MethodParameter.class),
+                any(ModelAndViewContainer.class),
+                any(NativeWebRequest.class),
+                any(WebDataBinderFactory.class)
+        )).thenReturn(admin);
+    }
+
+    // 팀원 추가
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 팀원이 추가된다.")
+    void 유효한_요청이면_정상적으로_팀원이_추가된다() throws Exception {
+        final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
+
+        doNothing().when(teamMemberCommandService).createTeamMember(any(), any(), any(), any());
+
+        mockMvc.perform(post("/teams/{teamId}/members", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("add-team-member",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("memberName", "추가할 팀원 이름"),
+                                stringFieldWithPath("memberStudentId", "추가할 팀원 학번"),
+                                stringFieldWithPath("roleType", "추가할 팀원의 역할(ROLE_팀장, ROLE_팀원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 팀원명이 비어있으면 400 에러를 반환한다.")
+    void 팀원명이_비어있으면_에러를_반환한다() throws Exception {
+        final TeamMemberCreateRequest request = new TeamMemberCreateRequest("", "202612345", ROLE_팀원);
+
+        mockMvc.perform(post("/teams/{teamId}/members", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("add-team-member-fail-empty-name",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("memberName", "비어있는 팀원명"),
+                                stringFieldWithPath("memberStudentId", "팀원 학번"),
+                                stringFieldWithPath("roleType", "추가할 팀원의 역할(ROLE_팀장, ROLE_팀원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 팀원학번이 비어있으면 400 에러를 반환한다.")
+    void 팀원학번이_비어있으면_에러를_반환한다() throws Exception {
+        final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "", ROLE_팀원);
+
+        mockMvc.perform(post("/teams/{teamId}/members", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("add-team-member-fail-empty-student-id",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("memberName", "팀원명"),
+                                stringFieldWithPath("memberStudentId", "비어있는 팀원 학번"),
+                                stringFieldWithPath("roleType", "추가할 팀원의 역할(ROLE_팀장, ROLE_팀원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 팀 ID인 경우 404 에러를 반환한다.")
+    void 존재하지_않는_팀_ID인_경우_에러를_반환한다() throws Exception {
+        final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
+
+        willThrow(new TeamException(NOT_FOUND_TEAM)).given(teamMemberCommandService)
+                .createTeamMember(any(), any(), any(), any());
+
+        mockMvc.perform(post("/teams/{teamId}/members", 999)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isNotFound())
+                .andDo(document("add-team-member-fail-team-not-found",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("존재하지 않는 팀 ID")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("memberName", "팀원명"),
+                                stringFieldWithPath("memberStudentId", "팀원 학번"),
+                                stringFieldWithPath("roleType", "추가할 팀원의 역할(ROLE_팀장, ROLE_팀원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 팀원명과 팀원학번이 맞지 않으면 400 에러를 반환한다.")
+    void 팀원명과_팀원학번이_맞지_않으면_에러를_반환한다() throws Exception {
+        final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
+
+        willThrow(new MemberException(MISMATCH_STUDENT_ID_AND_NAME)).given(teamMemberCommandService)
+                .createTeamMember(any(), any(), any(), any());
+
+        mockMvc.perform(post("/teams/{teamId}/members", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("add-team-member-fail-mismatch",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("memberName", "팀원명 (학번과 일치하지 않음)"),
+                                stringFieldWithPath("memberStudentId", "팀원 학번 (이름과 일치하지 않음)"),
+                                stringFieldWithPath("roleType", "추가할 팀원의 역할(ROLE_팀장, ROLE_팀원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 동일한 참가자명 + 학번이 해당 팀에 있는 경우 409 에러를 반환한다.")
+    void 동일한_참가자명과_학번이_해당_팀에_있는_경우_에러를_반환한다() throws Exception {
+        final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
+
+        willThrow(new TeamMemberException(TEAM_MEMBER_ALREADY_EXISTS)).given(teamMemberCommandService)
+                .createTeamMember(any(), any(), any(), any());
+
+        mockMvc.perform(post("/teams/{teamId}/members", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isConflict())
+                .andDo(document("add-team-member-fail-already-exists",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("memberName", "이미 등록된 팀원명"),
+                                stringFieldWithPath("memberStudentId", "이미 등록된 팀원 학번"),
+                                stringFieldWithPath("roleType", "추가할 팀원의 역할(ROLE_팀장, ROLE_팀원)")
+                        )
+                ));
+    }
+
+    // 팀원 삭제
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 팀원이 삭제된다.")
+    void 유효한_요청이면_정상적으로_팀원이_삭제된다() throws Exception {
+        doNothing().when(teamMemberCommandService).deleteTeamMember(any(), any());
+
+        mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-team-member",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("memberId").description("회원 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 팀 ID인 경우 404 에러를 반환한다.")
+    void 삭제_존재하지_않는_팀_ID인_경우_에러를_반환한다() throws Exception {
+        willThrow(new TeamException(NOT_FOUND_TEAM)).given(teamMemberCommandService)
+                .deleteTeamMember(any(), any());
+
+        mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 999, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("delete-team-member-fail-team-not-found",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("존재하지 않는 팀 ID"),
+                                parameterWithName("memberId").description("회원 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 멤버 ID인 경우 404 에러를 반환한다.")
+    void 존재하지_않는_멤버_ID인_경우_에러를_반환한다() throws Exception {
+        willThrow(new MemberException(NOT_FOUND_MEMBER)).given(teamMemberCommandService)
+                .deleteTeamMember(any(), any());
+
+        mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 1, 999)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("delete-team-member-fail-member-not-found",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("memberId").description("존재하지 않는 회원 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 삭제 대상 팀원이 해당 팀에 없을 경우 404 에러를 반환한다.")
+    void 삭제_대상_팀원이_해당_팀에_없을_경우_에러를_반환한다() throws Exception {
+        willThrow(new TeamMemberException(TEAM_MEMBER_NOT_FOUND_IN_TEAM))
+                .given(teamMemberCommandService)
+                .deleteTeamMember(any(), any());
+
+        mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("delete-team-member-fail-not-in-team",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID"),
+                                parameterWithName("memberId").description("해당 팀에 속하지 않은 회원 ID")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/team/FileFixture.java
+++ b/src/test/java/com/opus/opus/team/FileFixture.java
@@ -1,0 +1,19 @@
+package com.opus.opus.team;
+
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
+
+import com.opus.opus.modules.file.domain.File;
+
+public class FileFixture {
+
+    public static File createTeamPosterFile() {
+        return File.builder()
+                .name("poster.jpg")
+                .filePath("path/to/poster.webp")
+                .referenceId(1L)
+                .referenceType(TEAM)
+                .imageType(POSTER)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/team/TeamCommentFixture.java
+++ b/src/test/java/com/opus/opus/team/TeamCommentFixture.java
@@ -1,0 +1,15 @@
+package com.opus.opus.team;
+
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamComment;
+
+public class TeamCommentFixture {
+
+    public static TeamComment createTeamComment(final Team team, final Long memberId) {
+        return TeamComment.builder()
+                .description("테스트용 댓글입니다.")
+                .memberId(memberId)
+                .team(team)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/team/TeamFixture.java
+++ b/src/test/java/com/opus/opus/team/TeamFixture.java
@@ -1,0 +1,23 @@
+package com.opus.opus.team;
+
+import com.opus.opus.modules.team.domain.Team;
+import java.util.ArrayList;
+
+public class TeamFixture {
+
+    public static Team createTeam() {
+        return Team.builder()
+                .teamName("팀 옵스")
+                .projectName("옵스 프로젝트")
+                .professorName("김교수")
+                .overview("이 프로젝트는 옵스 프로젝트입니다.")
+                .githubPath("http://github.com/example")
+                .productionPath("http://production.example.com")
+                .youTubePath("http://youtube.com/example")
+                .contestId(1L)
+                .trackId(1L)
+                .itemOrder(1)
+                .teamMembers(new ArrayList<>())
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
@@ -1,0 +1,123 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.opus.opus.global.util.FileStorageUtil;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.dao.FileRepository;
+import com.opus.opus.modules.team.application.TeamCommandService;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.team.FileFixture;
+import com.opus.opus.team.TeamFixture;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class TeamCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamCommandService teamCommandService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(TeamFixture.createTeam());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지를 저장한다.")
+    void 팀_포스터_이미지를_저장한다() {
+        // given
+        final MockMultipartFile image = new MockMultipartFile("image", "poster.jpg", "image/jpeg",
+                "content".getBytes());
+
+        // when
+        teamCommandService.savePosterImage(team.getId(), image);
+
+        // then
+        verify(fileStorageUtil, times(1)).storeFile(any(), eq(team.getId()), eq(TEAM), eq(POSTER));
+    }
+
+    @Test
+    @DisplayName("[실패] 팀이 존재하지 않으면 포스터 이미지를 저장할 수 없다.")
+    void 팀이_존재하지_않으면_포스터_이미지를_저장할_수_없다() {
+        // given
+        final MockMultipartFile image = new MockMultipartFile("image", "poster.jpg", "image/jpeg",
+                "content".getBytes());
+        final long notExistTeamId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> teamCommandService.savePosterImage(notExistTeamId, image))
+                .isInstanceOf(TeamException.class)
+                .hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지를 삭제한다.")
+    void 팀_포스터_이미지를_삭제한다() {
+        // given
+        final File file = FileFixture.createTeamPosterFile();
+        setField(file, "referenceId", team.getId());
+        final File savedFile = fileRepository.save(file);
+        savedFile.updateIsWebpConverted(true);
+        fileRepository.saveAndFlush(savedFile);
+
+        // when
+        teamCommandService.deletePosterImage(team.getId());
+
+        // then
+        verify(fileStorageUtil, times(1)).deleteFile(savedFile.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지가 없어도 삭제 요청 시 예외가 발생하지 않는다.")
+    void 팀_포스터_이미지가_없어도_삭제_요청_시_예외가_발생하지_않는다() {
+        // when
+        teamCommandService.deletePosterImage(team.getId());
+
+        // then
+        verify(fileStorageUtil, never()).deleteFile(any());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지가 이미 존재하면 기존 이미지를 삭제하고 새로 저장한다.")
+    void 팀_포스터_이미지가_이미_존재하면_기존_이미지를_삭제하고_새로_저장한다() {
+        // given
+        final File existingFile = FileFixture.createTeamPosterFile();
+        setField(existingFile, "referenceId", team.getId());
+        final File savedFile = fileRepository.save(existingFile);
+
+        final MockMultipartFile newImage = new MockMultipartFile("image", "new_poster.jpg", "image/jpeg",
+                "new_content".getBytes());
+
+        // when
+        teamCommandService.savePosterImage(team.getId(), newImage);
+
+        // then
+        verify(fileStorageUtil, times(1)).deleteFile(savedFile.getId());
+        verify(fileStorageUtil, times(1)).storeFile(any(), eq(team.getId()), eq(TEAM), eq(POSTER));
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamCommentCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommentCommandServiceTest.java
@@ -1,0 +1,174 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.COMMENT_NOT_BELONG_TO_TEAM;
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.NOT_FOUND_COMMENT;
+import static com.opus.opus.modules.team.exception.TeamCommentExceptionType.NOT_OWNER_COMMENT;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.application.TeamCommentCommandService;
+import com.opus.opus.modules.team.application.dto.request.TeamCommentCreateRequest;
+import com.opus.opus.modules.team.application.dto.request.TeamCommentUpdateRequest;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamComment;
+import com.opus.opus.modules.team.domain.dao.TeamCommentRepository;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamCommentException;
+import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.team.TeamFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TeamCommentCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamCommentCommandService teamCommentCommandService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamCommentRepository teamCommentRepository;
+
+    private Team team;
+    private Member member;
+    private final String commentDescription = "테스트용 댓글입니다.";
+    private final String updatedCommentDescription = "수정된 댓글입니다.";
+    private TeamCommentCreateRequest commentCreateRequest;
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(TeamFixture.createTeam());
+        member = memberRepository.save(MemberFixture.createMember());
+        commentCreateRequest = new TeamCommentCreateRequest(commentDescription);
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 댓글이 정상적으로 등록된다.")
+    void 팀_댓글이_정상적으로_등록된다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+
+        final TeamComment savedComment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+        assertThat(savedComment.getDescription()).isEqualTo(commentCreateRequest.description());
+        assertThat(savedComment.getMemberId()).isEqualTo(member.getId());
+        assertThat(savedComment.getTeam().getId()).isEqualTo(team.getId());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 팀에는 댓글 등록이 불가능하다.")
+    void 존재하지_않는_팀에는_댓글_등록이_불가능하다() {
+        final Long invalidTeamId = 999L;
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.createComment(invalidTeamId, member.getId(), commentCreateRequest.description());
+        }).isInstanceOf(TeamException.class).hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 댓글이 정상적으로 수정된다.")
+    void 댓글이_정상적으로_수정된다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+        final TeamComment comment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+        final TeamCommentUpdateRequest updateRequest = new TeamCommentUpdateRequest(updatedCommentDescription);
+
+        teamCommentCommandService.updateComment(team.getId(), comment.getId(), member.getId(), updateRequest.description());
+
+        final TeamComment updatedComment = teamCommentRepository.findById(comment.getId()).orElseThrow();
+        assertThat(updatedComment.getDescription()).isEqualTo(updateRequest.description());
+        assertThat(updatedComment.getDescription()).isNotEqualTo(commentCreateRequest.description());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 댓글은 수정할 수 없다.")
+    void 존재하지_않는_댓글은_수정할_수_없다() {
+        final Long invalidCommentId = 999L;
+        final TeamCommentUpdateRequest request = new TeamCommentUpdateRequest(updatedCommentDescription);
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.updateComment(team.getId(), invalidCommentId, member.getId(), request.description());
+        }).isInstanceOf(TeamCommentException.class).hasMessage(NOT_FOUND_COMMENT.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 본인이 작성하지 않은 댓글은 수정할 수 없다.")
+    void 본인이_작성하지_않은_댓글은_수정할_수_없다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+        final TeamComment comment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+        final Member otherMember = memberRepository.save(MemberFixture.createMemberWithUniqueNum(1));
+
+        final TeamCommentUpdateRequest updateRequest = new TeamCommentUpdateRequest(updatedCommentDescription);
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.updateComment(team.getId(), comment.getId(), otherMember.getId(), updateRequest.description());
+        }).isInstanceOf(TeamCommentException.class).hasMessage(NOT_OWNER_COMMENT.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 팀의 댓글은 수정할 수 없다.")
+    void 다른_팀의_댓글은_수정할_수_없다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+        final TeamComment comment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+        final Team otherTeam = teamRepository.save(TeamFixture.createTeam());
+
+        final TeamCommentUpdateRequest updateRequest = new TeamCommentUpdateRequest(updatedCommentDescription);
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.updateComment(otherTeam.getId(), comment.getId(), member.getId(), updateRequest.description());
+        }).isInstanceOf(TeamCommentException.class)
+                .hasMessage(COMMENT_NOT_BELONG_TO_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 댓글이 정상적으로 삭제된다.")
+    void 댓글이_정상적으로_삭제된다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+        final TeamComment comment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+
+        teamCommentCommandService.deleteComment(team.getId(), comment.getId(), member.getId());
+
+        assertThat(teamCommentRepository.findById(comment.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 팀의 댓글은 삭제할 수 없다.")
+    void 다른_팀의_댓글은_삭제할_수_없다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+        final TeamComment comment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+        final Team otherTeam = teamRepository.save(TeamFixture.createTeam());
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.deleteComment(otherTeam.getId(), comment.getId(), member.getId());
+        }).isInstanceOf(TeamCommentException.class)
+                .hasMessage(COMMENT_NOT_BELONG_TO_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 댓글은 삭제할 수 없다.")
+    void 존재하지_않는_댓글은_삭제할_수_없다() {
+        final Long invalidCommentId = 999L;
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.deleteComment(team.getId(), invalidCommentId, member.getId());
+        }).isInstanceOf(TeamCommentException.class).hasMessage(NOT_FOUND_COMMENT.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 본인이 작성하지 않은 댓글은 삭제할 수 없다.")
+    void 본인이_작성하지_않은_댓글은_삭제할_수_없다() {
+        teamCommentCommandService.createComment(team.getId(), member.getId(), commentCreateRequest.description());
+        final TeamComment comment = teamCommentRepository.findAllByTeamIdOrderByIdDesc(team.getId()).get(0);
+        final Member otherMember = memberRepository.save(MemberFixture.createMemberWithUniqueNum(1));
+
+        assertThatThrownBy(() -> {
+            teamCommentCommandService.deleteComment(team.getId(), comment.getId(), otherMember.getId());
+        }).isInstanceOf(TeamCommentException.class).hasMessage(NOT_OWNER_COMMENT.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamCommentQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommentQueryServiceTest.java
@@ -1,0 +1,109 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.application.TeamCommentQueryService;
+import com.opus.opus.modules.team.application.dto.response.TeamCommentResponse;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamComment;
+import com.opus.opus.modules.team.domain.dao.TeamCommentRepository;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.team.TeamCommentFixture;
+import com.opus.opus.team.TeamFixture;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TeamCommentQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamCommentQueryService teamCommentQueryService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TeamCommentRepository teamCommentRepository;
+
+    private Team team;
+    private Member member;
+    private final String commentDescription = "테스트용 댓글입니다.";
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(TeamFixture.createTeam());
+        member = memberRepository.save(MemberFixture.createMember());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 댓글 목록을 조회할 수 있다.")
+    void 팀의_댓글_목록을_조회할_수_있다() {
+        teamCommentRepository.save(TeamCommentFixture.createTeamComment(team, member.getId()));
+        teamCommentRepository.save(TeamCommentFixture.createTeamComment(team, member.getId()));
+
+        final List<TeamCommentResponse> commentResponseList = teamCommentQueryService.getComments(team.getId());
+
+        assertThat(commentResponseList).hasSize(2);
+        assertThat(commentResponseList.get(0).description()).isEqualTo(commentDescription);
+        assertThat(commentResponseList.get(0).memberId()).isEqualTo(member.getId());
+        assertThat(commentResponseList.get(0).memberName()).isEqualTo(member.getName());
+        assertThat(commentResponseList.get(0).teamId()).isEqualTo(team.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 댓글이 없는 팀의 경우 빈 리스트를 반환한다.")
+    void 댓글이_없는_팀의_경우_빈_리스트를_반환한다() {
+        final List<TeamCommentResponse> responses = teamCommentQueryService.getComments(team.getId());
+
+        assertThat(responses).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 댓글 목록은 최신순으로 정렬되어 조회된다.")
+    void 댓글_목록은_최신순으로_정렬되어_조회된다() {
+        final TeamComment firstComment = teamCommentRepository.save(TeamCommentFixture.createTeamComment(team, member.getId()));
+        final TeamComment secondComment = teamCommentRepository.save(TeamCommentFixture.createTeamComment(team, member.getId()));
+
+        final List<TeamCommentResponse> commentResponseList = teamCommentQueryService.getComments(team.getId());
+
+        assertThat(commentResponseList).hasSize(2);
+        assertThat(commentResponseList.get(0).commentId()).isEqualTo(secondComment.getId());
+        assertThat(commentResponseList.get(1).commentId()).isEqualTo(firstComment.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 여러 회원이 작성한 댓글을 조회할 수 있다.")
+    void 여러_회원이_작성한_댓글을_조회할_수_있다() {
+        final Member otherMember = memberRepository.save(MemberFixture.createMemberWithUniqueNum(1));
+        teamCommentRepository.save(TeamCommentFixture.createTeamComment(team, member.getId()));
+        teamCommentRepository.save(TeamCommentFixture.createTeamComment(team, otherMember.getId()));
+
+        final List<TeamCommentResponse> commentResponseList = teamCommentQueryService.getComments(team.getId());
+
+        assertThat(commentResponseList).hasSize(2);
+        assertThat(commentResponseList).extracting(TeamCommentResponse::memberName)
+                .containsExactly(otherMember.getName(), member.getName());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 팀의 댓글 목록은 조회할 수 없다.")
+    void 존재하지_않는_팀의_댓글_목록은_조회할_수_없다() {
+        final Long invalidTeamId = 999L;
+
+        assertThatThrownBy(() -> {
+            teamCommentQueryService.getComments(invalidTeamId);
+        }).isInstanceOf(TeamException.class).hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamMemberCommandServiceTest.java
@@ -1,0 +1,130 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.member.exception.MemberExceptionType.MISMATCH_STUDENT_ID_AND_NAME;
+import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀원;
+import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀장;
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.member.exception.MemberException;
+import com.opus.opus.modules.team.application.TeamMemberCommandService;
+import com.opus.opus.modules.team.application.dto.request.TeamMemberCreateRequest;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import com.opus.opus.team.TeamFixture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class TeamMemberCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamMemberCommandService teamMemberCommandService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Team team;
+    private Member member;
+    private TeamMemberCreateRequest request;
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(TeamFixture.createTeam());
+        member = memberRepository.save(MemberFixture.createMember());
+        request = new TeamMemberCreateRequest("이사람", "123456789", ROLE_팀원);
+    }
+
+    @Test
+    @DisplayName("[성공] 회원가입한 학번과 이름이 없으면 가짜 회원을 생성 후 팀원으로 추가한다.")
+    void 회원가입한_학번과_이름이_없으면_가짜_회원을_생성_후_팀원으로_추가한다() {
+        final String notExistStudentId = "202654321";
+        final String notExistStudentName = "문스옵";
+
+        teamMemberCommandService.createTeamMember(team.getId(), notExistStudentId, notExistStudentName,
+                request.roleType());
+
+        final Member fakeMember = memberRepository.findByStudentId(notExistStudentId).orElseThrow();
+        assertThat(fakeMember.getStudentId()).isEqualTo(notExistStudentId);
+
+        final TeamMember teamMember = teamMemberRepository.findByTeamIdAndMemberId(team.getId(), fakeMember.getId())
+                .get();
+        assertThat(teamMember.getMemberId()).isEqualTo(fakeMember.getId());
+        assertThat(teamMember.getTeam().getId()).isEqualTo(team.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 이미 회원가입한 회원의 학번과 이름으로 팀원으로 추가될 때 기존 회원을 팀원으로 추가한다")
+    void 이미_회원가입한_회원의_학번과_이름으로_팀원으로_추가될_때_기존_회원을_팀원으로_추가한다() {
+        final String signedUpStudentId = member.getStudentId();
+        final String signedUpStudentName = member.getName();
+
+        teamMemberCommandService.createTeamMember(team.getId(), signedUpStudentId, signedUpStudentName,
+                request.roleType());
+
+        final TeamMember teamMember = teamMemberRepository.findByTeamIdAndMemberId(team.getId(), member.getId())
+                .orElseThrow();
+        assertThat(teamMember.getMemberId()).isEqualTo(member.getId());
+    }
+
+    @Test
+    @DisplayName("[실패] 이미 회원가입한 회원의 학번인데 저장된 이름과 같지 않으면 팀원으로 추가 불가하다.")
+    void 이미_회원가입한_회원의_학번인데_저장된_이름과_같지_않으면_팀원으로_추가_불가하다() {
+        final String studentId = member.getStudentId();
+        final String wrongStudentName = "이옵스아님";
+
+        assertThatThrownBy(() -> {
+            teamMemberCommandService.createTeamMember(team.getId(), studentId, wrongStudentName, request.roleType());
+        }).isInstanceOf(MemberException.class).hasMessage(MISMATCH_STUDENT_ID_AND_NAME.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] roleType이 팀장이라면 팀장으로 저장된다.")
+    void roleType이_팀장이라면_팀장으로_저장된다() {
+        final TeamMemberCreateRequest teamLeaderRequest = new TeamMemberCreateRequest("나팀장", "202798743", ROLE_팀장);
+
+        teamMemberCommandService.createTeamMember(team.getId(), teamLeaderRequest.memberStudentId(),
+                teamLeaderRequest.memberName(), teamLeaderRequest.roleType());
+
+        final Member addedMember = memberRepository.findByStudentId(teamLeaderRequest.memberStudentId())
+                .orElseThrow();
+        final TeamMember teamLeader = teamMemberRepository.findByTeamIdAndMemberId(team.getId(), addedMember.getId())
+                .orElseThrow();
+        assertThat(teamLeader.getRoles()).containsExactly(teamLeaderRequest.roleType());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀원이 정상적으로 삭제된다.")
+    void 팀원이_정상적으로_삭제된다() {
+        teamMemberCommandService.createTeamMember(team.getId(), request.memberStudentId(), request.memberName(),
+                request.roleType());
+        final Member addedMember = memberRepository.findByStudentId(request.memberStudentId()).get();
+
+        teamMemberCommandService.deleteTeamMember(team.getId(), addedMember.getId());
+
+        assertThat(teamMemberRepository.existsByTeamIdAndMemberId(team.getId(), addedMember.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("[실패] 팀원 목록에 팀원 정보가 없다면 팀원 삭제 불가하다.")
+    void 팀원_목록에_팀원_정보가_없다면_팀원_삭제_불가하다() {
+        final Team otherTeam = teamRepository.save(TeamFixture.createTeam());
+
+        assertThatThrownBy(() -> {
+            teamMemberCommandService.deleteTeamMember(otherTeam.getId(), member.getId());
+        }).isInstanceOf(TeamMemberException.class).hasMessage(TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamQueryServiceTest.java
@@ -1,0 +1,100 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
+import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_MATCHING_IMAGE_ID;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.opus.opus.global.util.FileStorageUtil;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.dao.FileRepository;
+import com.opus.opus.modules.file.exception.FileException;
+import com.opus.opus.modules.team.application.TeamQueryService;
+import com.opus.opus.modules.team.application.dto.ImageResponse;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.team.TeamFixture;
+import java.util.ArrayList;
+import org.antlr.v4.runtime.misc.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class TeamQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamQueryService teamQueryService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    @Autowired
+    private FileStorageUtil fileStorageUtil;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(TeamFixture.createTeam());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지를 조회한다.")
+    void 팀_포스터_이미지를_조회한다() {
+        // given
+        final File file = File.builder()
+                .referenceId(team.getId())
+                .referenceType(TEAM)
+                .imageType(POSTER)
+                .filePath("path/to/poster.webp")
+                .name("poster.jpg")
+                .build();
+        final File savedFile = fileRepository.save(file);
+        savedFile.updateIsWebpConverted(true);
+        fileRepository.saveAndFlush(savedFile);
+
+        Resource resource = new ByteArrayResource("content".getBytes());
+        given(fileStorageUtil.findFileAndType(savedFile.getId()))
+                .willReturn(new Pair<>(resource, "image/webp"));
+
+        // when
+        ImageResponse response = teamQueryService.getPosterImage(team.getId());
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.contentType()).isEqualTo("image/webp");
+    }
+
+    @Test
+    @DisplayName("[실패] 팀이 존재하지 않으면 포스터 이미지를 조회할 수 없다.")
+    void 팀이_존재하지_않으면_포스터_이미지를_조회할_수_없다() {
+        // given
+        long notExistTeamId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> teamQueryService.getPosterImage(notExistTeamId))
+                .isInstanceOf(TeamException.class)
+                .hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 팀 포스터 이미지가 존재하지 않으면 조회할 수 없다.")
+    void 팀_포스터_이미지가_존재하지_않으면_조회할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> teamQueryService.getPosterImage(team.getId()))
+                .isInstanceOf(FileException.class)
+                .hasMessage(NOT_EXISTS_MATCHING_IMAGE_ID.errorMessage());
+    }
+}


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #47 

## 📜 작업 내용

- 대회 팀 상세보기 템플릿 수정 및 조회 API를 구현하였습다.
- 해당 대회의 팀 상세보기의 각 필드는 아래의 세 값 중 하나를 가집니다.
  - REQUIRED : 상세보기 수정 페이지에서 보이고 필수로 작성해야함
  - OPTIONAL : 상세보기 수정 페이징에서 보이나 선택적으로 작성
  - HIDDEN : 상세보기 수정 페이지에서 보이지 않음
- 팀 상세보기 템플릿은 대회 생성 시 기본값으로 자동 생성됩니다.
  - 만약 대회가 속한 카테고리의 이름에 “창의융합”이 포함된다면 기본값은
    - 지도교수 : HIDDEN
    - 깃헙 제외한 링크 : OPTIONAL
    - 깃헙 링크 : REQUIRED
    - 나머지 다 REQUIRED
  - 만약 대회가 속한 카테고리의 이름에 “캡스톤”이 포함된다면 기본값은. 
    - 포스터와 배포 주소 OPTIONAL
    - 나머지 다 REQUIRED
  - “창의융합” 혹은 “캡스톤”이 포함되지 않는다면 모두 OPTIONAL
## 💬 리뷰 요구사항

- 기능 구현 후 아직 테스트는 작성하지 않았으나 출국 전에 PR을 미리 올립니다!
- 테스트 작성 후 커밋하겠습니다

## ✨ 기타

- 오늘의 한마디
