### PR TITLE
Feature/#7 구글 로그인 api 구현

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -152,3 +152,55 @@ include::{snippets}/get-password/path-parameters.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-password/response-fields.adoc[]
+
+== `GET`: Google OAuth 로그인 리다이렉트
+
+사용자를 Google OAuth 인증 페이지로 리다이렉트합니다. CSRF 공격 방지를 위한 `state` 파라미터가 세션 ID와 함께 Redis에 저장됩니다. (TTL: 5분)
+
+.HTTP Request
+include::{snippets}/oauth-google-redirect/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/oauth-google-redirect/http-response.adoc[]
+
+== `GET`: Google OAuth 콜백
+
+Google OAuth 인증 완료 후 호출되는 콜백 엔드포인트입니다. 기존 회원이면 로그인 처리, 신규 회원이면 자동 가입 후 JWT 토큰을 발급합니다.
+
+.HTTP Request
+include::{snippets}/oauth-google-callback/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/oauth-google-callback/http-response.adoc[]
+
+.Query Parameters
+include::{snippets}/oauth-google-callback/query-parameters.adoc[]
+
+.Response Body's Fields
+include::{snippets}/oauth-google-callback/response-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: state 누락/불일치/만료
+
+[%collapsible]
+
+====
+
+include::{snippets}/oauth-google-callback-fail-state/http-request.adoc[]
+
+include::{snippets}/oauth-google-callback-fail-state/http-response.adoc[]
+
+====
+
+.❌ Case 2: 사용자 권한 거부
+
+[%collapsible]
+
+====
+
+include::{snippets}/oauth-google-callback-fail-denied/http-request.adoc[]
+
+include::{snippets}/oauth-google-callback-fail-denied/http-response.adoc[]
+
+====

--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -155,7 +155,7 @@ include::{snippets}/get-password/response-fields.adoc[]
 
 == `GET`: Google OAuth 로그인 리다이렉트
 
-사용자를 Google OAuth 인증 페이지로 리다이렉트합니다. CSRF 공격 방지를 위한 `state` 파라미터가 세션 ID와 함께 Redis에 저장됩니다. (TTL: 5분)
+NOTE: 사용자를 Google OAuth 인증 페이지로 리다이렉트합니다. CSRF 공격 방지를 위한 `state` 파라미터가 세션 ID와 함께 Redis에 저장됩니다. (TTL: 5분)
 
 .HTTP Request
 include::{snippets}/oauth-google-redirect/http-request.adoc[]
@@ -165,7 +165,7 @@ include::{snippets}/oauth-google-redirect/http-response.adoc[]
 
 == `GET`: Google OAuth 콜백
 
-Google OAuth 인증 완료 후 호출되는 콜백 엔드포인트입니다. 기존 회원이면 로그인 처리, 신규 회원이면 자동 가입 후 JWT 토큰을 발급합니다.
+NOTE: Google OAuth 인증 완료 후 호출되는 콜백 엔드포인트입니다. 기존 회원이면 로그인 처리, 신규 회원이면 자동 가입 후 JWT 토큰을 발급합니다.
 
 .HTTP Request
 include::{snippets}/oauth-google-callback/http-request.adoc[]

