### PR TITLE
Feature/#78 메인페이지 사이드바 조회 api

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-category.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-category.adoc
@@ -87,3 +87,16 @@ include::{snippets}/get-all-contest-category/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-all-contest-category/response-fields.adoc[]
+
+== `GET`: 메인페이지 사이드바 조회
+
+NOTE: 모든 카테고리를 대회 목록과 함께 반환합니다. 대회가 없는 카테고리는 `contests` 가 빈 배열로 반환됩니다.
+
+.HTTP Request
+include::{snippets}/get-sidebar/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-sidebar/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-sidebar/response-fields.adoc[]

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestCategoryController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestCategoryController.java
@@ -4,6 +4,7 @@ import com.opus.opus.modules.contest.application.ContestCategoryCommandService;
 import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestCategoryRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCategoryResponse;
+import com.opus.opus.modules.contest.application.dto.response.SidebarResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -54,6 +55,12 @@ public class ContestCategoryController {
     @GetMapping
     public ResponseEntity<List<ContestCategoryResponse>> getAllContestCategories() {
         List<ContestCategoryResponse> response = contestCategoryQueryService.getAllContestCategories();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/sidebar")
+    public ResponseEntity<List<SidebarResponse>> getSidebar() {
+        final List<SidebarResponse> response = contestCategoryQueryService.getSidebar();
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryQueryService.java
@@ -1,9 +1,14 @@
 package com.opus.opus.modules.contest.application;
 
 import com.opus.opus.modules.contest.application.dto.response.ContestCategoryResponse;
+import com.opus.opus.modules.contest.application.dto.response.SidebarResponse;
+import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,12 +19,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestCategoryQueryService {
 
     private final ContestCategoryRepository contestCategoryRepository;
+    private final ContestRepository contestRepository;
 
     public List<ContestCategoryResponse> getAllContestCategories() {
         List<ContestCategory> ContestCategories = contestCategoryRepository.findAll();
 
         return ContestCategories.stream()
                 .map(ContestCategoryResponse::from)
+                .toList();
+    }
+
+    public List<SidebarResponse> getSidebar() {
+        final List<ContestCategory> categories = contestCategoryRepository.findAll();
+        final Map<Long, List<Contest>> contestsByCategory = contestRepository.findAll().stream()
+                .collect(Collectors.groupingBy(Contest::getCategoryId));
+
+        return categories.stream()
+                .map(category -> SidebarResponse.of(category, contestsByCategory.getOrDefault(category.getId(), List.of())))
                 .toList();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCategoryQueryService.java
@@ -6,6 +6,7 @@ import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -32,9 +33,11 @@ public class ContestCategoryQueryService {
     public List<SidebarResponse> getSidebar() {
         final List<ContestCategory> categories = contestCategoryRepository.findAll();
         final Map<Long, List<Contest>> contestsByCategory = contestRepository.findAll().stream()
+                .sorted(Comparator.comparing(Contest::getCreatedAt))
                 .collect(Collectors.groupingBy(Contest::getCategoryId));
 
         return categories.stream()
+                .sorted(Comparator.comparing(ContestCategory::getCreatedAt))
                 .map(category -> SidebarResponse.of(category, contestsByCategory.getOrDefault(category.getId(), List.of())))
                 .toList();
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/SidebarResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/SidebarResponse.java
@@ -1,0 +1,31 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import java.util.List;
+
+public record SidebarResponse(
+        Long categoryId,
+        String categoryName,
+        List<ContestItem> contests
+) {
+
+    public static SidebarResponse of(ContestCategory category, List<Contest> contests) {
+        return new SidebarResponse(
+                category.getId(),
+                category.getCategoryName(),
+                contests.stream().map(ContestItem::from).toList()
+        );
+    }
+
+    public record ContestItem(
+            Long contestId,
+            String contestName,
+            Boolean isCurrent
+    ) {
+        public static ContestItem from(Contest contest) {
+            return new ContestItem(contest.getId(), contest.getContestName(), contest.getIsCurrent());
+        }
+
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestCategoryQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestCategoryQueryServiceTest.java
@@ -1,0 +1,85 @@
+package com.opus.opus.contest.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.opus.opus.contest.ContestCategoryFixture;
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
+import com.opus.opus.modules.contest.application.dto.response.SidebarResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestCategory;
+import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContestCategoryQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestCategoryQueryService contestCategoryQueryService;
+
+    @Autowired
+    private ContestCategoryRepository contestCategoryRepository;
+
+    @Autowired
+    private ContestRepository contestRepository;
+
+    @Test
+    @DisplayName("[성공] 카테고리가 없으면 빈 리스트를 반환한다.")
+    void 카테고리가_없으면_빈_리스트를_반환한다() {
+        final List<SidebarResponse> response = contestCategoryQueryService.getSidebar();
+
+        assertThat(response).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 대회가 없는 카테고리는 contests가 빈 리스트로 반환된다.")
+    void 대회가_없는_카테고리는_contests가_빈_리스트로_반환된다() {
+        contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+
+        final List<SidebarResponse> response = contestCategoryQueryService.getSidebar();
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).contests()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 카테고리에 속한 대회들이 올바르게 반환된다.")
+    void 카테고리에_속한_대회들이_올바르게_반환된다() {
+        final ContestCategory category = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        contestRepository.save(ContestFixture.createContestWithCategoryId(category.getId()));
+        contestRepository.save(ContestFixture.createContestWithCategoryId(category.getId()));
+
+        final List<SidebarResponse> response = contestCategoryQueryService.getSidebar();
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).categoryId()).isEqualTo(category.getId());
+        assertThat(response.get(0).categoryName()).isEqualTo(category.getCategoryName());
+        assertThat(response.get(0).contests()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("[성공] 대회들이 각자의 카테고리에 맞게 분류된다.")
+    void 대회들이_각자의_카테고리에_맞게_분류된다() {
+        final ContestCategory categoryA = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        final ContestCategory categoryB = contestCategoryRepository.save(ContestCategoryFixture.createContestCategory());
+        contestRepository.save(ContestFixture.createContestWithCategoryId(categoryA.getId()));
+        contestRepository.save(ContestFixture.createContestWithCategoryId(categoryA.getId()));
+        contestRepository.save(ContestFixture.createContestWithCategoryId(categoryB.getId()));
+
+        final List<SidebarResponse> response = contestCategoryQueryService.getSidebar();
+
+        final SidebarResponse responseA = response.stream()
+                .filter(r -> r.categoryId().equals(categoryA.getId()))
+                .findFirst().orElseThrow();
+        final SidebarResponse responseB = response.stream()
+                .filter(r -> r.categoryId().equals(categoryB.getId()))
+                .findFirst().orElseThrow();
+
+        assertThat(responseA.contests()).hasSize(2);
+        assertThat(responseB.contests()).hasSize(1);
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestCategoryApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestCategoryApiDocsTest.java
@@ -23,6 +23,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.dto.request.ContestCategoryRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestCategoryResponse;
+import com.opus.opus.modules.contest.application.dto.response.SidebarResponse;
+import com.opus.opus.modules.contest.application.dto.response.SidebarResponse.ContestItem;
 import com.opus.opus.modules.contest.exception.ContestCategoryException;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.restdocs.RestDocsTest;
@@ -144,6 +146,34 @@ public class ContestCategoryApiDocsTest extends RestDocsTest {
                                 numberFieldWithPath("[].categoryId", "카테고리 ID"),
                                 stringFieldWithPath("[].categoryName", "카테고리 이름"),
                                 dateTimeFieldWithPath("[].updatedAt", "수정 일시")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 사이드바 조회는 카테고리별 대회 목록을 반환한다.")
+    void 사이드바_조회는_카테고리별_대회_목록을_반환한다() throws Exception {
+        final List<SidebarResponse> responses = List.of(
+                new SidebarResponse(1L, "창의융합 SW해커톤", List.of(
+                        new ContestItem(4L, "제6회 PNU 창의융합 SW해커톤", true),
+                        new ContestItem(3L, "제5회 PNU 창의융합 SW해커톤", false)
+                )),
+                new SidebarResponse(2L, "졸업과제", List.of())
+        );
+
+        when(contestCategoryQueryService.getSidebar()).thenReturn(responses);
+
+        mockMvc.perform(get("/categories/sidebar"))
+                .andExpect(status().isOk())
+                .andDo(document("get-sidebar",
+                        responseFields(
+                                arrayFieldWithPath("[]", "카테고리 목록"),
+                                numberFieldWithPath("[].categoryId", "카테고리 ID"),
+                                stringFieldWithPath("[].categoryName", "카테고리 이름"),
+                                arrayFieldWithPath("[].contests[]", "해당 카테고리의 대회 목록 (대회가 없으면 빈 배열)"),
+                                numberFieldWithPath("[].contests[].contestId", "대회 ID"),
+                                stringFieldWithPath("[].contests[].contestName", "대회 이름"),
+                                booleanFieldWithPath("[].contests[].isCurrent", "현재 진행 중인 대회 여부")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #78 

## 📜 작업 내용

- 메인 페이지의 사이드바를 조회하는 기능 개발

## 💬 리뷰 요구사항

- 카테고리나 대회가 증가해도 쿼리가 추가 발생되지 않도록 개발했습니다

