### PR TITLE
Feature/#1 대회별 공지사항 관련 api 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 == API 목록
 
-link:../opus.html[API 목록으로 돌아가기]
+link:./opus.html[API 목록으로 돌아가기]
 
 == `POST`: 회원가입 이메일 인증
 

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -141,3 +141,17 @@ include::{snippets}/get-contest-notice/http-response.adoc[]
 
 .Path Parameters
 include::{snippets}/get-contest-notice/path-parameters.adoc[]
+
+== `GET`: 대회별 공지사항 목록 조회
+
+.HTTP Request
+include::{snippets}/get-all-contest-notices/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/get-all-contest-notices/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/get-all-contest-notices/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-all-contest-notices/response-fields.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -116,3 +116,17 @@ include::{snippets}/update-contest-notice/request-fields.adoc[]
 
 .Path Parameters
 include::{snippets}/update-contest-notice/path-parameters.adoc[]
+
+== `DELETE`: 대회별 공지사항 삭제
+
+.HTTP Request Headers
+include::{snippets}/delete-contest-notice/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/delete-contest-notice/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-contest-notice/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-contest-notice/path-parameters.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -130,3 +130,14 @@ include::{snippets}/delete-contest-notice/http-response.adoc[]
 
 .Path Parameters
 include::{snippets}/delete-contest-notice/path-parameters.adoc[]
+
+== `GET`: 대회별 공지사항 상세 조회
+
+.HTTP Request
+include::{snippets}/get-contest-notice/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-contest-notice/http-response.adoc[]
+
+.Path Parameters
+include::{snippets}/get-contest-notice/path-parameters.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -80,3 +80,20 @@ include::{snippets}/get-all-notices/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-all-notices/response-fields.adoc[]
+
+== `POST`: 대회별 공지사항 생성
+
+.HTTP Request Headers
+include::{snippets}/create-contest-notice/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/create-contest-notice/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/create-contest-notice/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/create-contest-notice/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/create-contest-notice/request-fields.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -16,6 +16,8 @@ link:../opus.html[API 목록으로 돌아가기]
 
 == `POST`: 전체 공지사항 생성
 
+NOTE: 전체 공지사항의 contestId는 null 입니다.
+
 .HTTP Request Headers
 include::{snippets}/create-notice/request-headers.adoc[]
 
@@ -97,3 +99,20 @@ include::{snippets}/create-contest-notice/http-response.adoc[]
 
 .Request Fields
 include::{snippets}/create-contest-notice/request-fields.adoc[]
+
+== `PATCH`: 대회별 공지사항 수정
+
+.HTTP Request Headers
+include::{snippets}/update-contest-notice/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/update-contest-notice/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/update-contest-notice/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/update-contest-notice/request-fields.adoc[]
+
+.Path Parameters
+include::{snippets}/update-contest-notice/path-parameters.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/notice.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 == API 목록
 
-link:../opus.html[API 목록으로 돌아가기]
+link:./opus.html[API 목록으로 돌아가기]
 
 == `POST`: 전체 공지사항 생성
 

--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -14,3 +14,6 @@ link:./member.html[회원 API]
 
 == 팀 관련 API
 link:./team-comment.html[팀 댓글 API]
+
+== 공지 관련 API
+link:./notice.html[공지 API]

--- a/src/main/java/com/opus/opus/docs/asciidoc/team-comment.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/team-comment.adoc
@@ -12,7 +12,7 @@ endif::[]
 
 == API 목록
 