--- a/src/main/java/com/opus/opus/global/security/SecurityConfig.java
+++ b/src/main/java/com/opus/opus/global/security/SecurityConfig.java
@@ -42,6 +42,7 @@ public class SecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**", "/oauth/**").permitAll()
+                        .requestMatchers("/oauth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/teams/**", "/contests/**", "/notices/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장", "팀원")
                 )

--- a/src/main/java/com/opus/opus/global/security/SecurityConfig.java
+++ b/src/main/java/com/opus/opus/global/security/SecurityConfig.java
@@ -42,7 +42,6 @@ public class SecurityConfig {
                 .formLogin(FormLoginConfigurer::disable)
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/sign-up/**", "/sign-in/**", "/oauth/**").permitAll()
-                        .requestMatchers("/oauth/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/teams/**", "/contests/**", "/notices/**").permitAll()
                         .anyRequest().hasAnyRole("회원", "관리자", "팀장", "팀원")
                 )

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -64,10 +64,12 @@ public class GoogleOauth implements SocialOauth {
     public String getOauthRedirectURL() {
         String callbackUrl = determineCallbackUrl();
 
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        HttpServletRequest request = attributes.getRequest();
+        String sessionId = request.getSession().getId();
         String state = UUID.randomUUID().toString();
-
-        // Redis에 state 저장 (5분 TTL)
-        String stateKey = "oauth:state:" + state;
+        String stateKey = "oauth:state:" + sessionId + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
 
         return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -1,0 +1,182 @@
+package com.opus.opus.global.util.oauth.component;
+
+
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_ACCESS_TOKEN;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opus.opus.global.util.oauth.dto.GoogleOAuthToken;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class GoogleOauth implements SocialOauth {
+
+    @Value("${spring.oauth2.google.url}")
+    private String GOOGLE_SNS_URL;
+
+    @Value("${spring.oauth2.google.client-id}")
+    private String GOOGLE_SNS_CLIENT_ID;
+
+    @Value("${spring.oauth2.google.callback-login-url}")
+    private String GOOGLE_SNS_CALLBACK_LOGIN_URL;
+
+    @Value("${spring.oauth2.google.frontend-local-callback-login-url}")
+    private String GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
+
+    @Value("${spring.oauth2.google.client-secret}")
+    private String GOOGLE_SNS_CLIENT_SECRET;
+
+    @Value("${spring.oauth2.google.scope}")
+    private String GOOGLE_DATA_ACCESS_SCOPE;
+
+    private final ObjectMapper objectMapper;
+    private final RestTemplate restTemplate;
+
+    @Override
+    public String getOauthRedirectURL() {
+        String callbackUrl = determineCallbackUrl();
+
+        return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)
+                .queryParam("scope", GOOGLE_DATA_ACCESS_SCOPE)
+                .queryParam("response_type", "code")
+                .queryParam("client_id", GOOGLE_SNS_CLIENT_ID)
+                .queryParam("redirect_uri", callbackUrl)
+                .build()
+                .toUriString();
+    }
+
+    @Override
+    public <T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
+        ResponseEntity<String> requestAccessToken = requestAccessToken(code);
+        GoogleOAuthToken oAuthToken = getAccessToken(requestAccessToken);
+        ResponseEntity<String> userInfo = requestUserInfo(oAuthToken);
+        return getUserInfo(userInfo, userType);
+    }
+
+    private String determineCallbackUrl() {
+        try {
+            ServletRequestAttributes attributes =
+                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+            if (attributes == null) {
+                log.error("OAuth 인증 요청이 HTTP 요청 컨텍스트 외부에서 호출됨");
+                throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+            }
+
+            HttpServletRequest request = attributes.getRequest();
+            String origin = request.getHeader("Origin");
+            log.info("감지된 Origin 헤더: {}", origin);
+
+            if (origin != null && origin.contains("localhost:5173")) {
+                return GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
+            }
+
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+
+        } catch (Exception e) {
+            log.error("콜백 URL 결정 중 오류 발생", e);
+            return GOOGLE_SNS_CALLBACK_LOGIN_URL;
+        }
+    }
+
+    private ResponseEntity<String> requestAccessToken(String code) {
+        String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
+
+        String callbackUrl = determineCallbackUrl();
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("code", code);
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("redirect_uri", callbackUrl);
+        params.add("grant_type", "authorization_code");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> responseEntity =
+                    restTemplate.postForEntity(
+                            GOOGLE_TOKEN_REQUEST_URL, requestEntity, String.class);
+
+            if (responseEntity.getStatusCode() == HttpStatus.OK) {
+                return responseEntity;
+            } else {
+                log.error("Google Access Token Request Failed: {}", responseEntity.getBody());
+                throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
+            }
+        } catch (RestClientException e) {
+            log.error("Google Access Token Request Server Error: {}", e.getMessage());
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private GoogleOAuthToken getAccessToken(ResponseEntity<String> response) {
+        try {
+            GoogleOAuthToken oAuthToken =
+                    objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
+            if (oAuthToken == null || oAuthToken.accessToken() == null) {
+                throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+            }
+            return oAuthToken;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google OAuth Token: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_ACCESS_TOKEN);
+        }
+    }
+
+    private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
+        String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
+        headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        try {
+            return restTemplate.exchange(
+                    GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
+        } catch (RestClientException e) {
+            log.error("Google User Info Request Server Error: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
+
+    private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
+        try {
+            T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
+            if (googleUser == null) {
+                throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+            }
+            return googleUser;
+        } catch (JsonProcessingException e) {
+            log.error("Failed to parse Google User Info: {}", e.getMessage());
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -65,12 +65,12 @@ public class GoogleOauth implements SocialOauth {
 
     @Override
     public String getOauthRedirectURL() {
-        String callbackUrl = determineCallbackUrl();
+        final String callbackUrl = determineCallbackUrl();
 
-        HttpServletRequest request = getCurrentHttpRequest();
-        String sessionId = request.getSession().getId();
-        String state = UUID.randomUUID().toString();
-        String stateKey = createOAuthStateKey(sessionId, state);
+        final HttpServletRequest request = getCurrentHttpRequest();
+        final String sessionId = request.getSession().getId();
+        final String state = UUID.randomUUID().toString();
+        final String stateKey = createOAuthStateKey(sessionId, state);
         authRedisUtil.set(stateKey, "valid", OAUTH_STATE_TTL, TimeUnit.MINUTES);
 
         return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)
@@ -93,20 +93,20 @@ public class GoogleOauth implements SocialOauth {
         return new OAuthResult<>(userInfo, oAuthToken.accessToken(), oAuthToken.refreshToken());
     }
 
-    public String createOAuthStateKey(String sessionId, String state) {
+    public String createOAuthStateKey(final String sessionId, final String state) {
         return "oauth:state:" + sessionId + ":" + state;
     }
 
     public boolean revokeToken(final String token) {
         final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("token", token);
 
-        HttpHeaders headers = new HttpHeaders();
+        final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
 
         try {
             ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_REVOKE_URL, requestEntity, String.class);
@@ -124,16 +124,16 @@ public class GoogleOauth implements SocialOauth {
     public String refreshAccessToken(final String refreshToken) {
         final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("client_id", GOOGLE_SNS_CLIENT_ID);
         params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
         params.add("refresh_token", refreshToken);
         params.add("grant_type", "refresh_token");
 
-        HttpHeaders headers = new HttpHeaders();
+        final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
 
         try {
             ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_TOKEN_URL, requestEntity, String.class);
@@ -147,8 +147,8 @@ public class GoogleOauth implements SocialOauth {
 
     private String determineCallbackUrl() {
         try {
-            HttpServletRequest request = getCurrentHttpRequest();
-            String origin = request.getHeader("Origin");
+            final HttpServletRequest request = getCurrentHttpRequest();
+            final String origin = request.getHeader("Origin");
             log.debug("감지된 Origin 헤더: {}", origin);
 
             if (origin != null && origin.contains("localhost:5173")) {
@@ -174,21 +174,21 @@ public class GoogleOauth implements SocialOauth {
     }
 
     private ResponseEntity<String> requestAccessToken(String code) {
-        String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
+        final String GOOGLE_TOKEN_REQUEST_URL = "https://oauth2.googleapis.com/token";
 
-        String callbackUrl = determineCallbackUrl();
+        final String callbackUrl = determineCallbackUrl();
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        final MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("code", code);
         params.add("client_id", GOOGLE_SNS_CLIENT_ID);
         params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
         params.add("redirect_uri", callbackUrl);
         params.add("grant_type", "authorization_code");
 
-        HttpHeaders headers = new HttpHeaders();
+        final HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
 
-        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+        final HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
 
         try {
             ResponseEntity<String> responseEntity =
@@ -222,13 +222,13 @@ public class GoogleOauth implements SocialOauth {
     }
 
     private ResponseEntity<String> requestUserInfo(GoogleOAuthToken oAuthToken) {
-        String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
+        final String GOOGLE_USERINFO_REQUEST_URL = "https://www.googleapis.com/oauth2/v1/userinfo";
 
-        HttpHeaders headers = new HttpHeaders();
+        final HttpHeaders headers = new HttpHeaders();
         headers.add("Authorization", "Bearer " + oAuthToken.accessToken());
         headers.add("Accept", MediaType.APPLICATION_JSON_VALUE);
 
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
+        final HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(headers);
         try {
             return restTemplate.exchange(
                     GOOGLE_USERINFO_REQUEST_URL, HttpMethod.GET, request, String.class);
@@ -240,7 +240,7 @@ public class GoogleOauth implements SocialOauth {
 
     private <T> T getUserInfo(ResponseEntity<String> userInfoRes, Class<T> userType) {
         try {
-            T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
+            final T googleUser = objectMapper.readValue(userInfoRes.getBody(), userType);
             if (googleUser == null) {
                 throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
             }

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -5,6 +5,7 @@ import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILE
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
+import static org.hibernate.internal.util.JdbcExceptionHelper.extractErrorCode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -55,6 +56,8 @@ public class GoogleOauth implements SocialOauth {
     @Value("${spring.oauth2.google.scope}")
     private String GOOGLE_DATA_ACCESS_SCOPE;
 
+    private static final long OAUTH_STATE_TTL = 5L;
+
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
 
@@ -64,13 +67,11 @@ public class GoogleOauth implements SocialOauth {
     public String getOauthRedirectURL() {
         String callbackUrl = determineCallbackUrl();
 
-        ServletRequestAttributes attributes =
-                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-        HttpServletRequest request = attributes.getRequest();
+        HttpServletRequest request = getCurrentHttpRequest();
         String sessionId = request.getSession().getId();
         String state = UUID.randomUUID().toString();
-        String stateKey = "oauth:state:" + sessionId + ":" + state;
-        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        String stateKey = createOAuthStateKey(sessionId, state);
+        authRedisUtil.set(stateKey, "valid", OAUTH_STATE_TTL, TimeUnit.MINUTES);
 
         return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)
                 .queryParam("scope", GOOGLE_DATA_ACCESS_SCOPE)
@@ -90,19 +91,15 @@ public class GoogleOauth implements SocialOauth {
         return getUserInfo(userInfo, userType);
     }
 
+    public String createOAuthStateKey(String sessionId, String state) {
+        return "oauth:state:" + sessionId + ":" + state;
+    }
+
     private String determineCallbackUrl() {
         try {
-            ServletRequestAttributes attributes =
-                    (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
-
-            if (attributes == null) {
-                log.error("OAuth 인증 요청이 HTTP 요청 컨텍스트 외부에서 호출됨");
-                throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
-            }
-
-            HttpServletRequest request = attributes.getRequest();
+            HttpServletRequest request = getCurrentHttpRequest();
             String origin = request.getHeader("Origin");
-            log.info("감지된 Origin 헤더: {}", origin);
+            log.debug("감지된 Origin 헤더: {}", origin);
 
             if (origin != null && origin.contains("localhost:5173")) {
                 return GOOGLE_SNS_FRONTEND_LOCAL_CALLBACK_LOGIN_URL;
@@ -114,6 +111,16 @@ public class GoogleOauth implements SocialOauth {
             log.error("콜백 URL 결정 중 오류 발생", e);
             return GOOGLE_SNS_CALLBACK_LOGIN_URL;
         }
+    }
+
+    private HttpServletRequest getCurrentHttpRequest() {
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            log.error("OAuth 인증 요청이 HTTP 요청 컨텍스트 외부에서 호출됨");
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+        return attributes.getRequest();
     }
 
     private ResponseEntity<String> requestAccessToken(String code) {
@@ -141,7 +148,7 @@ public class GoogleOauth implements SocialOauth {
             if (responseEntity.getStatusCode() == HttpStatus.OK) {
                 return responseEntity;
             } else {
-                log.error("Google Access Token Request Failed: {}", responseEntity.getBody());
+                log.error("Google Access Token Request Failed with status: {}", responseEntity.getStatusCode());
                 throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
             }
         } catch (RestClientException e) {

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -8,9 +8,12 @@ import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIA
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.opus.opus.global.util.AuthRedisUtil;
 import com.opus.opus.global.util.oauth.dto.GoogleOAuthToken;
 import com.opus.opus.global.util.oauth.exception.OAuthException;
 import jakarta.servlet.http.HttpServletRequest;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -55,15 +58,24 @@ public class GoogleOauth implements SocialOauth {
     private final ObjectMapper objectMapper;
     private final RestTemplate restTemplate;
 
+    private final AuthRedisUtil authRedisUtil;
+
     @Override
     public String getOauthRedirectURL() {
         String callbackUrl = determineCallbackUrl();
+
+        String state = UUID.randomUUID().toString();
+
+        // Redis에 state 저장 (5분 TTL)
+        String stateKey = "oauth:state:" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
 
         return UriComponentsBuilder.fromUriString(GOOGLE_SNS_URL)
                 .queryParam("scope", GOOGLE_DATA_ACCESS_SCOPE)
                 .queryParam("response_type", "code")
                 .queryParam("client_id", GOOGLE_SNS_CLIENT_ID)
                 .queryParam("redirect_uri", callbackUrl)
+                .queryParam("state", state)
                 .build()
                 .toUriString();
     }

--- a/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/GoogleOauth.java
@@ -5,12 +5,12 @@ import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILE
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
-import static org.hibernate.internal.util.JdbcExceptionHelper.extractErrorCode;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.opus.opus.global.util.AuthRedisUtil;
 import com.opus.opus.global.util.oauth.dto.GoogleOAuthToken;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
 import com.opus.opus.global.util.oauth.exception.OAuthException;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.UUID;
@@ -84,15 +84,65 @@ public class GoogleOauth implements SocialOauth {
     }
 
     @Override
-    public <T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
-        ResponseEntity<String> requestAccessToken = requestAccessToken(code);
-        GoogleOAuthToken oAuthToken = getAccessToken(requestAccessToken);
-        ResponseEntity<String> userInfo = requestUserInfo(oAuthToken);
-        return getUserInfo(userInfo, userType);
+    public <T> OAuthResult<T> getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException {
+        ResponseEntity<String> accessTokenResponse = requestAccessToken(code);
+        GoogleOAuthToken oAuthToken = getAccessToken(accessTokenResponse);
+        ResponseEntity<String> userInfoResponse = requestUserInfo(oAuthToken);
+        T userInfo = getUserInfo(userInfoResponse, userType);
+
+        return new OAuthResult<>(userInfo, oAuthToken.accessToken(), oAuthToken.refreshToken());
     }
 
     public String createOAuthStateKey(String sessionId, String state) {
         return "oauth:state:" + sessionId + ":" + state;
+    }
+
+    public boolean revokeToken(final String token) {
+        final String GOOGLE_REVOKE_URL = "https://oauth2.googleapis.com/revoke";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("token", token);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_REVOKE_URL, requestEntity, String.class);
+            if (response.getStatusCode() == HttpStatus.OK) {
+                log.debug("Google 토큰 연동 해제 성공");
+                return true;
+            }
+            return false;
+        } catch (RestClientException e) {
+            log.error("Google 토큰 연동 해제 실패: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    public String refreshAccessToken(final String refreshToken) {
+        final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("client_id", GOOGLE_SNS_CLIENT_ID);
+        params.add("client_secret", GOOGLE_SNS_CLIENT_SECRET);
+        params.add("refresh_token", refreshToken);
+        params.add("grant_type", "refresh_token");
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        HttpEntity<MultiValueMap<String, String>> requestEntity = new HttpEntity<>(params, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(GOOGLE_TOKEN_URL, requestEntity, String.class);
+            GoogleOAuthToken newToken = objectMapper.readValue(response.getBody(), GoogleOAuthToken.class);
+            return newToken.accessToken();
+        } catch (Exception e) {
+            log.error("Google Access Token 갱신 실패: {}", e.getMessage());
+            return null;
+        }
     }
 
     private String determineCallbackUrl() {

--- a/src/main/java/com/opus/opus/global/util/oauth/component/SocialOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/SocialOauth.java
@@ -1,22 +1,23 @@
 package com.opus.opus.global.util.oauth.component;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
 
 public interface SocialOauth {
 
-	/**
-	 * 각 소셜 로그인 페이지로 리다이렉트할 URL을 빌드합니다.
-	 * 사용자로부터 로그인 요청을 받아 소셜 로그인 서버 인증용 코드를 요청합니다.
-	 */
-	String getOauthRedirectURL();
+    /**
+     * 각 소셜 로그인 페이지로 리다이렉트할 URL을 빌드합니다.
+     * 사용자로부터 로그인 요청을 받아 소셜 로그인 서버 인증용 코드를 요청합니다.
+     */
+    String getOauthRedirectURL();
 
