### PR TITLE
Feature/#33 팀 포스터 관련 api개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -11,3 +11,6 @@ endif::[]
 
 == 멤버 관련 API
 link:./member.html[회원 API]
+
+== 팀 관련 API
+link:./team.html[팀 API]

--- a/src/main/java/com/opus/opus/docs/asciidoc/team.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/team.adoc
@@ -1,0 +1,57 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= TEAM API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:../opus.html[API 목록으로 돌아가기]
+
+== `GET`: 팀 포스터 이미지 조회
+
+.HTTP Request
+include::{snippets}/get-team-poster/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-team-poster/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/get-team-poster/path-parameters.adoc[]
+
+== `POST`: 팀 포스터 이미지 등록
+
+.HTTP Request
+include::{snippets}/save-team-poster/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/save-team-poster/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/save-team-poster/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/save-team-poster/request-headers.adoc[]
+
+.Request Parts
+include::{snippets}/save-team-poster/request-parts.adoc[]
+
+== `DELETE`: 팀 포스터 이미지 삭제
+
+.HTTP Request
+include::{snippets}/delete-team-poster/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-team-poster/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-team-poster/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/delete-team-poster/request-headers.adoc[]

--- a/src/main/java/com/opus/opus/modules/file/application/convenience/FileConvenience.java
+++ b/src/main/java/com/opus/opus/modules/file/application/convenience/FileConvenience.java
@@ -1,8 +1,6 @@
 package com.opus.opus.modules.file.application.convenience;
 
-import static com.opus.opus.modules.file.domain.FileImageType.THUMBNAIL;
-import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
-import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_THUMBNAIL;
+import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_MATCHING_IMAGE_ID;
 
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.FileImageType;
@@ -23,7 +21,7 @@ public class FileConvenience {
     public File findByReferenceIdAndReferenceTypeAndImageType(final Long teamId,
                                                               final ReferenceDomainType referenceType,
                                                               final FileImageType imageType) {
-        return fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
-                .orElseThrow(() -> new FileException(NOT_EXISTS_THUMBNAIL));
+        return fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, referenceType, imageType)
+                .orElseThrow(() -> new FileException(NOT_EXISTS_MATCHING_IMAGE_ID));
     }
 }

--- a/src/main/java/com/opus/opus/modules/file/domain/FileImageType.java
+++ b/src/main/java/com/opus/opus/modules/file/domain/FileImageType.java
@@ -5,5 +5,6 @@ public enum FileImageType {
     PREVIEW,
     THUMBNAIL,
     BANNER,
+    POSTER,
 }
 

