### PR TITLE
Bug/#58 대회 등록 시 에러 발생

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestTrackController.java
@@ -24,7 +24,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/contest/{contestId}/tracks")
+@RequestMapping("/contests/{contestId}/tracks")
 public class ContestTrackController {
 
     private final ContestTrackCommandService contestTrackCommandService;

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestRequest.java
@@ -1,11 +1,12 @@
 package com.opus.opus.modules.contest.application.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public record ContestRequest(
         @NotBlank(message = "대회명은 비어 있을 수 없습니다.")
         String contestName,
-        @NotBlank(message = "카테고리ID는 비어 있을 수 없습니다.")
+        @NotNull(message = "카테고리ID는 비어 있을 수 없습니다.")
         Long categoryId
 ) {
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #58 

## 📜 작업 내용

- 관리자가 대회 등록 시 401 에러가 발생하는 오류를 수정했습니다.
- ContestRequest의 categoryId 필드 검증 어노테이션을 NotBlank를 NotNull로 변경하여 수정하였습니다.

## 💬 리뷰 요구사항

- 확인 부탁드립니다!

## ✨ 기타

- 오늘의 한마디