-	/**
-	 * 인가 코드를 사용하여 사용자 정보를 가져옵니다.
-	 * 내부적으로 액세스 토큰 요청 -> 사용자 정보 요청 과정을 처리합니다.
-	 * @param code 인가 코드
-	 * @param userType 반환할 사용자 객체 클래스 (예: GoogleUser.class)
-	 * @return 파싱된 사용자 객체
-	 * @throws JsonProcessingException JSON 파싱 실패 시 발생
-	 */
-	<T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException;
+    /**
+     * 인가 코드를 사용하여 사용자 정보와 토큰을 가져옵니다.
+     * 내부적으로 액세스 토큰 요청 -> 사용자 정보 요청 과정을 처리합니다.
+     * @param code 인가 코드
+     * @param userType 반환할 사용자 객체 클래스 (예: GoogleUser.class)
+     * @return 사용자 정보와 토큰을 담은 OAuthResult
+     * @throws JsonProcessingException JSON 파싱 실패 시 발생
+     */
+    <T> OAuthResult<T> getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException;
 }

--- a/src/main/java/com/opus/opus/global/util/oauth/component/SocialOauth.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/component/SocialOauth.java
@@ -1,0 +1,22 @@
+package com.opus.opus.global.util.oauth.component;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+public interface SocialOauth {
+
+	/**
+	 * 각 소셜 로그인 페이지로 리다이렉트할 URL을 빌드합니다.
+	 * 사용자로부터 로그인 요청을 받아 소셜 로그인 서버 인증용 코드를 요청합니다.
+	 */
+	String getOauthRedirectURL();
+
+	/**
+	 * 인가 코드를 사용하여 사용자 정보를 가져옵니다.
+	 * 내부적으로 액세스 토큰 요청 -> 사용자 정보 요청 과정을 처리합니다.
+	 * @param code 인가 코드
+	 * @param userType 반환할 사용자 객체 클래스 (예: GoogleUser.class)
+	 * @return 파싱된 사용자 객체
+	 * @throws JsonProcessingException JSON 파싱 실패 시 발생
+	 */
+	<T> T getUserInfoByCode(String code, Class<T> userType) throws JsonProcessingException;
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleOAuthToken.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleOAuthToken.java
@@ -3,7 +3,10 @@ package com.opus.opus.global.util.oauth.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 public record GoogleOAuthToken(
-	@JsonProperty("access_token")
-	String accessToken
+        @JsonProperty("access_token")
+        String accessToken,
+
+        @JsonProperty("refresh_token")
+        String refreshToken
 ) {
 }

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleOAuthToken.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleOAuthToken.java
@@ -1,0 +1,9 @@
+package com.opus.opus.global.util.oauth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record GoogleOAuthToken(
+	@JsonProperty("access_token")
+	String accessToken
+) {
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleUser.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/GoogleUser.java
@@ -1,0 +1,7 @@
+package com.opus.opus.global.util.oauth.dto;
+
+public record GoogleUser(
+	String email,
+	String name
+) {
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/dto/OAuthResult.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/dto/OAuthResult.java
@@ -1,0 +1,8 @@
+package com.opus.opus.global.util.oauth.dto;
+
+public record OAuthResult<T>(
+        T userInfo,
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthException.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthException.java
@@ -1,0 +1,25 @@
+package com.opus.opus.global.util.oauth.exception;
+
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class OAuthException extends BaseException {
+
+	private final OAuthExceptionType exceptionType;
+
+	public OAuthException(final OAuthExceptionType exceptionType) {
+		super(exceptionType.errorMessage());
+		this.exceptionType = exceptionType;
+	}
+
+	public OAuthException(final OAuthExceptionType exceptionType, final String message) {
+		super(message);
+		this.exceptionType = exceptionType;
+	}
+
+	@Override
+	public BaseExceptionType exceptionType() {
+		return exceptionType;
+	}
+}

--- a/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthExceptionType.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthExceptionType.java
@@ -11,6 +11,7 @@ public enum OAuthExceptionType implements BaseExceptionType {
 	FAILED_TO_GET_SOCIAL_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 사용자 정보를 가져오는데 실패했습니다."),
 	INVALID_OAUTH_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth 토큰 타입입니다."),
 	OAUTH_AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증에 실패했습니다."),
+    USER_DENIED_AUTHORIZATION(HttpStatus.BAD_REQUEST, "사용자가 권한 요청을 거부했습니다."),
 	UNSUPPORTED_SOCIAL_LOGIN_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
 	;
 

--- a/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthExceptionType.java
+++ b/src/main/java/com/opus/opus/global/util/oauth/exception/OAuthExceptionType.java
@@ -1,0 +1,34 @@
+package com.opus.opus.global.util.oauth.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum OAuthExceptionType implements BaseExceptionType {
+
+	SOCIAL_LOGIN_FAILED_AUTH_CODE(HttpStatus.BAD_REQUEST, "소셜 로그인 인증 코드가 유효하지 않습니다."),
+	SOCIAL_LOGIN_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 서버와의 통신에 실패했습니다."),
+	FAILED_TO_GET_ACCESS_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "액세스 토큰을 가져오는데 실패했습니다."),
+	FAILED_TO_GET_SOCIAL_USER_INFO(HttpStatus.INTERNAL_SERVER_ERROR, "소셜 로그인 사용자 정보를 가져오는데 실패했습니다."),
+	INVALID_OAUTH_TOKEN_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 OAuth 토큰 타입입니다."),
+	OAUTH_AUTHORIZATION_FAILED(HttpStatus.UNAUTHORIZED, "소셜 로그인 인증에 실패했습니다."),
+	UNSUPPORTED_SOCIAL_LOGIN_TYPE(HttpStatus.BAD_REQUEST, "지원하지 않는 소셜 로그인 타입입니다."),
+	;
+
+	private final HttpStatus httpStatus;
+	private final String errorMessage;
+
+	OAuthExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+		this.httpStatus = httpStatus;
+		this.errorMessage = errorMessage;
+	}
+
+	@Override
+	public HttpStatus httpStatus() {
+		return httpStatus;
+	}
+
+	@Override
+	public String errorMessage() {
+		return errorMessage;
+	}
+}

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -13,7 +13,9 @@ import com.opus.opus.modules.member.application.dto.request.SignUpRequest;
 import com.opus.opus.modules.member.application.dto.response.EmailFindResponse;
 import com.opus.opus.modules.member.application.dto.response.SignInResponse;
 import jakarta.validation.Valid;
+import java.net.URI;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -22,6 +24,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Validated
 @RestController
@@ -78,6 +81,21 @@ public class MemberController {
     @GetMapping("/sign-in/{studentId}/email-find")
     public ResponseEntity<EmailFindResponse> getMyEmail(@PathVariable final String studentId) {
         final EmailFindResponse response = memberQueryService.getMyEmail(studentId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/oauth/google")
+    public ResponseEntity<Void> googleOAuthRedirect() {
+        final String redirectURL = memberCommandService.getGoogleOAuthRedirectURL();
+
+        URI uri = UriComponentsBuilder.fromUriString(redirectURL).encode().build().toUri();
+
+        return ResponseEntity.status(HttpStatus.FOUND).location(uri).build();
+    }
+
+    @GetMapping("/oauth/google/callback")
+    public ResponseEntity<SignInResponse> googleOAuthCallback(final String code) {
+        final SignInResponse response = memberCommandService.getGoogleOAuthCallback(code);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -1,8 +1,10 @@
 package com.opus.opus.modules.member.api;
 
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.modules.member.application.MemberCommandService;
 import com.opus.opus.modules.member.application.MemberQueryService;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
@@ -94,8 +96,12 @@ public class MemberController {
     }
 
     @GetMapping("/oauth/google/callback")
-    public ResponseEntity<SignInResponse> googleOAuthCallback(final String code) {
-        final SignInResponse response = memberCommandService.getGoogleOAuthCallback(code);
+    public ResponseEntity<SignInResponse> googleOAuthCallback(
+            final String code,
+            final String state,
+            final String error
+    ) {
+        final SignInResponse response = memberCommandService.getGoogleOAuthCallback(code, state, error);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -1,10 +1,8 @@
 package com.opus.opus.modules.member.api;
 
-import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
-import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.modules.member.application.MemberCommandService;
 import com.opus.opus.modules.member.application.MemberQueryService;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -1,6 +1,8 @@
 package com.opus.opus.modules.member.application;
 
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_CHANGE_SAME_PASSWORD;
@@ -157,8 +159,10 @@ public class MemberCommandService {
         }
     }
 
-    public SignInResponse getGoogleOAuthCallback(final String code) {
+    public SignInResponse getGoogleOAuthCallback(final String code, final String state, final String error) {
         try {
+            validateGoogleOAuthRequest(code, state, error);
+
             final GoogleUser googleUser = googleOauth.getUserInfoByCode(code, GoogleUser.class);
 
             return memberRepository.findByEmail(googleUser.email())
@@ -294,5 +298,32 @@ public class MemberCommandService {
 
     private static String signInVerifiedKey(final String email) {
         return SIGNIN_EMAIL_VERIFIED_KEY_PREFIX + email;
+    }
+
+    private void validateGoogleOAuthRequest(final String code, final String state, final String error) {
+        validateState(state);
+
+        if (error != null) {
+            throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
+        }
+
+        if (code == null || code.isBlank()) {
+            throw new OAuthException(SOCIAL_LOGIN_FAILED_AUTH_CODE);
+        }
+    }
+
+    private void validateState(final String state) {
+        if (state == null || state.isBlank()) {
+            throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
+        }
+
+        String stateKey = "oauth:state:" + state;
+        String storedState = authRedisUtil.get(stateKey);
+
+        if (storedState == null) {
+            throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
+        }
+
+        authRedisUtil.delete(stateKey);
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -1,5 +1,7 @@
 package com.opus.opus.modules.member.application;
 
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILED_TO_GET_SOCIAL_USER_INFO;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_CHANGE_SAME_PASSWORD;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
@@ -7,9 +9,13 @@ import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_VERIFIED_EMAIL_AUTH;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.opus.opus.global.security.JwtProvider;
 import com.opus.opus.global.util.AuthRedisUtil;
 import com.opus.opus.global.util.MailUtil;
+import com.opus.opus.global.util.oauth.component.GoogleOauth;
+import com.opus.opus.global.util.oauth.dto.GoogleUser;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthRequest;
@@ -26,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -45,10 +52,12 @@ public class MemberCommandService {
     private final JwtProvider jwtProvider;
     private final MailUtil mailUtil;
     private final AuthRedisUtil authRedisUtil;
+    private final GoogleOauth googleOauth;
 
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
     private static final int AUTH_CODE_LENGTH = 10;
     private static final char[] AUTH_CODE_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+    private static final String PASSWORD_POOL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*";
 
     private static final long SIGNUP_AUTH_CODE_TTL = 5L;
     private static final long SIGNUP_VERIFIED_TTL = 10L;
@@ -138,6 +147,72 @@ public class MemberCommandService {
         member.updatePassword(passwordEncoder.encode(request.newPassword()));
 
         authRedisUtil.delete(signInVerifiedKey(email));
+    }
+
+    public String getGoogleOAuthRedirectURL() {
+        try {
+            return googleOauth.getOauthRedirectURL();
+        } catch (Exception e) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    public SignInResponse getGoogleOAuthCallback(final String code) {
+        try {
+            final GoogleUser googleUser = googleOauth.getUserInfoByCode(code, GoogleUser.class);
+
+            return memberRepository.findByEmail(googleUser.email())
+                    .map(this::processExistingMemberLogin) // 기존 회원 로그인 처리
+                    .orElseGet(() -> processNewMemberSignUp(googleUser)); // 새로운 회원 가입 처리
+
+        } catch (JsonProcessingException e) {
+            throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
+        } catch (Exception e) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private SignInResponse processExistingMemberLogin(final Member member) {
+        final List<String> roles = member.getRoles().stream()
+                .map(MemberRoleType::toString)
+                .toList();
+        final String token = jwtProvider.createToken(String.valueOf(member.getId()), roles, member.getName());
+
+        return SignInResponse.from(member, token);
+    }
+
+    private SignInResponse processNewMemberSignUp(final GoogleUser googleUser) {
+        try {
+            final Member newMember = getRegisterNewMember(googleUser.name(), googleUser.email());
+            return processExistingMemberLogin(newMember);
+
+        } catch (Exception e) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+    }
+
+    private Member getRegisterNewMember(final String name, final String email) {
+        final String randomPassword = generateRandomPassword();
+        final String uniqueStudentId = "fake_" + UUID.randomUUID().toString().replace("-", "").substring(0, 10);
+
+        return memberRepository.save(Member.builder()
+                .name(name)
+                .studentId(uniqueStudentId)
+                .email(email)
+                .password(randomPassword)
+                .roles(Set.of(ROLE_회원))
+                .build());
+    }
+
+    private String generateRandomPassword() {
+        final int passwordLength = 32;
+
+        StringBuilder password = new StringBuilder();
+        for (int i = 0; i < passwordLength; i++) {
+            password.append(PASSWORD_POOL.charAt(SECURE_RANDOM.nextInt(PASSWORD_POOL.length())));
+        }
+
+        return passwordEncoder.encode(password.toString());
     }
 
     private void verifyVerifiedKey(final String verifiedKey) {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -30,6 +30,7 @@ import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.MemberRoleType;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
 import com.opus.opus.modules.member.exception.MemberException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 @Service
 @Transactional
@@ -318,7 +321,11 @@ public class MemberCommandService {
             throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
         }
 
-        String stateKey = "oauth:state:" + state;
+        ServletRequestAttributes attributes =
+                (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        HttpServletRequest request = attributes.getRequest();
+        String sessionId = request.getSession().getId();
+        String stateKey = "oauth:state:" + sessionId + ":" + state;
         String storedState = authRedisUtil.get(stateKey);
 
         if (storedState == null) {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -173,6 +173,8 @@ public class MemberCommandService {
                     .map(this::processExistingMemberLogin) // 기존 회원 로그인 처리
                     .orElseGet(() -> processNewMemberSignUp(googleUser)); // 새로운 회원 가입 처리
 
+        } catch (OAuthException e) {
+            throw e;
         } catch (JsonProcessingException e) {
             throw new OAuthException(FAILED_TO_GET_SOCIAL_USER_INFO);
         } catch (Exception e) {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -4,6 +4,7 @@ import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.FAILE
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
 import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_SERVER_ERROR;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.USER_DENIED_AUTHORIZATION;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_회원;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_CHANGE_SAME_PASSWORD;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
@@ -304,7 +305,7 @@ public class MemberCommandService {
         validateState(state);
 
         if (error != null) {
-            throw new OAuthException(OAUTH_AUTHORIZATION_FAILED);
+            throw new OAuthException(USER_DENIED_AUTHORIZATION);
         }
 
         if (code == null || code.isBlank()) {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -325,6 +325,10 @@ public class MemberCommandService {
 
         ServletRequestAttributes attributes =
                 (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attributes == null) {
+            throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
+        }
+
         HttpServletRequest request = attributes.getRequest();
         String sessionId = request.getSession().getId();
         String stateKey = "oauth:state:" + sessionId + ":" + state;

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -331,7 +331,7 @@ public class MemberCommandService {
 
         HttpServletRequest request = attributes.getRequest();
         String sessionId = request.getSession().getId();
-        String stateKey = "oauth:state:" + sessionId + ":" + state;
+        String stateKey = googleOauth.createOAuthStateKey(sessionId, state);
         String storedState = authRedisUtil.get(stateKey);
 
         if (storedState == null) {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -18,6 +18,7 @@ import com.opus.opus.global.util.AuthRedisUtil;
 import com.opus.opus.global.util.MailUtil;
 import com.opus.opus.global.util.oauth.component.GoogleOauth;
 import com.opus.opus.global.util.oauth.dto.GoogleUser;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
 import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
@@ -67,6 +68,8 @@ public class MemberCommandService {
 
     private static final long SIGNUP_AUTH_CODE_TTL = 5L;
     private static final long SIGNUP_VERIFIED_TTL = 10L;
+    private static final long GOOGLE_TOKEN_TTL = 3L; // 3시간
+    private static final String GOOGLE_TOKEN_KEY_PREFIX = "oauth:google:token:";
     private static final String SIGNUP_EMAIL_AUTH_KEY_PREFIX = "signup:email:auth:";
     private static final String SIGNUP_EMAIL_VERIFIED_KEY_PREFIX = "signup:email:verified:";
 
@@ -167,11 +170,12 @@ public class MemberCommandService {
         try {
             validateGoogleOAuthRequest(code, state, error);
 
-            final GoogleUser googleUser = googleOauth.getUserInfoByCode(code, GoogleUser.class);
+            final OAuthResult<GoogleUser> result = googleOauth.getUserInfoByCode(code, GoogleUser.class);
+            final GoogleUser googleUser = result.userInfo();
 
             return memberRepository.findByEmail(googleUser.email())
-                    .map(this::processExistingMemberLogin) // 기존 회원 로그인 처리
-                    .orElseGet(() -> processNewMemberSignUp(googleUser)); // 새로운 회원 가입 처리
+                    .map(member -> processExistingMemberLogin(member, result))
+                    .orElseGet(() -> processNewMemberSignUp(googleUser, result));
 
         } catch (OAuthException e) {
             throw e;
@@ -182,7 +186,32 @@ public class MemberCommandService {
         }
     }
 
-    private SignInResponse processExistingMemberLogin(final Member member) {
+    public void unlinkGoogleAccount(final Long memberId) {
+        final String key = GOOGLE_TOKEN_KEY_PREFIX + memberId;
+        final String storedValue = authRedisUtil.get(key);
+
+        if (storedValue == null) { // 구글 로그인하지 않은 회원인 경우
+            return;
+        }
+
+        String[] tokens = storedValue.split(":");
+        final String accessToken = tokens[0];
+        final String refreshToken = tokens[1];
+        boolean success = googleOauth.revokeToken(accessToken);
+
+        if (!success && refreshToken != null) {
+            String newAccessToken = googleOauth.refreshAccessToken(refreshToken);
+            if (newAccessToken != null) {
+                googleOauth.revokeToken(newAccessToken);
+            }
+        }
+
+        authRedisUtil.delete(key);
+    }
+
+    private SignInResponse processExistingMemberLogin(final Member member, final OAuthResult<?> oAuthResult) {
+        saveGoogleToken(member.getId(), oAuthResult);
+
         final List<String> roles = member.getRoles().stream()
                 .map(MemberRoleType::toString)
                 .toList();
@@ -191,10 +220,10 @@ public class MemberCommandService {
         return SignInResponse.from(member, token);
     }
 
-    private SignInResponse processNewMemberSignUp(final GoogleUser googleUser) {
+    private SignInResponse processNewMemberSignUp(final GoogleUser googleUser, final OAuthResult<?> oAuthResult) {
         try {
             final Member newMember = getRegisterNewMember(googleUser.name(), googleUser.email());
-            return processExistingMemberLogin(newMember);
+            return processExistingMemberLogin(newMember, oAuthResult);
 
         } catch (Exception e) {
             throw new OAuthException(SOCIAL_LOGIN_SERVER_ERROR);
@@ -339,5 +368,11 @@ public class MemberCommandService {
         }
 
         authRedisUtil.delete(stateKey);
+    }
+
+    private void saveGoogleToken(final Long memberId, final OAuthResult<?> oAuthResult) {
+        final String key = GOOGLE_TOKEN_KEY_PREFIX + memberId;
+        final String value = oAuthResult.accessToken() + ":" + oAuthResult.refreshToken();
+        authRedisUtil.set(key, value, GOOGLE_TOKEN_TTL, TimeUnit.HOURS);
     }
 }

--- a/src/test/java/com/opus/opus/helper/IntegrationTest.java
+++ b/src/test/java/com/opus/opus/helper/IntegrationTest.java
@@ -3,6 +3,7 @@ package com.opus.opus.helper;
 import com.opus.opus.global.security.JwtProvider;
 import com.opus.opus.global.util.MailUtil;
 import com.opus.opus.global.util.AuthRedisUtil;
+import com.opus.opus.global.util.oauth.component.GoogleOauth;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -30,6 +31,9 @@ public abstract class IntegrationTest extends ApiTestHelper {
 
     @MockitoBean
     private MailUtil mailUtil;
+
+    @MockitoBean
+    protected GoogleOauth googleOauth;
 
     @BeforeEach
     void setUp(final WebApplicationContext context) {

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.opus.opus.global.util.oauth.component.GoogleOauth;
 import com.opus.opus.global.util.oauth.dto.GoogleUser;
 import com.opus.opus.global.util.oauth.dto.OAuthResult;
 import com.opus.opus.global.util.oauth.exception.OAuthException;
@@ -35,7 +34,6 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.web.context.request.RequestContextHolder;
@@ -48,9 +46,6 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
     @Autowired
     private MemberRepository memberRepository;
-
-    @MockitoBean
-    private GoogleOauth googleOauth;
 
     private Member teamLeader;
     private EmailAuthRequest emailAuthRequest;
@@ -225,8 +220,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] state가 null이면 인증 실패한다")
     void state가_null이면_인증_실패한다() {
-        String code = "code";
-        String state = null;
+        final String code = "code";
+        final String state = null;
 
         assertThatThrownBy(() -> {
             memberCommandService.getGoogleOAuthCallback(code, state, null);
@@ -237,8 +232,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] state가 빈 문자열이면 인증 실패한다")
     void state가_빈_문자열이면_인증_실패한다() {
-        String code = "code";
-        String state = "";
+        final String code = "code";
+        final String state = "";
 
         assertThatThrownBy(() -> {
             memberCommandService.getGoogleOAuthCallback(code, state, null);
@@ -249,8 +244,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] Redis에 저장되지 않은 state면 인증 실패한다")
     void Redis에_저장되지_않은_state면_인증_실패한다() {
-        String code = "code";
-        String state = "invalidState";
+        final String code = "code";
+        final String state = "invalidState";
 
         assertThatThrownBy(() -> {
             memberCommandService.getGoogleOAuthCallback(code, state, null);
@@ -262,9 +257,9 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] 다른 세션의 state로는 인증 실패한다 (CSRF 방어)")
     void 다른_세션의_state로는_인증_실패한다() {
         setUpMockRequest();
-        String attackerSessionId = "attacker-session-id";
-        String state = "state";
-        String attackerStateKey = "oauth:state:" + attackerSessionId + ":" + state;
+        final String attackerSessionId = "attacker-session-id";
+        final String state = "state";
+        final String attackerStateKey = "oauth:state:" + attackerSessionId + ":" + state;
         authRedisUtil.set(attackerStateKey, "valid", 5L, TimeUnit.MINUTES);
 
         assertThatThrownBy(() -> {
@@ -277,8 +272,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] error 파라미터가 있으면 사용자 권한 거부로 처리된다")
     void error_파라미터가_있으면_사용자_권한_거부로_처리된다() {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
 
         assertThatThrownBy(() -> {
@@ -291,8 +286,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] code가 null이면 인증 실패한다")
     void code가_null이면_인증_실패한다() {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
 
         assertThatThrownBy(() -> {
@@ -305,8 +300,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] code가 빈 문자열이면 인증 실패한다")
     void code가_빈_문자열이면_인증_실패한다() {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
 
         assertThatThrownBy(() -> {
@@ -319,11 +314,11 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 기존 회원은 OAuth 로그인 처리된다")
     void 기존_회원은_OAuth_로그인_처리된다() throws Exception {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
-        GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
-        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
+        final GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
                 .thenReturn(mockResult);
 
@@ -338,11 +333,11 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 신규 회원은 자동 가입 후 OAuth 로그인 처리된다")
     void 신규_회원은_자동_가입_후_OAuth_로그인_처리된다() throws Exception {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
-        GoogleUser mockGoogleUser = new GoogleUser("kty@gmail.com", "김태윤");
-        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
+        final GoogleUser mockGoogleUser = new GoogleUser("kty@gmail.com", "김태윤");
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
                 .thenReturn(mockResult);
 
@@ -359,11 +354,11 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 검증 성공 시 state가 Redis에서 삭제된다")
     void 검증_성공_시_state가_Redis에서_삭제된다() throws Exception {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
-        GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
-        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
+        final GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
                 .thenReturn(mockResult);
 
@@ -376,17 +371,17 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] OAuth 로그인 시 토큰이 Redis에 저장된다")
     void OAuth_로그인_시_토큰이_Redis에_저장된다() throws Exception {
         setUpMockRequest();
-        String state = "state";
-        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        final String state = "state";
+        final String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
-        GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
-        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "testAccessToken", "testRefreshToken");
+        final GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        final OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "testAccessToken", "testRefreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
                 .thenReturn(mockResult);
 
         memberCommandService.getGoogleOAuthCallback("code", state, null);
 
-        String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        final String tokenKey = "oauth:google:token:" + teamLeader.getId();
         assertThat(authRedisUtil.exists(tokenKey)).isTrue();
         assertThat(authRedisUtil.get(tokenKey)).isEqualTo("testAccessToken:testRefreshToken");
     }
@@ -394,7 +389,7 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 구글 연동 해제 시 Redis 토큰이 삭제된다")
     void 구글_연동_해제_시_Redis_토큰이_삭제된다() {
-        String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        final String tokenKey = "oauth:google:token:" + teamLeader.getId();
         authRedisUtil.set(tokenKey, "accessToken:refreshToken", 3L, TimeUnit.HOURS);
 
         memberCommandService.unlinkGoogleAccount(teamLeader.getId());
@@ -405,7 +400,7 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 구글 연동 해제 시 revokeToken이 호출된다")
     void 구글_연동_해제_시_revokeToken이_호출된다() {
-        String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        final String tokenKey = "oauth:google:token:" + teamLeader.getId();
         authRedisUtil.set(tokenKey, "testAccessToken:testRefreshToken", 3L, TimeUnit.HOURS);
 
         memberCommandService.unlinkGoogleAccount(teamLeader.getId());

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -1,12 +1,21 @@
 package com.opus.opus.member.application;
 
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.SOCIAL_LOGIN_FAILED_AUTH_CODE;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.USER_DENIED_AUTHORIZATION;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_VERIFIED_EMAIL_AUTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
+import com.opus.opus.global.util.oauth.component.GoogleOauth;
+import com.opus.opus.global.util.oauth.dto.GoogleUser;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.member.application.MemberCommandService;
@@ -24,6 +33,11 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
 public class MemberCommandServiceTest extends IntegrationTest {
 
@@ -33,13 +47,27 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Autowired
     private MemberRepository memberRepository;
 
+    @MockitoBean
+    private GoogleOauth googleOauth;
+
     private Member teamLeader;
     private EmailAuthRequest emailAuthRequest;
+    private MockHttpServletRequest mockRequest;
 
     @BeforeEach
     void setUp() {
         teamLeader = memberRepository.save(MemberFixture.createMember());
         emailAuthRequest = new EmailAuthRequest("qwer1234@pusan.ac.kr");
+    }
+
+    private void setUpMockRequest() {
+        mockRequest = new MockHttpServletRequest();
+        mockRequest.setSession(new MockHttpSession());
+        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(mockRequest));
+    }
+
+    private String getSessionId() {
+        return mockRequest.getSession().getId();
     }
 
     @Test
@@ -188,5 +216,152 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
         assertThat(response.memberId()).isEqualTo(teamLeader.getId());
         assertThat(response.token()).isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] state가 null이면 인증 실패한다")
+    void state가_null이면_인증_실패한다() {
+        String code = "code";
+        String state = null;
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(code, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] state가 빈 문자열이면 인증 실패한다")
+    void state가_빈_문자열이면_인증_실패한다() {
+        String code = "code";
+        String state = "";
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(code, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] Redis에 저장되지 않은 state면 인증 실패한다")
+    void Redis에_저장되지_않은_state면_인증_실패한다() {
+        String code = "code";
+        String state = "invalidState";
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(code, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 세션의 state로는 인증 실패한다 (CSRF 방어)")
+    void 다른_세션의_state로는_인증_실패한다() {
+        setUpMockRequest();
+        String attackerSessionId = "attacker-session-id";
+        String state = "state";
+        String attackerStateKey = "oauth:state:" + attackerSessionId + ":" + state;
+        authRedisUtil.set(attackerStateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback("code", state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(OAUTH_AUTHORIZATION_FAILED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] error 파라미터가 있으면 사용자 권한 거부로 처리된다")
+    void error_파라미터가_있으면_사용자_권한_거부로_처리된다() {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback("code", state, "access_denied");
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(USER_DENIED_AUTHORIZATION.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] code가 null이면 인증 실패한다")
+    void code가_null이면_인증_실패한다() {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback(null, state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(SOCIAL_LOGIN_FAILED_AUTH_CODE.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] code가 빈 문자열이면 인증 실패한다")
+    void code가_빈_문자열이면_인증_실패한다() {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+
+        assertThatThrownBy(() -> {
+            memberCommandService.getGoogleOAuthCallback("", state, null);
+        }).isInstanceOf(OAuthException.class)
+                .hasMessage(SOCIAL_LOGIN_FAILED_AUTH_CODE.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 기존 회원은 OAuth 로그인 처리된다")
+    void 기존_회원은_OAuth_로그인_처리된다() throws Exception {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockGoogleUser);
+
+        SignInResponse response = memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        assertThat(response.memberId()).isEqualTo(teamLeader.getId());
+        assertThat(response.token()).isNotEmpty();
+        assertThat(memberRepository.count()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("[성공] 신규 회원은 자동 가입 후 OAuth 로그인 처리된다")
+    void 신규_회원은_자동_가입_후_OAuth_로그인_처리된다() throws Exception {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        GoogleUser mockGoogleUser = new GoogleUser("kty@gmail.com", "김태윤");
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockGoogleUser);
+
+        SignInResponse response = memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        assertThat(response.name()).isEqualTo("김태윤");
+        assertThat(response.token()).isNotEmpty();
+        assertThat(memberRepository.count()).isEqualTo(2);
+        Member newMember = memberRepository.findByEmail("kty@gmail.com").orElseThrow();
+        assertThat(newMember.getStudentId()).startsWith("fake_");
+    }
+
+    @Test
+    @DisplayName("[성공] 검증 성공 시 state가 Redis에서 삭제된다")
+    void 검증_성공_시_state가_Redis에서_삭제된다() throws Exception {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockGoogleUser);
+
+        memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        assertThat(authRedisUtil.exists(stateKey)).isFalse();
     }
 }

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -11,10 +11,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.opus.opus.global.util.oauth.component.GoogleOauth;
 import com.opus.opus.global.util.oauth.dto.GoogleUser;
+import com.opus.opus.global.util.oauth.dto.OAuthResult;
 import com.opus.opus.global.util.oauth.exception.OAuthException;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
@@ -58,6 +60,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     void setUp() {
         teamLeader = memberRepository.save(MemberFixture.createMember());
         emailAuthRequest = new EmailAuthRequest("qwer1234@pusan.ac.kr");
+
+        when(googleOauth.createOAuthStateKey(anyString(), anyString())).thenCallRealMethod(); // state key값이 null이 되는 문제 방지하기 위해 실제 메서드 호출
     }
 
     private void setUpMockRequest() {
@@ -319,8 +323,9 @@ public class MemberCommandServiceTest extends IntegrationTest {
         String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
         GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
-                .thenReturn(mockGoogleUser);
+                .thenReturn(mockResult);
 
         SignInResponse response = memberCommandService.getGoogleOAuthCallback("code", state, null);
 
@@ -337,8 +342,9 @@ public class MemberCommandServiceTest extends IntegrationTest {
         String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
         GoogleUser mockGoogleUser = new GoogleUser("kty@gmail.com", "김태윤");
+        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
-                .thenReturn(mockGoogleUser);
+                .thenReturn(mockResult);
 
         SignInResponse response = memberCommandService.getGoogleOAuthCallback("code", state, null);
 
@@ -357,11 +363,53 @@ public class MemberCommandServiceTest extends IntegrationTest {
         String stateKey = "oauth:state:" + getSessionId() + ":" + state;
         authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
         GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "accessToken", "refreshToken");
         when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
-                .thenReturn(mockGoogleUser);
+                .thenReturn(mockResult);
 
         memberCommandService.getGoogleOAuthCallback("code", state, null);
 
         assertThat(authRedisUtil.exists(stateKey)).isFalse();
+    }
+
+    @Test
+    @DisplayName("[성공] OAuth 로그인 시 토큰이 Redis에 저장된다")
+    void OAuth_로그인_시_토큰이_Redis에_저장된다() throws Exception {
+        setUpMockRequest();
+        String state = "state";
+        String stateKey = "oauth:state:" + getSessionId() + ":" + state;
+        authRedisUtil.set(stateKey, "valid", 5L, TimeUnit.MINUTES);
+        GoogleUser mockGoogleUser = new GoogleUser(teamLeader.getEmail(), teamLeader.getName());
+        OAuthResult<GoogleUser> mockResult = new OAuthResult<>(mockGoogleUser, "testAccessToken", "testRefreshToken");
+        when(googleOauth.getUserInfoByCode(anyString(), eq(GoogleUser.class)))
+                .thenReturn(mockResult);
+
+        memberCommandService.getGoogleOAuthCallback("code", state, null);
+
+        String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        assertThat(authRedisUtil.exists(tokenKey)).isTrue();
+        assertThat(authRedisUtil.get(tokenKey)).isEqualTo("testAccessToken:testRefreshToken");
+    }
+
+    @Test
+    @DisplayName("[성공] 구글 연동 해제 시 Redis 토큰이 삭제된다")
+    void 구글_연동_해제_시_Redis_토큰이_삭제된다() {
+        String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        authRedisUtil.set(tokenKey, "accessToken:refreshToken", 3L, TimeUnit.HOURS);
+
+        memberCommandService.unlinkGoogleAccount(teamLeader.getId());
+
+        assertThat(authRedisUtil.exists(tokenKey)).isFalse();
+    }
+
+    @Test
+    @DisplayName("[성공] 구글 연동 해제 시 revokeToken이 호출된다")
+    void 구글_연동_해제_시_revokeToken이_호출된다() {
+        String tokenKey = "oauth:google:token:" + teamLeader.getId();
+        authRedisUtil.set(tokenKey, "testAccessToken:testRefreshToken", 3L, TimeUnit.HOURS);
+
+        memberCommandService.unlinkGoogleAccount(teamLeader.getId());
+
+        verify(googleOauth).revokeToken("testAccessToken");
     }
 }

--- a/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
@@ -3,6 +3,9 @@ package com.opus.opus.restdocs.docs;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.OAUTH_AUTHORIZATION_FAILED;
+import static com.opus.opus.global.util.oauth.exception.OAuthExceptionType.USER_DENIED_AUTHORIZATION;
+import com.opus.opus.global.util.oauth.exception.OAuthException;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
@@ -15,6 +18,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -259,6 +263,81 @@ public class MemberApiDocsTest extends RestDocsTest {
                         ),
                         responseFields(
                                 stringFieldWithPath("email", "가입된 이메일")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] Google OAuth 리다이렉트 URL을 반환한다.")
+    void Google_OAuth_리다이렉트_URL을_반환한다() throws Exception {
+        String redirectURL = "https://accounts.google.com/o/oauth2/v2/auth?client_id=test&redirect_uri=http://localhost:8080/oauth/google/callback&response_type=code&scope=email+profile&state=test-state";
+
+        when(memberCommandService.getGoogleOAuthRedirectURL()).thenReturn(redirectURL);
+
+        mockMvc.perform(get("/oauth/google"))
+                .andExpect(status().isFound())
+                .andDo(document("oauth-google-redirect"));
+    }
+
+    @Test
+    @DisplayName("[성공] Google OAuth 콜백으로 로그인 처리된다.")
+    void Google_OAuth_콜백으로_로그인_처리된다() throws Exception {
+        SignInResponse response = new SignInResponse(member.getId(), member.getName(), "exampleToken", member.getRoles());
+
+        when(memberCommandService.getGoogleOAuthCallback(any(), any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .param("code", "authorization_code")
+                        .param("state", "state_token"))
+                .andExpect(status().isOk())
+                .andDo(document("oauth-google-callback",
+                        queryParameters(
+                                parameterWithName("code").description("Google 인가 코드"),
+                                parameterWithName("state").description("CSRF 방어용 상태 토큰")
+                        ),
+                        responseFields(
+                                numberFieldWithPath("memberId", "회원 고유 식별자"),
+                                stringFieldWithPath("name", "회원 이름"),
+                                stringFieldWithPath("token", "JWT 액세스 토큰"),
+                                arrayFieldWithPath("types", "회원 권한 목록(회원, 관리자)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] Google OAuth 콜백에서 state가 유효하지 않으면 401 에러를 반환한다.")
+    void Google_OAuth_콜백에서_state가_유효하지_않으면_에러를_반환한다() throws Exception {
+        willThrow(new OAuthException(OAUTH_AUTHORIZATION_FAILED))
+                .given(memberCommandService).getGoogleOAuthCallback(any(), any(), any());
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .param("code", "authorization_code")
+                        .param("state", "invalid_state"))
+                .andExpect(status().isUnauthorized())
+                .andDo(document("oauth-google-callback-fail-state",
+                        queryParameters(
+                                parameterWithName("code").description("Google 인가 코드"),
+                                parameterWithName("state").description("유효하지 않은 상태 토큰")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] Google OAuth 콜백에서 사용자가 권한을 거부하면 400 에러를 반환한다.")
+    void Google_OAuth_콜백에서_사용자가_권한을_거부하면_에러를_반환한다() throws Exception {
+        willThrow(new OAuthException(USER_DENIED_AUTHORIZATION))
+                .given(memberCommandService).getGoogleOAuthCallback(any(), any(), any());
+
+        mockMvc.perform(get("/oauth/google/callback")
+                        .param("code", "authorization_code")
+                        .param("state", "state_token")
+                        .param("error", "access_denied"))
+                .andExpect(status().isBadRequest())
+                .andDo(document("oauth-google-callback-fail-denied",
+                        queryParameters(
+                                parameterWithName("code").description("Google 인가 코드"),
+                                parameterWithName("state").description("상태 토큰"),
+                                parameterWithName("error").description("에러 코드 (사용자 권한 거부)")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #7 

## 📜 작업 내용
<img width="715" height="647" alt="스크린샷 2026-01-15 오전 11 46 24" src="https://github.com/user-attachments/assets/cedd7751-6b70-414d-b3ff-ed6cb21061ba" />

- 구글 로그인 시작 및 콜백 API를 구현하였습니다.
- 자세한 전체 플로우는 [여기](https://fuchsia-tabletop-6fc.notion.site/2e7dea889b8780398a51ddfdfee74c61?source=copy_link)를 클릭하시면 확인하실 수 있습니다.
- CSRF 공격 방어를 위해 왜 state를 사용하게 되었는지에 대한 정리도 [여기](https://fuchsia-tabletop-6fc.notion.site/CSRF-2e9dea889b87804c9d65e60a5c9c9e3d?source=copy_link)를 클릭하시면 확인하실 수 있습니다.

## 💬 리뷰 요구사항
### (1) 로컬에서 테스트
- 로컬에서 테스트하실 때는 반드시 설정 파일의 `callback-login-url`을 `http://localhost:8080/oauth/google/callback`로 설정하고 테스트해주세요!

### (2) 회원 탈퇴 시 구글 계정과의 연동 끊기 메서드의 부재
- 이번 PR에서 회원 탈퇴 시 구글 계정 연동 해제 기능까지 구현하고 싶었는데, 전체 회의 후 의견을 맞춰 봐야할 사항이 있어 아직 미구현된 상태입니다. 
- 문제상황은 다음과 같습니다.
1. 구글은 연동 해제 시 반드시 구글 OAuth의 AccessToken이 필요한데, AccessToken은 1시간이면 만료됩니다.
2. 우리 JWT 만료시간은 3시간인데 구글 AccessToken은 1시간이라, 회원 탈퇴 시점에 AccessToken이 이미 만료되어 없는 상황이 발생할 수 있습니다.
- 제안되는 해결 방식은 다음과 같습니다.
 구글 소셜 로그인 시 AccessToken + RefreshToken을 예를 들어 Redis에 `memberId : {accessToken, refreshToken}` 형태로 저장 (TTL 3시간)하여 회원 탈퇴 시 해당 토큰으로 연동을 해제한다. 
 이를 통한 장점은 DB 스키마 변경이 불필요하고, 3시간 후 Redis에서 삭제되므로 토큰 암호화 고민이 불필요합니다.

### (3) Spring Security를 활용하여 리팩토링
- 1월 마지막 주에 도전해보려고 합니다!


## ✨ 기타
- 구글 소셜 로그인의 볼륨이 이렇게나 클줄 몰랐는데... 그래도 얻어가는건 많은 거 같아서 뿌듯하네용!