--- a/src/main/java/com/opus/opus/modules/file/exception/FileExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/file/exception/FileExceptionType.java
@@ -5,12 +5,11 @@ import org.springframework.http.HttpStatus;
 
 public enum FileExceptionType implements BaseExceptionType {
     NOT_EXISTS_MATCHING_IMAGE_ID(HttpStatus.NOT_FOUND, "아이디와 일치하는 이미지가 없습니다"),
-    NOT_EXISTS_THUMBNAIL(HttpStatus.NOT_FOUND, "팀 썸네일이 존재하지 않습니다"),
+    NOT_EXISTS_MATCHING_IMAGE_ID_AND_TYPE(HttpStatus.NOT_FOUND, "아이디, 타입과 일치하는 이미지가 없습니다"),
     NOT_EXISTS_PREVIEW(HttpStatus.NOT_FOUND, "존재하지 않는 팀 프리뷰 ID 를 요청하였습니다"),
     EXCEED_PREVIEW_LIMIT(HttpStatus.BAD_REQUEST, "프리뷰 이미지는 6장 이하입니다"),
     NOT_EXISTS_PHYSICAL_FILE(HttpStatus.NOT_FOUND, "물리적 파일이 존재하지 않습니다"),
     NOT_WEBP_CONVERTED(HttpStatus.ACCEPTED, "이미지 변환중 입니다"),
-    NOT_EXISTS_BANNER(HttpStatus.BAD_REQUEST, "배너가 존재하지 않습니다")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/opus/opus/modules/team/api/TeamController.java
+++ b/src/main/java/com/opus/opus/modules/team/api/TeamController.java
@@ -79,4 +79,28 @@ public class TeamController {
         teamCommandService.deleteThumbnailImage(teamId);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/{teamId}/image/posters")
+    public ResponseEntity<Resource> getPosterImage(@PathVariable final Long teamId) {
+        final ImageResponse imageResponse = teamQueryService.getPosterImage(teamId);
+
+        return ResponseEntity.ok()
+                .contentType(imageResponse.getMediaType())
+                .body(imageResponse.resource());
+    }
+
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
+    @PostMapping("/{teamId}/image/posters")
+    public ResponseEntity<Void> savePosterImage(@PathVariable final Long teamId,
+                                                @RequestPart("image") final MultipartFile image) {
+        teamCommandService.savePosterImage(teamId, image);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Secured({"ROLE_팀장", "ROLE_관리자", "ROLE_팀원"})
+    @DeleteMapping("/{teamId}/image/posters")
+    public ResponseEntity<Void> deletePosterImage(@PathVariable final Long teamId) {
+        teamCommandService.deletePosterImage(teamId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -39,17 +39,13 @@ public class TeamCommandService {
 
     public void deletePreviewImages(final Long teamId, final List<Long> ids) {
         teamConvenience.validateExistTeam(teamId);
-        ids.forEach(fileId -> {
-            fileRepository.findById(fileId).ifPresent(this::checkWebpConverted);
-            fileStorageUtil.deleteFile(fileId);
-        });
+        ids.forEach(fileStorageUtil::deleteFile);
     }
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
                 .ifPresent(existingFile -> {
-                    checkWebpConverted(existingFile);
                     fileStorageUtil.deleteFile(existingFile.getId());
                 });
         fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
@@ -59,7 +55,6 @@ public class TeamCommandService {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
                 .ifPresent(existingFile -> {
-                    checkWebpConverted(existingFile);
                     fileStorageUtil.deleteFile(existingFile.getId());
                 });
     }
@@ -68,7 +63,6 @@ public class TeamCommandService {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
                 .ifPresent(existingFile -> {
-                    checkWebpConverted(existingFile);
                     fileStorageUtil.deleteFile(existingFile.getId());
                 });
         fileStorageUtil.storeFile(image, teamId, TEAM, POSTER);
@@ -78,7 +72,6 @@ public class TeamCommandService {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
                 .ifPresent(existingFile -> {
-                    checkWebpConverted(existingFile);
                     fileStorageUtil.deleteFile(existingFile.getId());
                 });
     }
@@ -87,12 +80,6 @@ public class TeamCommandService {
         long savedCount = fileRepository.countByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, PREVIEW);
         if (savedCount + images.size() > 5) {
             throw new FileException(EXCEED_PREVIEW_LIMIT);
-        }
-    }
-
-    private void checkWebpConverted(final File existingFile) {
-        if (!existingFile.getIsWebpConverted()) {
-            throw new FileException(NOT_WEBP_CONVERTED);
         }
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.team.application;
 
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
 import static com.opus.opus.modules.file.domain.FileImageType.PREVIEW;
 import static com.opus.opus.modules.file.domain.FileImageType.THUMBNAIL;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
@@ -46,19 +47,40 @@ public class TeamCommandService {
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL).ifPresent(existingFile -> {
-            checkWebpConverted(existingFile);
-            fileStorageUtil.deleteFile(existingFile.getId());
-        });
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
+                .ifPresent(existingFile -> {
+                    checkWebpConverted(existingFile);
+                    fileStorageUtil.deleteFile(existingFile.getId());
+                });
         fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
     }
 
     public void deleteThumbnailImage(final Long teamId) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL).ifPresent(existingFile -> {
-            checkWebpConverted(existingFile);
-            fileStorageUtil.deleteFile(existingFile.getId());
-        });
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
+                .ifPresent(existingFile -> {
+                    checkWebpConverted(existingFile);
+                    fileStorageUtil.deleteFile(existingFile.getId());
+                });
+    }
+
+    public void savePosterImage(final Long teamId, final MultipartFile image) {
+        teamConvenience.validateExistTeam(teamId);
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
+                .ifPresent(existingFile -> {
+                    checkWebpConverted(existingFile);
+                    fileStorageUtil.deleteFile(existingFile.getId());
+                });
+        fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
+    }
+
+    public void deletePosterImage(final Long teamId) {
+        teamConvenience.validateExistTeam(teamId);
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
+                .ifPresent(existingFile -> {
+                    checkWebpConverted(existingFile);
+                    fileStorageUtil.deleteFile(existingFile.getId());
+                });
     }
 
     private void checkPreviewLimit(final Long teamId, final List<MultipartFile> images) {

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -71,7 +71,7 @@ public class TeamCommandService {
                     checkWebpConverted(existingFile);
                     fileStorageUtil.deleteFile(existingFile.getId());
                 });
-        fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
+        fileStorageUtil.storeFile(image, teamId, TEAM, POSTER);
     }
 
     public void deletePosterImage(final Long teamId) {

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -45,35 +45,31 @@ public class TeamCommandService {
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
-                .ifPresent(existingFile -> {
-                    fileStorageUtil.deleteFile(existingFile.getId());
-                });
+                .ifPresent(this::deleteFileById);
         fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
     }
 
     public void deleteThumbnailImage(final Long teamId) {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
-                .ifPresent(existingFile -> {
-                    fileStorageUtil.deleteFile(existingFile.getId());
-                });
+                .ifPresent(this::deleteFileById);
     }
 
     public void savePosterImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
-                .ifPresent(existingFile -> {
-                    fileStorageUtil.deleteFile(existingFile.getId());
-                });
+                .ifPresent(this::deleteFileById);
         fileStorageUtil.storeFile(image, teamId, TEAM, POSTER);
     }
 
     public void deletePosterImage(final Long teamId) {
         teamConvenience.validateExistTeam(teamId);
         fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
-                .ifPresent(existingFile -> {
-                    fileStorageUtil.deleteFile(existingFile.getId());
-                });
+                .ifPresent(this::deleteFileById);
+    }
+
+    private void deleteFileById(final File existingFile) {
+        fileStorageUtil.deleteFile(existingFile.getId());
     }
 
     private void checkPreviewLimit(final Long teamId, final List<MultipartFile> images) {

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -9,6 +9,7 @@ import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_WEBP_CO
 
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileImageType;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
@@ -44,32 +45,29 @@ public class TeamCommandService {
 
     public void saveThumbnailImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
-                .ifPresent(this::deleteFileById);
+        deleteIfExists(teamId, THUMBNAIL);
         fileStorageUtil.storeFile(image, teamId, TEAM, THUMBNAIL);
     }
 
     public void deleteThumbnailImage(final Long teamId) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL)
-                .ifPresent(this::deleteFileById);
+        deleteIfExists(teamId, THUMBNAIL);
     }
 
     public void savePosterImage(final Long teamId, final MultipartFile image) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
-                .ifPresent(this::deleteFileById);
+        deleteIfExists(teamId, POSTER);
         fileStorageUtil.storeFile(image, teamId, TEAM, POSTER);
     }
 
     public void deletePosterImage(final Long teamId) {
         teamConvenience.validateExistTeam(teamId);
-        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, POSTER)
-                .ifPresent(this::deleteFileById);
+        deleteIfExists(teamId, POSTER);
     }
 
