### PR TITLE
Bug/#56 대회 카테고리 삭제 시 에러 발생

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestCategory.java
@@ -17,7 +17,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
-@SQLDelete(sql = "UPDATE contest SET is_deleted = true where id = ?")
+@SQLDelete(sql = "UPDATE contest_category SET is_deleted = true WHERE id = ?")
 public class ContestCategory extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -28,7 +28,7 @@ public class ContestCategory extends BaseEntity {
 
     @Column(nullable = false)
     private Boolean isDeleted;
-    
+
     @Builder
     private ContestCategory(final String categoryName) {
         this.categoryName = categoryName;

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestTrack.java
@@ -21,7 +21,7 @@ import org.hibernate.annotations.SQLRestriction;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @SQLRestriction("is_deleted = false")
-@SQLDelete(sql = "UPDATE contest SET is_deleted = true where id = ?")
+@SQLDelete(sql = "UPDATE contest_track SET is_deleted = true WHERE id = ?")
 public class ContestTrack extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #56 

## 📜 작업 내용

- 대회 카테고리 삭제 시 발생하던 오류를 수정했습니다.
- ContestCategory의 소프트 삭제 대상이 contest 테이블이었던 문제를 수정했습니다.
- 동일한 문제가 있던 ContestTrack의 소프트 삭제 대상 테이블도 함께 수정했습니다.

## 💬 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요.

## ✨ 기타

- 엔티티를 복붙하여 수정하는 과정에서 놓친 부분이었습니다…