-link:../opus.html[API 목록으로 돌아가기]
+link:./opus.html[API 목록으로 돌아가기]
 
 == `POST`: 팀 댓글 등록
 

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestConvenience.java
@@ -24,6 +24,10 @@ public class ContestConvenience {
         return contestRepository.findById(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
     }
 
+    public void validateExistContest(final Long contestId) {
+        contestRepository.findById(contestId).orElseThrow(() -> new ContestException(NOT_FOUND_CONTEST));
+    }
+
     public void validateAllContestsDeletedInCategory(final Long categoryId) {
         if (contestRepository.existsByCategoryId(categoryId)) {
             throw new ContestException(CATEGORY_HAS_CONTEST);

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -76,4 +76,12 @@ public class NoticeController {
         noticeCommandService.updateContestNotice(request, contestId, noticeId);
         return ResponseEntity.noContent().build();
     }
+
+    @Secured("ROLE_관리자")
+    @DeleteMapping("/contests/{contestId}/notices/{noticeId}")
+    public ResponseEntity<Void> deleteContestNotice(@PathVariable final Long contestId,
+                                                    @PathVariable final Long noticeId) {
+        noticeCommandService.deleteContestNotice(contestId, noticeId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -84,4 +84,11 @@ public class NoticeController {
         noticeCommandService.deleteContestNotice(contestId, noticeId);
         return ResponseEntity.noContent().build();
     }
+
+    @GetMapping("/contests/{contestId}/notices/{noticeId}")
+    public ResponseEntity<NoticeDetailResponse> getContestNotice(@PathVariable final Long contestId,
+                                                                 @PathVariable final Long noticeId) {
+        return ResponseEntity.ok(noticeQueryService.getContestNotice(contestId, noticeId));
+    }
+
 }

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -37,8 +37,8 @@ public class NoticeController {
 
     @Secured("ROLE_관리자")
     @PatchMapping("/notices/{noticeId}")
-    public ResponseEntity<Void> updateNotice(@Valid @RequestBody final NoticeRequest request,
-                                             @PathVariable final Long noticeId) {
+    public ResponseEntity<Void> updateNotice(@PathVariable final Long noticeId,
+                                             @Valid @RequestBody final NoticeRequest request) {
         noticeCommandService.updateNotice(request, noticeId);
         return ResponseEntity.noContent().build();
     }
@@ -70,9 +70,9 @@ public class NoticeController {
 
     @Secured("ROLE_관리자")
     @PatchMapping("/contests/{contestId}/notices/{noticeId}")
-    public ResponseEntity<Void> updateContestNotice(@Valid @RequestBody final NoticeRequest request,
-                                                    @PathVariable final Long contestId,
-                                                    @PathVariable final Long noticeId) {
+    public ResponseEntity<Void> updateContestNotice(@PathVariable final Long contestId,
+                                                    @PathVariable final Long noticeId,
+                                                    @Valid @RequestBody final NoticeRequest request) {
         noticeCommandService.updateContestNotice(request, contestId, noticeId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -59,4 +59,12 @@ public class NoticeController {
     public ResponseEntity<List<NoticeSummaryResponse>> getAllNotices() {
         return ResponseEntity.ok(noticeQueryService.getAllNotices());
     }
+
+    @Secured("ROLE_관리자")
+    @PostMapping("/contests/{contestId}/notices")
+    public ResponseEntity<Void> createContestNotice(@PathVariable final Long contestId,
+                                                    @Valid @RequestBody final NoticeRequest request) {
+        noticeCommandService.createContestNotice(contestId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -67,4 +67,13 @@ public class NoticeController {
         noticeCommandService.createContestNotice(contestId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
+
+    @Secured("ROLE_관리자")
+    @PatchMapping("/contests/{contestId}/notices/{noticeId}")
+    public ResponseEntity<Void> updateContestNotice(@Valid @RequestBody final NoticeRequest request,
+                                                    @PathVariable final Long contestId,
+                                                    @PathVariable final Long noticeId) {
+        noticeCommandService.updateContestNotice(request, contestId, noticeId);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
+++ b/src/main/java/com/opus/opus/modules/notice/api/NoticeController.java
@@ -91,4 +91,9 @@ public class NoticeController {
         return ResponseEntity.ok(noticeQueryService.getContestNotice(contestId, noticeId));
     }
 
+    @GetMapping("/contests/{contestId}/notices")
+    public ResponseEntity<List<NoticeSummaryResponse>> getAllContestNotices(@PathVariable final Long contestId) {
+        return ResponseEntity.ok(noticeQueryService.getAllContestNotices(contestId));
+    }
+
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -49,6 +49,10 @@ public class NoticeCommandService {
         notice.updateNotice(request.title(), request.description());
     }
 
+    public void deleteContestNotice(final Long contestId, final Long noticeId) {
+        noticeRepository.delete(getContestNotice(contestId, noticeId));
+    }
+
     private Notice getContestNotice(final Long contestId, final Long noticeId) {
         return noticeRepository.findByContestIdAndId(contestId, noticeId)
                 .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -32,4 +32,12 @@ public class NoticeCommandService {
     public void deleteNotice(final Long noticeId) {
         noticeRepository.delete(noticeConvenience.getValidateExistNotice(noticeId));
     }
+
+    public void createContestNotice(final Long contestId, final NoticeRequest request) {
+        noticeRepository.save(Notice.builder()
+                .contestId(contestId)
+                .title(request.title())
+                .description(request.description())
+                .build());
+    }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.notice.application;
 
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
@@ -16,6 +17,7 @@ public class NoticeCommandService {
     private final NoticeRepository noticeRepository;
 
     private final NoticeConvenience noticeConvenience;
+    private final ContestConvenience contestConvenience;
 
     public void createNotice(final NoticeRequest request) {
         noticeRepository.save(Notice.builder()
@@ -34,6 +36,8 @@ public class NoticeCommandService {
     }
 
     public void createContestNotice(final Long contestId, final NoticeRequest request) {
+        contestConvenience.validateExistContest(contestId);
+
         noticeRepository.save(Notice.builder()
                 .contestId(contestId)
                 .title(request.title())

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -2,7 +2,7 @@ package com.opus.opus.modules.notice.application;
 
 import static com.opus.opus.modules.notice.exception.NoticeExceptionType.NOT_FOUND_NOTICE;
 
-import com.opus.opus.modules.notice.application.dto.NoticeConvenience;
+import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
 import com.opus.opus.modules.notice.domain.dao.NoticeRepository;

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -1,9 +1,12 @@
 package com.opus.opus.modules.notice.application;
 
+import static com.opus.opus.modules.notice.exception.NoticeExceptionType.NOT_FOUND_NOTICE;
+
 import com.opus.opus.modules.notice.application.dto.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
 import com.opus.opus.modules.notice.domain.dao.NoticeRepository;
+import com.opus.opus.modules.notice.exception.NoticeException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -39,5 +42,15 @@ public class NoticeCommandService {
                 .title(request.title())
                 .description(request.description())
                 .build());
+    }
+
+    public void updateContestNotice(final NoticeRequest request, final Long contestId, final Long noticeId) {
+        final Notice notice =getContestNotice(contestId, noticeId);
+        notice.updateNotice(request.title(), request.description());
+    }
+
+    private Notice getContestNotice(final Long contestId, final Long noticeId) {
+        return noticeRepository.findByContestIdAndId(contestId, noticeId)
+                .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
     }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -42,11 +42,11 @@ public class NoticeCommandService {
     }
 
     public void updateContestNotice(final NoticeRequest request, final Long contestId, final Long noticeId) {
-        final Notice notice = noticeConvenience.getContestNotice(contestId, noticeId);
+        final Notice notice = noticeConvenience.getValidateContestNotice(contestId, noticeId);
         notice.updateNotice(request.title(), request.description());
     }
 
     public void deleteContestNotice(final Long contestId, final Long noticeId) {
-        noticeRepository.delete(noticeConvenience.getContestNotice(contestId, noticeId));
+        noticeRepository.delete(noticeConvenience.getValidateContestNotice(contestId, noticeId));
     }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -27,12 +27,12 @@ public class NoticeCommandService {
     }
 
     public void updateNotice(final NoticeRequest request, final Long noticeId) {
-        final Notice notice = noticeConvenience.getValidateExistNotice(noticeId);
+        final Notice notice = noticeConvenience.getValidateGlobalNotice(noticeId);
         notice.updateNotice(request.title(), request.description());
     }
 
     public void deleteNotice(final Long noticeId) {
-        noticeRepository.delete(noticeConvenience.getValidateExistNotice(noticeId));
+        noticeRepository.delete(noticeConvenience.getValidateGlobalNotice(noticeId));
     }
 
     public void createContestNotice(final Long contestId, final NoticeRequest request) {

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeCommandService.java
@@ -1,12 +1,9 @@
 package com.opus.opus.modules.notice.application;
 
-import static com.opus.opus.modules.notice.exception.NoticeExceptionType.NOT_FOUND_NOTICE;
-
 import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
 import com.opus.opus.modules.notice.domain.dao.NoticeRepository;
-import com.opus.opus.modules.notice.exception.NoticeException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,16 +42,11 @@ public class NoticeCommandService {
     }
 
     public void updateContestNotice(final NoticeRequest request, final Long contestId, final Long noticeId) {
-        final Notice notice =getContestNotice(contestId, noticeId);
+        final Notice notice = noticeConvenience.getContestNotice(contestId, noticeId);
         notice.updateNotice(request.title(), request.description());
     }
 
     public void deleteContestNotice(final Long contestId, final Long noticeId) {
-        noticeRepository.delete(getContestNotice(contestId, noticeId));
-    }
-
-    private Notice getContestNotice(final Long contestId, final Long noticeId) {
-        return noticeRepository.findByContestIdAndId(contestId, noticeId)
-                .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
+        noticeRepository.delete(noticeConvenience.getContestNotice(contestId, noticeId));
     }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
@@ -30,4 +30,9 @@ public class NoticeQueryService {
                 .map(NoticeSummaryResponse::from)
                 .toList();
     }
+
+    public NoticeDetailResponse getContestNotice(final Long contestId, final Long noticeId) {
+        final Notice notice = noticeConvenience.getValidateContestNotice(contestId, noticeId);
+        return NoticeDetailResponse.from(notice);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.notice.application;
 
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.response.NoticeDetailResponse;
 import com.opus.opus.modules.notice.application.dto.response.NoticeSummaryResponse;
@@ -18,6 +19,7 @@ public class NoticeQueryService {
     private final NoticeRepository noticeRepository;
 
     private final NoticeConvenience noticeConvenience;
+    private final ContestConvenience contestConvenience;
 
     public NoticeDetailResponse getNotice(final Long noticeId) {
         final Notice notice = noticeConvenience.getValidateExistNotice(noticeId);
@@ -34,5 +36,13 @@ public class NoticeQueryService {
     public NoticeDetailResponse getContestNotice(final Long contestId, final Long noticeId) {
         final Notice notice = noticeConvenience.getValidateContestNotice(contestId, noticeId);
         return NoticeDetailResponse.from(notice);
+    }
+
+    public List<NoticeSummaryResponse> getAllContestNotices(final Long contestId) {
+        contestConvenience.validateExistContest(contestId);
+        return noticeRepository.findAllByContestIdOrderByCreatedAtDesc(contestId)
+                .stream()
+                .map(NoticeSummaryResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
@@ -22,7 +22,7 @@ public class NoticeQueryService {
     private final ContestConvenience contestConvenience;
 
     public NoticeDetailResponse getNotice(final Long noticeId) {
-        final Notice notice = noticeConvenience.getValidateExistNotice(noticeId);
+        final Notice notice = noticeConvenience.getValidateGlobalNotice(noticeId);
         return NoticeDetailResponse.from(notice);
     }
 

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
@@ -27,7 +27,7 @@ public class NoticeQueryService {
     }
 
     public List<NoticeSummaryResponse> getAllNotices() {
-        return noticeRepository.findAllByOrderByCreatedAtDesc()
+        return noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc()
                 .stream()
                 .map(NoticeSummaryResponse::from)
                 .toList();

--- a/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/NoticeQueryService.java
@@ -1,6 +1,6 @@
 package com.opus.opus.modules.notice.application;
 
-import com.opus.opus.modules.notice.application.dto.NoticeConvenience;
+import com.opus.opus.modules.notice.application.convenience.NoticeConvenience;
 import com.opus.opus.modules.notice.application.dto.response.NoticeDetailResponse;
 import com.opus.opus.modules.notice.application.dto.response.NoticeSummaryResponse;
 import com.opus.opus.modules.notice.domain.Notice;

--- a/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
@@ -19,5 +19,10 @@ public class NoticeConvenience {
     public Notice getValidateExistNotice(final Long noticeId) {
         return noticeRepository.findById(noticeId).orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
     }
+
+    public Notice getContestNotice(final Long contestId, final Long noticeId) {
+        return noticeRepository.findByContestIdAndId(contestId, noticeId)
+                .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
+    }
 }
 

--- a/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
@@ -20,7 +20,7 @@ public class NoticeConvenience {
         return noticeRepository.findById(noticeId).orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
     }
 
-    public Notice getContestNotice(final Long contestId, final Long noticeId) {
+    public Notice getValidateContestNotice(final Long contestId, final Long noticeId) {
         return noticeRepository.findByContestIdAndId(contestId, noticeId)
                 .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
     }

--- a/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
@@ -1,4 +1,4 @@
-package com.opus.opus.modules.notice.application.dto;
+package com.opus.opus.modules.notice.application.convenience;
 
 import static com.opus.opus.modules.notice.exception.NoticeExceptionType.NOT_FOUND_NOTICE;
 

--- a/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
+++ b/src/main/java/com/opus/opus/modules/notice/application/convenience/NoticeConvenience.java
@@ -16,8 +16,9 @@ public class NoticeConvenience {
 
     private final NoticeRepository noticeRepository;
 
-    public Notice getValidateExistNotice(final Long noticeId) {
-        return noticeRepository.findById(noticeId).orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
+    public Notice getValidateGlobalNotice(final Long noticeId) {
+        return noticeRepository.findByIdAndContestIdIsNull(noticeId)
+                .orElseThrow(() -> new NoticeException(NOT_FOUND_NOTICE));
     }
 
     public Notice getValidateContestNotice(final Long contestId, final Long noticeId) {

--- a/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
+++ b/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
@@ -12,4 +12,6 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
     List<Notice> findAllByContestIdOrderByCreatedAtDesc(final Long contestId);
 
     Optional<Notice> findByContestIdAndId(final Long contestId, final Long id);
+
+    Optional<Notice> findByIdAndContestIdIsNull(final Long id);
 }

--- a/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
+++ b/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
@@ -9,5 +9,7 @@ public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     List<Notice> findAllByOrderByCreatedAtDesc();
 
+    List<Notice> findAllByContestIdOrderByCreatedAtDesc(Long contestId);
+
     Optional<Notice> findByContestIdAndId(Long contestId, Long id);
 }

--- a/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
+++ b/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
@@ -7,9 +7,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
-    List<Notice> findAllByOrderByCreatedAtDesc();
+    List<Notice> findAllByContestIdIsNullOrderByCreatedAtDesc();
 
-    List<Notice> findAllByContestIdOrderByCreatedAtDesc(Long contestId);
+    List<Notice> findAllByContestIdOrderByCreatedAtDesc(final Long contestId);
 
-    Optional<Notice> findByContestIdAndId(Long contestId, Long id);
+    Optional<Notice> findByContestIdAndId(final Long contestId, final Long id);
 }

--- a/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
+++ b/src/main/java/com/opus/opus/modules/notice/domain/dao/NoticeRepository.java
@@ -2,9 +2,12 @@ package com.opus.opus.modules.notice.domain.dao;
 
 import com.opus.opus.modules.notice.domain.Notice;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NoticeRepository extends JpaRepository<Notice, Long> {
 
     List<Notice> findAllByOrderByCreatedAtDesc();
+
+    Optional<Notice> findByContestIdAndId(Long contestId, Long id);
 }

--- a/src/test/java/com/opus/opus/contest/ContestCategoryFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestCategoryFixture.java
@@ -1,0 +1,12 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.ContestCategory;
+
+public class ContestCategoryFixture {
+
+    public static ContestCategory createContestCategory() {
+        return ContestCategory.builder()
+                .categoryName("테스트 카테고리")
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/contest/ContestFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestFixture.java
@@ -1,0 +1,13 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.Contest;
+
+public class ContestFixture {
+
+    public static Contest createContest(final Long categoryId) {
+        return Contest.builder()
+                .contestName("테스트 대회")
+                .categoryId(categoryId)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/notice/NoticeFixture.java
+++ b/src/test/java/com/opus/opus/notice/NoticeFixture.java
@@ -4,10 +4,19 @@ import com.opus.opus.modules.notice.domain.Notice;
 
 public class NoticeFixture {
 
-    public static Notice createNotice() {
+    public static Notice createGlobalNotice() {
         return Notice.builder()
-                .title("공지 제목입니다.")
-                .description("공지 내용입니다.")
+                .title("전체 공지 제목입니다.")
+                .contestId(null)
+                .description("전체 공지 내용입니다.")
+                .build();
+    }
+
+    public static Notice createContestNotice() {
+        return Notice.builder()
+                .title("대회 공지 제목입니다.")
+                .contestId(1L)
+                .description("대회 공지 내용입니다.")
                 .build();
     }
 }

--- a/src/test/java/com/opus/opus/notice/NoticeFixture.java
+++ b/src/test/java/com/opus/opus/notice/NoticeFixture.java
@@ -12,10 +12,10 @@ public class NoticeFixture {
                 .build();
     }
 
-    public static Notice createContestNotice() {
+    public static Notice createContestNotice(final Long contestId) {
         return Notice.builder()
                 .title("대회 공지 제목입니다.")
-                .contestId(1L)
+                .contestId(contestId)
                 .description("대회 공지 내용입니다.")
                 .build();
     }

--- a/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
@@ -25,7 +25,7 @@ public class NoticeCommandServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        notice = noticeRepository.save(NoticeFixture.createNotice());
+        notice = noticeRepository.save(NoticeFixture.createGlobalNotice());
     }
 
     @Test

--- a/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
@@ -35,7 +35,7 @@ public class NoticeCommandServiceTest extends IntegrationTest {
 
         noticeCommandService.createNotice(request);
 
-        final Notice notice = noticeRepository.findAllByOrderByCreatedAtDesc().get(0);
+        final Notice notice = noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc().get(0);
         assertThat(notice.getTitle()).isEqualTo(request.title());
         assertThat(notice.getDescription()).isEqualTo(request.description());
         assertThat(notice.getContestId()).isNull();
@@ -50,7 +50,7 @@ public class NoticeCommandServiceTest extends IntegrationTest {
 
         noticeCommandService.updateNotice(request, notice.getId());
 
-        final Notice updateNotice = noticeRepository.findAllByOrderByCreatedAtDesc().get(0);
+        final Notice updateNotice = noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc().get(0);
         assertThat(updateNotice.getTitle()).isNotEqualTo(beforeTitle);
         assertThat(updateNotice.getDescription()).isNotEqualTo(beforeDescription);
         assertThat(updateNotice.getTitle()).isEqualTo(request.title());

--- a/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
@@ -95,4 +95,21 @@ public class NoticeCommandServiceTest extends IntegrationTest {
         assertThat(notice.getTitle()).isEqualTo(request.title());
         assertThat(notice.getDescription()).isEqualTo(request.description());
     }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항이 정상적으로 수정된다.")
+    void 대회별_공지사항이_정상적으로_수정된다() {
+        final String beforeTitle = contestNotice.getTitle();
+        final String beforeDescription = contestNotice.getDescription();
+        final NoticeRequest request = new NoticeRequest("수정 대회별 공지 제목", "수정 대회별 공지 내용");
+
+        noticeCommandService.updateContestNotice(request, contestNotice.getContestId(), contestNotice.getId());
+
+        final Notice updateNotice = noticeRepository.findAllByContestIdOrderByCreatedAtDesc(
+                contestNotice.getContestId()).get(0);
+        assertThat(updateNotice.getTitle()).isNotEqualTo(beforeTitle);
+        assertThat(updateNotice.getDescription()).isNotEqualTo(beforeDescription);
+        assertThat(updateNotice.getTitle()).isEqualTo(request.title());
+        assertThat(updateNotice.getDescription()).isEqualTo(request.description());
+    }
 }

--- a/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
@@ -112,4 +112,14 @@ public class NoticeCommandServiceTest extends IntegrationTest {
         assertThat(updateNotice.getTitle()).isEqualTo(request.title());
         assertThat(updateNotice.getDescription()).isEqualTo(request.description());
     }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항이 정상적으로 삭제된다.")
+    void 대회별_공지사항이_정상적으로_삭제된다() {
+        assertThat(noticeRepository.count()).isEqualTo(2);
+
+        noticeCommandService.deleteContestNotice(contestNotice.getContestId(), contestNotice.getId());
+
+        assertThat(noticeRepository.count()).isEqualTo(1);
+    }
 }

--- a/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeCommandServiceTest.java
@@ -2,7 +2,13 @@ package com.opus.opus.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.opus.opus.contest.ContestCategoryFixture;
+import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.notice.application.NoticeCommandService;
 import com.opus.opus.modules.notice.application.dto.request.NoticeRequest;
 import com.opus.opus.modules.notice.domain.Notice;
@@ -20,18 +26,28 @@ public class NoticeCommandServiceTest extends IntegrationTest {
 
     @Autowired
     private NoticeRepository noticeRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private ContestCategoryRepository contestCategoryRepository;
 
-    private Notice notice;
+    private Contest contest;
+    private ContestCategory contestCategory;
+    private Notice globalNotice;
+    private Notice contestNotice;
 
     @BeforeEach
     void setUp() {
-        notice = noticeRepository.save(NoticeFixture.createGlobalNotice());
+        contestCategory = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        contest = contestRepository.save(ContestFixture.createContest(contestCategory.getId()));
+        globalNotice = noticeRepository.save(NoticeFixture.createGlobalNotice());
+        contestNotice = noticeRepository.save(NoticeFixture.createContestNotice(contest.getId()));
     }
 
     @Test
     @DisplayName("[성공] 전체 공지사항이 정상적으로 생성된다.")
     void 전체_공지사항이_정상적으로_생성된다() {
-        final NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+        final NoticeRequest request = new NoticeRequest("전체 공지 제목", "전체 공지 내용");
 
         noticeCommandService.createNotice(request);
 
@@ -44,11 +60,11 @@ public class NoticeCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 전체 공지사항이 정상적으로 수정된다.")
     void 전체_공지사항이_정상적으로_수정된다() {
-        final String beforeTitle = notice.getTitle();
-        final String beforeDescription = notice.getDescription();
-        final NoticeRequest request = new NoticeRequest("수정 공지 제목", "수정 공지 내용");
+        final String beforeTitle = globalNotice.getTitle();
+        final String beforeDescription = globalNotice.getDescription();
+        final NoticeRequest request = new NoticeRequest("수정 전체 공지 제목", "수정 전체 공지 내용");
 
-        noticeCommandService.updateNotice(request, notice.getId());
+        noticeCommandService.updateNotice(request, globalNotice.getId());
 
         final Notice updateNotice = noticeRepository.findAllByContestIdIsNullOrderByCreatedAtDesc().get(0);
         assertThat(updateNotice.getTitle()).isNotEqualTo(beforeTitle);
@@ -60,10 +76,23 @@ public class NoticeCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 전체 공지사항이 정상적으로 삭제된다.")
     void 전체_공지사항이_정상적으로_삭제된다() {
+        assertThat(noticeRepository.count()).isEqualTo(2);
+
+        noticeCommandService.deleteNotice(globalNotice.getId());
+
         assertThat(noticeRepository.count()).isEqualTo(1);
+    }
 
-        noticeCommandService.deleteNotice(notice.getId());
+    @Test
+    @DisplayName("[성공] 대회별 공지사항이 정상적으로 생성된다.")
+    void 대회별_공지사항이_정상적으로_생성된다() {
+        final NoticeRequest request = new NoticeRequest("대회별 공지 제목", "대회별 공지 내용");
 
-        assertThat(noticeRepository.count()).isEqualTo(0);
+        noticeCommandService.createContestNotice(contestNotice.getContestId(), request);
+
+        final Notice notice = noticeRepository.findAllByContestIdOrderByCreatedAtDesc(contestNotice.getContestId())
+                .get(0);
+        assertThat(notice.getTitle()).isEqualTo(request.title());
+        assertThat(notice.getDescription()).isEqualTo(request.description());
     }
 }

--- a/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
@@ -77,4 +77,18 @@ public class NoticeQueryServiceTest extends IntegrationTest {
         assertThat(response.title()).isEqualTo(contestNotice.getTitle());
         assertThat(response.description()).isEqualTo(contestNotice.getDescription());
     }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항 목록을 조회할 수 있다.")
+    void 대회별_공지사항_목록을_조회할_수_있다() {
+        final Notice anotherContestNotice = noticeRepository.save(NoticeFixture.createContestNotice(contest.getId()));
+
+        final List<NoticeSummaryResponse> responses = noticeQueryService.getAllContestNotices(
+                anotherContestNotice.getContestId());
+
+        assertThat(responses).hasSize(2);
+        assertThat(responses)
+                .extracting(NoticeSummaryResponse::noticeId)
+                .containsExactlyInAnyOrder(contestNotice.getId(), anotherContestNotice.getId());
+    }
 }

--- a/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
@@ -27,7 +27,7 @@ public class NoticeQueryServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        notice = noticeRepository.save(NoticeFixture.createNotice());
+        notice = noticeRepository.save(NoticeFixture.createGlobalNotice());
     }
 
     @Test
@@ -42,7 +42,7 @@ public class NoticeQueryServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 전체 공지사항 목록을 조회할 수 있다.")
     void 전체_공지사항_목록을_조회할_수_있다() {
-        final Notice anotherNotice = noticeRepository.save(NoticeFixture.createNotice());
+        final Notice anotherNotice = noticeRepository.save(NoticeFixture.createGlobalNotice());
 
         final List<NoticeSummaryResponse> responses = noticeQueryService.getAllNotices();
 

--- a/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/notice/application/NoticeQueryServiceTest.java
@@ -2,7 +2,13 @@ package com.opus.opus.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.opus.opus.contest.ContestCategoryFixture;
+import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.notice.application.NoticeQueryService;
 import com.opus.opus.modules.notice.application.dto.response.NoticeDetailResponse;
 import com.opus.opus.modules.notice.application.dto.response.NoticeSummaryResponse;
@@ -22,21 +28,31 @@ public class NoticeQueryServiceTest extends IntegrationTest {
 
     @Autowired
     private NoticeRepository noticeRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private ContestCategoryRepository contestCategoryRepository;
 
-    private Notice notice;
+    private Contest contest;
+    private ContestCategory contestCategory;
+    private Notice globalNotice;
+    private Notice contestNotice;
 
     @BeforeEach
     void setUp() {
-        notice = noticeRepository.save(NoticeFixture.createGlobalNotice());
+        contestCategory = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        contest = contestRepository.save(ContestFixture.createContest(contestCategory.getId()));
+        globalNotice = noticeRepository.save(NoticeFixture.createGlobalNotice());
+        contestNotice = noticeRepository.save(NoticeFixture.createContestNotice(contest.getId()));
     }
 
     @Test
     @DisplayName("[성공] 전체 공지사항을 상세 조회할 수 있다.")
     void 전체_공지사항을_상세_조회할_수_있다() {
-        final NoticeDetailResponse response = noticeQueryService.getNotice(notice.getId());
+        final NoticeDetailResponse response = noticeQueryService.getNotice(globalNotice.getId());
 
-        assertThat(response.title()).isEqualTo(notice.getTitle());
-        assertThat(response.description()).isEqualTo(notice.getDescription());
+        assertThat(response.title()).isEqualTo(globalNotice.getTitle());
+        assertThat(response.description()).isEqualTo(globalNotice.getDescription());
     }
 
     @Test
@@ -49,6 +65,16 @@ public class NoticeQueryServiceTest extends IntegrationTest {
         assertThat(responses).hasSize(2);
         assertThat(responses)
                 .extracting(NoticeSummaryResponse::noticeId)
-                .containsExactlyInAnyOrder(notice.getId(), anotherNotice.getId());
+                .containsExactlyInAnyOrder(globalNotice.getId(), anotherNotice.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 대회별 공지사항을 상세 조회할 수 있다.")
+    void 대회별_공지사항을_상세_조회할_수_있다() {
+        final NoticeDetailResponse response = noticeQueryService.getContestNotice(contestNotice.getContestId(),
+                contestNotice.getId());
+
+        assertThat(response.title()).isEqualTo(contestNotice.getTitle());
+        assertThat(response.description()).isEqualTo(contestNotice.getDescription());
     }
 }

--- a/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
@@ -34,13 +34,12 @@ import org.springframework.http.MediaType;
 public class NoticeApiDocsTest extends RestDocsTest {
 
     private Member admin;
-    private String adminToken;
+    private static final String ADMIN_TOKEN = "Bearer admin.access.token";
 
     @BeforeEach
     void setUp() {
         this.admin = MemberFixture.createMember();
         setField(admin, "id", 1L);
-        adminToken = "mock_admin_access_token";
     }
 
     @Test
@@ -51,7 +50,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
         doNothing().when(noticeCommandService).createNotice(any());
 
         mockMvc.perform(post("/notices")
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -74,7 +73,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
         doNothing().when(noticeCommandService).updateNotice(any(), any());
 
         mockMvc.perform(patch("/notices/{noticeId}", 1)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNoContent())
@@ -98,7 +97,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
         doNothing().when(noticeCommandService).deleteNotice(any());
 
         mockMvc.perform(delete("/notices/{noticeId}", 1)
-                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + adminToken))
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-notice",
                         pathParameters(
@@ -153,4 +152,31 @@ public class NoticeApiDocsTest extends RestDocsTest {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항이 생성된다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항이_생성된다() throws Exception {
+        final NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+
+        doNothing().when(noticeCommandService).createContestNotice(any(), any());
+
+        mockMvc.perform(post("/contests/{contestId}/notices", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("create-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("title", "공지 제목"),
+                                stringFieldWithPath("description", "공지 내용")
+                        )
+                ));
+    }
+
 }

--- a/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
@@ -135,8 +135,8 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항 목록을 조회할 수 있다.")
     void 유효한_요청이면_정상적으로_전체_공지사항_목록을_조회할_수_있다() throws Exception {
         final List<NoticeSummaryResponse> responses = List.of(
-                new NoticeSummaryResponse(1L, "공지 제목 1", now()),
-                new NoticeSummaryResponse(2L, "공지 제목 2", now())
+                new NoticeSummaryResponse(1L, "전체 공지 제목 1", now()),
+                new NoticeSummaryResponse(2L, "전체 공지 제목 2", now())
         );
 
         when(noticeQueryService.getAllNotices()).thenReturn(responses);
@@ -244,6 +244,31 @@ public class NoticeApiDocsTest extends RestDocsTest {
                                 stringFieldWithPath("description", "공지 내용"),
                                 dateTimeFieldWithPath("createdAt", "공지 생성 시각"),
                                 dateTimeFieldWithPath("updatedAt", "공지 수정 시각")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항 목록을 조회할 수 있다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항_목록을_조회할_수_있다() throws Exception {
+        final List<NoticeSummaryResponse> responses = List.of(
+                new NoticeSummaryResponse(1L, "대회별 공지 제목 1", now()),
+                new NoticeSummaryResponse(2L, "대회별 공지 제목 2", now())
+        );
+
+        when(noticeQueryService.getAllContestNotices(any())).thenReturn(responses);
+
+        mockMvc.perform(get("/contests/{contestId}/notices", 1))
+                .andExpect(status().isOk())
+                .andDo(document("get-all-contest-notices",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        responseFields(
+                                arrayFieldWithPath("[]", "공지 목록"),
+                                numberFieldWithPath("[].noticeId", "공지 ID"),
+                                stringFieldWithPath("[].title", "공지 제목"),
+                                dateTimeFieldWithPath("[].createdAt", "공지 생성 시각")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
@@ -112,11 +112,11 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항 상세 조회를 할 수 있다.")
     void 유효한_요청이면_정상적으로_전체_공지사항_상세_조회를_할_수_있다() throws Exception {
-        final NoticeDetailResponse response = new NoticeDetailResponse("공지 전체 제목", "공지 전체 내용", now(), now());
+        final NoticeDetailResponse response = new NoticeDetailResponse("전체 공지 제목", "전체 공지 내용", now(), now());
 
         when(noticeQueryService.getNotice(any())).thenReturn(response);
 
-        mockMvc.perform(get("/notices/{noticeId}", 1L))
+        mockMvc.perform(get("/notices/{noticeId}", 1))
                 .andExpect(status().isOk())
                 .andDo(document("get-notice",
                         pathParameters(
@@ -211,7 +211,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
     void 유효한_요청이면_정상적으로_대회별_공지사항이_삭제된다() throws Exception {
         doNothing().when(noticeCommandService).deleteContestNotice(any(), any());
 
-        mockMvc.perform(delete("/contests/{contestId}/notices/{noticeId}", 1,1)
+        mockMvc.perform(delete("/contests/{contestId}/notices/{noticeId}", 1, 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-contest-notice",
@@ -221,6 +221,29 @@ public class NoticeApiDocsTest extends RestDocsTest {
                         ),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항 상세 조회를 할 수 있다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항_상세_조회를_할_수_있다() throws Exception {
+        final NoticeDetailResponse response = new NoticeDetailResponse("대회별 공지 제목", "대회별 공지 내용", now(), now());
+
+        when(noticeQueryService.getContestNotice(any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/contests/{contestId}/notices/{noticeId}", 1, 1))
+                .andExpect(status().isOk())
+                .andDo(document("get-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("noticeId").description("공지 ID")
+                        ),
+                        responseFields(
+                                stringFieldWithPath("title", "공지 제목"),
+                                stringFieldWithPath("description", "공지 내용"),
+                                dateTimeFieldWithPath("createdAt", "공지 생성 시각"),
+                                dateTimeFieldWithPath("updatedAt", "공지 수정 시각")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
@@ -205,4 +205,23 @@ public class NoticeApiDocsTest extends RestDocsTest {
                         )
                 ));
     }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항이 삭제된다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항이_삭제된다() throws Exception {
+        doNothing().when(noticeCommandService).deleteContestNotice(any(), any());
+
+        mockMvc.perform(delete("/contests/{contestId}/notices/{noticeId}", 1,1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("noticeId").description("공지 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        )
+                ));
+    }
 }

--- a/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/NoticeApiDocsTest.java
@@ -45,7 +45,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항이 생성된다.")
     void 유효한_요청이면_정상적으로_전체_공지사항이_생성된다() throws Exception {
-        final NoticeRequest request = new NoticeRequest("공지 제목", "공지 내용");
+        final NoticeRequest request = new NoticeRequest("전체 공지 제목", "전체 공지 내용");
 
         doNothing().when(noticeCommandService).createNotice(any());
 
@@ -68,7 +68,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항이 수정된다.")
     void 유효한_요청이면_정상적으로_전체_공지사항이_수정된다() throws Exception {
-        final NoticeRequest request = new NoticeRequest("수정된 공지 제목", "수정된 공지 내용");
+        final NoticeRequest request = new NoticeRequest("수정된 전체 공지 제목", "수정된 전체 공지 내용");
 
         doNothing().when(noticeCommandService).updateNotice(any(), any());
 
@@ -112,7 +112,7 @@ public class NoticeApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 전체 공지사항 상세 조회를 할 수 있다.")
     void 유효한_요청이면_정상적으로_전체_공지사항_상세_조회를_할_수_있다() throws Exception {
-        final NoticeDetailResponse response = new NoticeDetailResponse("공지 제목", "공지 내용", now(), now());
+        final NoticeDetailResponse response = new NoticeDetailResponse("공지 전체 제목", "공지 전체 내용", now(), now());
 
         when(noticeQueryService.getNotice(any())).thenReturn(response);
 
@@ -179,4 +179,30 @@ public class NoticeApiDocsTest extends RestDocsTest {
                 ));
     }
 
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 대회별 공지사항이 수정된다.")
+    void 유효한_요청이면_정상적으로_대회별_공지사항이_수정된다() throws Exception {
+        final NoticeRequest request = new NoticeRequest("수정된 대회별 공지 제목", "수정된 대회별 공지 내용");
+
+        doNothing().when(noticeCommandService).updateContestNotice(any(), any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/notices/{noticeId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-contest-notice",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("noticeId").description("공지 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("title", "수정된 대회별 공지 제목"),
+                                stringFieldWithPath("description", "수정된 대회별 공지 내용")
+                        )
+                ));
+    }
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #1

## 📜 작업 내용

- 전체 공지사항에 이어서, 대회별 공지사항 API를 개발했습니다.
- 전체 공지사항 목록에 대회별 공지사항이 뜨지 않도록 수정했습니다.
- mock token의 이름을 수정했습니다.

## 💬 리뷰 요구사항

- 지금은 전체 공지사항은 `contestId`가 `null`, 대회별 공지사항은 `contestId`를 가지도록 설계했는데 이후 졸업과제 공지사항이 생긴다면 어떻게 할 지도 생각해 봐야할 것 같습니다.
  - 지금은 졸업과제도 contestId를 가지고 있음.
  - 이게 나중에 구분이 될 지 안될 지..

## ✨ 기타

- 와우 1번 이슈네요ㅎㅎ