-    private void deleteFileById(final File existingFile) {
-        fileStorageUtil.deleteFile(existingFile.getId());
+    private void deleteIfExists(final Long teamId, final FileImageType imageType) {
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, imageType)
+                .ifPresent(existingFile -> fileStorageUtil.deleteFile(existingFile.getId()));
     }
 
     private void checkPreviewLimit(final Long teamId, final List<MultipartFile> images) {

--- a/src/main/java/com/opus/opus/modules/team/application/TeamQueryService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamQueryService.java
@@ -1,5 +1,7 @@
 package com.opus.opus.modules.team.application;
 
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.FileImageType.PREVIEW;
 import static com.opus.opus.modules.file.domain.FileImageType.THUMBNAIL;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
 import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_PREVIEW;
@@ -8,6 +10,7 @@ import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_WEBP_CO
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.modules.file.application.convenience.FileConvenience;
 import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileImageType;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
@@ -37,8 +40,16 @@ public class TeamQueryService {
     }
 
     public ImageResponse getThumbnailImage(final Long teamId) {
+        return getImage(teamId, THUMBNAIL);
+    }
+
+    public ImageResponse getPosterImage(final Long teamId) {
+        return getImage(teamId, POSTER);
+    }
+
+    private ImageResponse getImage(final Long teamId, final FileImageType fileImageType) {
         teamConvenience.validateExistTeam(teamId);
-        final File findFile = fileConvenience.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, THUMBNAIL);
+        final File findFile = fileConvenience.findByReferenceIdAndReferenceTypeAndImageType(teamId, TEAM, fileImageType);
         checkImageConverted(findFile);
         final Pair<Resource, String> storageResult = fileStorageUtil.findFileAndType(findFile.getId());
         return new ImageResponse(storageResult.a, storageResult.b);

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,4 +1,4 @@
-SET FOREIGN_KEY_CHECKS = 0;
+USE opus;
 
 DROP TABLE IF EXISTS `contest`;
 DROP TABLE IF EXISTS `contest_award`;
@@ -15,8 +15,6 @@ DROP TABLE IF EXISTS `team_like`;
 DROP TABLE IF EXISTS `team_member`;
 DROP TABLE IF EXISTS `team_member_roles`;
 DROP TABLE IF EXISTS `team_sort`;
-
-SET FOREIGN_KEY_CHECKS = 1;
 
 CREATE TABLE `contest` (
   `id` bigint NOT NULL AUTO_INCREMENT,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,3 @@
-USE opus;
-
 SET FOREIGN_KEY_CHECKS = 0;
 
 DROP TABLE IF EXISTS `contest`;

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,7 @@
 USE opus;
 
+SET FOREIGN_KEY_CHECKS = 0;
+
 DROP TABLE IF EXISTS `contest`;
 DROP TABLE IF EXISTS `contest_award`;
 DROP TABLE IF EXISTS `contest_category`;
@@ -15,6 +17,8 @@ DROP TABLE IF EXISTS `team_like`;
 DROP TABLE IF EXISTS `team_member`;
 DROP TABLE IF EXISTS `team_member_roles`;
 DROP TABLE IF EXISTS `team_sort`;
+
+SET FOREIGN_KEY_CHECKS = 1;
 
 CREATE TABLE `contest` (
   `id` bigint NOT NULL AUTO_INCREMENT,
@@ -65,7 +69,7 @@ CREATE TABLE `file` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `file_path` varchar(255) NOT NULL,
-  `image_type` enum('BANNER','PREVIEW','THUMBNAIL') NOT NULL,
+  `image_type` enum('BANNER','PREVIEW','THUMBNAIL','POSTER') NOT NULL,
   `is_webp_converted` bit(1) NOT NULL,
   `name` varchar(255) NOT NULL,
   `reference_id` bigint NOT NULL,

--- a/src/test/java/com/opus/opus/helper/IntegrationTest.java
+++ b/src/test/java/com/opus/opus/helper/IntegrationTest.java
@@ -33,7 +33,7 @@ public abstract class IntegrationTest extends ApiTestHelper {
     private MailUtil mailUtil;
 
     @MockitoBean
-    private FileStorageUtil fileStorageUtil;
+    protected FileStorageUtil fileStorageUtil;
 
     @BeforeEach
     void setUp(final WebApplicationContext context) {

--- a/src/test/java/com/opus/opus/helper/IntegrationTest.java
+++ b/src/test/java/com/opus/opus/helper/IntegrationTest.java
@@ -1,6 +1,7 @@
 package com.opus.opus.helper;
 
 import com.opus.opus.global.security.JwtProvider;
+import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.global.util.MailUtil;
 import com.opus.opus.global.util.AuthRedisUtil;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +31,9 @@ public abstract class IntegrationTest extends ApiTestHelper {
 
     @MockitoBean
     private MailUtil mailUtil;
+
+    @MockitoBean
+    private FileStorageUtil fileStorageUtil;
 
     @BeforeEach
     void setUp(final WebApplicationContext context) {

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -13,6 +13,9 @@ import com.opus.opus.modules.member.domain.dao.MemberRepository;
 import com.opus.opus.modules.notice.api.NoticeController;
 import com.opus.opus.modules.notice.application.NoticeCommandService;
 import com.opus.opus.modules.notice.application.NoticeQueryService;
+import com.opus.opus.modules.team.api.TeamController;
+import com.opus.opus.modules.team.application.TeamCommandService;
+import com.opus.opus.modules.team.application.TeamQueryService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,7 +32,8 @@ import org.springframework.web.filter.CharacterEncodingFilter;
 
 @WebMvcTest({
         MemberController.class,
-        NoticeController.class
+        NoticeController.class,
+        TeamController.class
 })
 @Import(RestDocsConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -47,6 +51,12 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected NoticeQueryService noticeQueryService;
+
+    @MockitoBean
+    protected TeamCommandService teamCommandService;
+
+    @MockitoBean
+    protected TeamQueryService teamQueryService;
 
     // Setting
     @Autowired

--- a/src/test/java/com/opus/opus/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/TeamApiDocsTest.java
@@ -1,0 +1,112 @@
+package com.opus.opus.restdocs.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.multipart;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.modules.team.application.dto.ImageResponse;
+import com.opus.opus.restdocs.RestDocsTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class TeamApiDocsTest extends RestDocsTest {
+
+    private String accessToken;
+
+    @BeforeEach
+    void setUp() {
+        accessToken = "mock_access_token";
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 포스터 이미지를 조회한다.")
+    void 팀의_포스터_이미지를_조회한다() throws Exception {
+        // Given
+        final Long teamId = 1L;
+        final byte[] mockImageContent = "test-image-content".getBytes();
+        final ImageResponse response = new ImageResponse(new ByteArrayResource(mockImageContent), "image/png");
+
+        when(teamQueryService.getPosterImage(any())).thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/teams/{teamId}/image/posters", teamId))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.IMAGE_PNG))
+                .andDo(document("get-team-poster",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 포스터 이미지를 등록한다.")
+    void 팀의_포스터_이미지를_등록한다() throws Exception {
+        // Given
+        final Long teamId = 1L;
+        final MockMultipartFile image = new MockMultipartFile(
+                "image",
+                "poster.png",
+                MediaType.IMAGE_PNG_VALUE,
+                "<<image-data>>".getBytes()
+        );
+
+        doNothing().when(teamCommandService).savePosterImage(any(), any());
+
+        // When & Then
+        mockMvc.perform(multipart("/teams/{teamId}/image/posters", teamId)
+                        .file(image)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andDo(document("save-team-poster",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (팀장, 관리자, 팀원 권한)")
+                        ),
+                        requestParts(
+                                partWithName("image").description("등록할 포스터 이미지 (모든 이미지 형식 지원)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 포스터 이미지를 삭제한다.")
+    void 팀의_포스터_이미지를_삭제한다() throws Exception {
+        // Given
+        final Long teamId = 1L;
+        doNothing().when(teamCommandService).deletePosterImage(any());
+
+        // When & Then
+        mockMvc.perform(delete("/teams/{teamId}/image/posters", teamId)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-team-poster",
+                        pathParameters(
+                                parameterWithName("teamId").description("팀 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (팀장, 관리자, 팀원 권한)")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/TeamApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/TeamApiDocsTest.java
@@ -29,10 +29,12 @@ import org.springframework.mock.web.MockMultipartFile;
 public class TeamApiDocsTest extends RestDocsTest {
 
     private String accessToken;
+    private byte[] testImage;
 
     @BeforeEach
     void setUp() {
-        accessToken = "mock_access_token";
+        accessToken = "Bearer member.access.token";
+        testImage = "test-image-content".getBytes();
     }
 
     @Test
@@ -40,8 +42,7 @@ public class TeamApiDocsTest extends RestDocsTest {
     void 팀의_포스터_이미지를_조회한다() throws Exception {
         // Given
         final Long teamId = 1L;
-        final byte[] mockImageContent = "test-image-content".getBytes();
-        final ImageResponse response = new ImageResponse(new ByteArrayResource(mockImageContent), "image/png");
+        final ImageResponse response = new ImageResponse(new ByteArrayResource(testImage), "image/png");
 
         when(teamQueryService.getPosterImage(any())).thenReturn(response);
 
@@ -65,7 +66,7 @@ public class TeamApiDocsTest extends RestDocsTest {
                 "image",
                 "poster.png",
                 MediaType.IMAGE_PNG_VALUE,
-                "<<image-data>>".getBytes()
+                testImage
         );
 
         doNothing().when(teamCommandService).savePosterImage(any(), any());
@@ -73,7 +74,7 @@ public class TeamApiDocsTest extends RestDocsTest {
         // When & Then
         mockMvc.perform(multipart("/teams/{teamId}/image/posters", teamId)
                         .file(image)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                        .header(HttpHeaders.AUTHORIZATION, accessToken)
                         .contentType(MediaType.MULTIPART_FORM_DATA))
                 .andExpect(status().isCreated())
                 .andDo(document("save-team-poster",
@@ -98,7 +99,7 @@ public class TeamApiDocsTest extends RestDocsTest {
 
         // When & Then
         mockMvc.perform(delete("/teams/{teamId}/image/posters", teamId)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                        .header(HttpHeaders.AUTHORIZATION, accessToken))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-team-poster",
                         pathParameters(

--- a/src/test/java/com/opus/opus/team/FileFixture.java
+++ b/src/test/java/com/opus/opus/team/FileFixture.java
@@ -1,0 +1,19 @@
+package com.opus.opus.team;
+
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
+
+import com.opus.opus.modules.file.domain.File;
+
+public class FileFixture {
+
+    public static File createTeamPosterFile() {
+        return File.builder()
+                .name("poster.jpg")
+                .filePath("path/to/poster.webp")
+                .referenceId(1L)
+                .referenceType(TEAM)
+                .imageType(POSTER)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
@@ -40,9 +40,6 @@ public class TeamCommandServiceTest extends IntegrationTest {
     @Autowired
     private FileRepository fileRepository;
 
-    @Autowired
-    private FileStorageUtil fileStorageUtil;
-
     private Team team;
 
     @BeforeEach

--- a/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
@@ -1,0 +1,116 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.opus.opus.global.util.FileStorageUtil;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.dao.FileRepository;
+import com.opus.opus.modules.team.application.TeamCommandService;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import java.util.ArrayList;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class TeamCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamCommandService teamCommandService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    @MockitoBean
+    private FileStorageUtil fileStorageUtil;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(Team.builder()
+                .teamName("팀 이름")
+                .projectName("프로젝트 이름")
+                .contestId(1L)
+                .trackId(1L)
+                .itemOrder(1)
+                .teamMembers(new ArrayList<>())
+                .build());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지를 저장한다.")
+    void 팀_포스터_이미지를_저장한다() {
+        // given
+        final MockMultipartFile image = new MockMultipartFile("image", "poster.jpg", "image/jpeg",
+                "content".getBytes());
+
+        // when
+        teamCommandService.savePosterImage(team.getId(), image);
+
+        // then
+        verify(fileStorageUtil, times(1)).storeFile(any(), eq(team.getId()), eq(TEAM), eq(POSTER));
+    }
+
+    @Test
+    @DisplayName("[실패] 팀이 존재하지 않으면 포스터 이미지를 저장할 수 없다.")
+    void 팀이_존재하지_않으면_포스터_이미지를_저장할_수_없다() {
+        // given
+        final MockMultipartFile image = new MockMultipartFile("image", "poster.jpg", "image/jpeg",
+                "content".getBytes());
+        final long notExistTeamId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> teamCommandService.savePosterImage(notExistTeamId, image))
+                .isInstanceOf(TeamException.class)
+                .hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지를 삭제한다.")
+    void 팀_포스터_이미지를_삭제한다() {
+        // given
+        final File file = File.builder()
+                .referenceId(team.getId())
+                .referenceType(TEAM)
+                .imageType(POSTER)
+                .filePath("path/to/poster.webp")
+                .name("poster.jpg")
+                .build();
+        final File savedFile = fileRepository.save(file);
+        savedFile.updateIsWebpConverted(true);
+        fileRepository.saveAndFlush(savedFile);
+
+        // when
+        teamCommandService.deletePosterImage(team.getId());
+
+        // then
+        verify(fileStorageUtil, times(1)).deleteFile(savedFile.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지가 없어도 삭제 요청 시 예외가 발생하지 않는다.")
+    void 팀_포스터_이미지가_없어도_삭제_요청_시_예외가_발생하지_않는다() {
+        // when
+        teamCommandService.deletePosterImage(team.getId());
+
+        // then
+        verify(fileStorageUtil, never()).deleteFile(any());
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.helper.IntegrationTest;
@@ -18,6 +19,8 @@ import com.opus.opus.modules.team.application.TeamCommandService;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.team.FileFixture;
+import com.opus.opus.team.TeamFixture;
 import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -37,21 +40,14 @@ public class TeamCommandServiceTest extends IntegrationTest {
     @Autowired
     private FileRepository fileRepository;
 
-    @MockitoBean
+    @Autowired
     private FileStorageUtil fileStorageUtil;
 
     private Team team;
 
     @BeforeEach
     void setUp() {
-        team = teamRepository.save(Team.builder()
-                .teamName("팀 이름")
-                .projectName("프로젝트 이름")
-                .contestId(1L)
-                .trackId(1L)
-                .itemOrder(1)
-                .teamMembers(new ArrayList<>())
-                .build());
+        team = teamRepository.save(TeamFixture.createTeam());
     }
 
     @Test
@@ -86,13 +82,8 @@ public class TeamCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 팀 포스터 이미지를 삭제한다.")
     void 팀_포스터_이미지를_삭제한다() {
         // given
-        final File file = File.builder()
-                .referenceId(team.getId())
-                .referenceType(TEAM)
-                .imageType(POSTER)
-                .filePath("path/to/poster.webp")
-                .name("poster.jpg")
-                .build();
+        final File file = FileFixture.createTeamPosterFile();
+        setField(file, "referenceId", team.getId());
         final File savedFile = fileRepository.save(file);
         savedFile.updateIsWebpConverted(true);
         fileRepository.saveAndFlush(savedFile);

--- a/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamCommandServiceTest.java
@@ -104,4 +104,23 @@ public class TeamCommandServiceTest extends IntegrationTest {
         // then
         verify(fileStorageUtil, never()).deleteFile(any());
     }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지가 이미 존재하면 기존 이미지를 삭제하고 새로 저장한다.")
+    void 팀_포스터_이미지가_이미_존재하면_기존_이미지를_삭제하고_새로_저장한다() {
+        // given
+        final File existingFile = FileFixture.createTeamPosterFile();
+        setField(existingFile, "referenceId", team.getId());
+        final File savedFile = fileRepository.save(existingFile);
+
+        final MockMultipartFile newImage = new MockMultipartFile("image", "new_poster.jpg", "image/jpeg",
+                "new_content".getBytes());
+
+        // when
+        teamCommandService.savePosterImage(team.getId(), newImage);
+
+        // then
+        verify(fileStorageUtil, times(1)).deleteFile(savedFile.getId());
+        verify(fileStorageUtil, times(1)).storeFile(any(), eq(team.getId()), eq(TEAM), eq(POSTER));
+    }
 }

--- a/src/test/java/com/opus/opus/team/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamQueryServiceTest.java
@@ -1,0 +1,106 @@
+package com.opus.opus.team.application;
+
+import static com.opus.opus.modules.file.domain.FileImageType.POSTER;
+import static com.opus.opus.modules.file.domain.ReferenceDomainType.TEAM;
+import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_MATCHING_IMAGE_ID;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.opus.opus.global.util.FileStorageUtil;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.dao.FileRepository;
+import com.opus.opus.modules.file.exception.FileException;
+import com.opus.opus.modules.team.application.TeamQueryService;
+import com.opus.opus.modules.team.application.dto.ImageResponse;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import java.util.ArrayList;
+import org.antlr.v4.runtime.misc.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+public class TeamQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private TeamQueryService teamQueryService;
+
+    @Autowired
+    private TeamRepository teamRepository;
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    @MockitoBean
+    private FileStorageUtil fileStorageUtil;
+
+    private Team team;
+
+    @BeforeEach
+    void setUp() {
+        team = teamRepository.save(Team.builder()
+                .teamName("팀 이름")
+                .projectName("프로젝트 이름")
+                .contestId(1L)
+                .trackId(1L)
+                .itemOrder(1)
+                .teamMembers(new ArrayList<>())
+                .build());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀 포스터 이미지를 조회한다.")
+    void 팀_포스터_이미지를_조회한다() {
+        // given
+        final File file = File.builder()
+                .referenceId(team.getId())
+                .referenceType(TEAM)
+                .imageType(POSTER)
+                .filePath("path/to/poster.webp")
+                .name("poster.jpg")
+                .build();
+        final File savedFile = fileRepository.save(file);
+        savedFile.updateIsWebpConverted(true);
+        fileRepository.saveAndFlush(savedFile);
+
+        Resource resource = new ByteArrayResource("content".getBytes());
+        given(fileStorageUtil.findFileAndType(savedFile.getId()))
+                .willReturn(new Pair<>(resource, "image/webp"));
+
+        // when
+        ImageResponse response = teamQueryService.getPosterImage(team.getId());
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.contentType()).isEqualTo("image/webp");
+    }
+
+    @Test
+    @DisplayName("[실패] 팀이 존재하지 않으면 포스터 이미지를 조회할 수 없다.")
+    void 팀이_존재하지_않으면_포스터_이미지를_조회할_수_없다() {
+        // given
+        long notExistTeamId = 999L;
+
+        // when & then
+        assertThatThrownBy(() -> teamQueryService.getPosterImage(notExistTeamId))
+                .isInstanceOf(TeamException.class)
+                .hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 팀 포스터 이미지가 존재하지 않으면 조회할 수 없다.")
+    void 팀_포스터_이미지가_존재하지_않으면_조회할_수_없다() {
+        // when & then
+        assertThatThrownBy(() -> teamQueryService.getPosterImage(team.getId()))
+                .isInstanceOf(FileException.class)
+                .hasMessage(NOT_EXISTS_MATCHING_IMAGE_ID.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/team/application/TeamQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamQueryServiceTest.java
@@ -18,6 +18,7 @@ import com.opus.opus.modules.team.application.dto.ImageResponse;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.exception.TeamException;
+import com.opus.opus.team.TeamFixture;
 import java.util.ArrayList;
 import org.antlr.v4.runtime.misc.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,21 +40,14 @@ public class TeamQueryServiceTest extends IntegrationTest {
     @Autowired
     private FileRepository fileRepository;
 
-    @MockitoBean
+    @Autowired
     private FileStorageUtil fileStorageUtil;
 
     private Team team;
 
     @BeforeEach
     void setUp() {
-        team = teamRepository.save(Team.builder()
-                .teamName("팀 이름")
-                .projectName("프로젝트 이름")
-                .contestId(1L)
-                .trackId(1L)
-                .itemOrder(1)
-                .teamMembers(new ArrayList<>())
-                .build());
+        team = teamRepository.save(TeamFixture.createTeam());
     }
 
     @Test


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #33 

## 📜 작업 내용

- 팀 포스터 관련 기능을 개발했습니다
- 코드 자체는 여타 다른 업로드 api와 비슷합니다.

## 💬 리뷰 요구사항

- schema.sql로 테이블 만들어질 때 오류가 발생해서 테이블 지울때 외래키 검사를 해제/설정하도록 앞뒤에 추가했는데 문제는 없을지 한번 확인 부탁드립니다.
  - `USE OPUS;`명령도 오류 해결이 안돼서 제거했습니다..
- Rest Docs는 잘 써본적이 없어서 잘 작성되었는지 한번 봐주시면 감사하겠습니다

## ✨ 기타

- 다들 새해에도 화이팅!
