### PR TITLE
Feature/#32 회원 탈퇴 api 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -326,3 +326,46 @@ include::{snippets}/delete-member-profile-image/http-response.adoc[]
 
 .Request Headers
 include::{snippets}/delete-member-profile-image/request-headers.adoc[]
+
+== `DELETE`: 회원 탈퇴
+
+.HTTP Request
+include::{snippets}/withdraw-member/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/withdraw-member/http-response.adoc[]
+
+.Request Headers
+include::{snippets}/withdraw-member/request-headers.adoc[]
+
+== `DELETE`: 관리자 강제 회원 탈퇴
+
+NOTE: 관리자 권한(`ROLE_관리자`)이 필요합니다.
+
+.HTTP Request
+include::{snippets}/admin-withdraw-member/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/admin-withdraw-member/http-response.adoc[]
+
+.Request Headers
+include::{snippets}/admin-withdraw-member/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/admin-withdraw-member/path-parameters.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 존재하지 않는 회원 ID
+
+[%collapsible]
+
+====
+
+include::{snippets}/admin-withdraw-member-fail-not-found/http-request.adoc[]
+
+include::{snippets}/admin-withdraw-member-fail-not-found/http-response.adoc[]
+
+include::{snippets}/admin-withdraw-member-fail-not-found/path-parameters.adoc[]
+
+====

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import com.opus.opus.global.util.CookieUtil;
 import com.opus.opus.global.security.annotation.LoginMember;
+import org.springframework.security.access.annotation.Secured;
 import com.opus.opus.modules.member.application.MemberCommandService;
 import com.opus.opus.modules.member.application.MemberQueryService;
 import com.opus.opus.modules.member.application.StatisticsQueryService;
@@ -140,6 +141,19 @@ public class MemberController {
     public ResponseEntity<Void> deleteProfileImage(@LoginMember final Member member) {
         memberCommandService.deleteProfileImage(member);
 
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/members/me")
+    public ResponseEntity<Void> withdraw(@LoginMember final Member member) {
+        memberCommandService.withdraw(member);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @DeleteMapping("/admin/members/{memberId}")
+    public ResponseEntity<Void> withdrawMember(@PathVariable final Long memberId) {
+        memberCommandService.withdrawByAdmin(memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -21,13 +21,9 @@ import com.opus.opus.modules.member.application.dto.response.SignInResponse;
 import jakarta.servlet.http.HttpServletResponse;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.dto.ImageResponse;
-import com.opus.opus.modules.team.application.dto.request.PreviewDeleteRequest;
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -36,11 +32,9 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.web.util.UriComponentsBuilder;
 
 @Validated
 @RestController
@@ -145,14 +139,14 @@ public class MemberController {
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<Void> withdraw(@LoginMember final Member member) {
+    public ResponseEntity<Void> deleteMember(@LoginMember final Member member) {
         memberCommandService.withdraw(member);
         return ResponseEntity.noContent().build();
     }
 
     @Secured("ROLE_관리자")
     @DeleteMapping("/admin/members/{memberId}")
-    public ResponseEntity<Void> withdrawMember(@PathVariable final Long memberId) {
+    public ResponseEntity<Void> forceDeleteMember(@PathVariable final Long memberId) {
         memberCommandService.withdrawByAdmin(memberId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -264,6 +264,20 @@ public class MemberCommandService {
         member.updateStudentId(request.studentId());
     }
 
+    public void withdraw(final Member member) {
+        deleteMember(member);
+    }
+
+    public void withdrawByAdmin(final Long memberId) {
+        final Member member = memberConvenience.getValidateExistMember(memberId);
+        deleteMember(member);
+    }
+
+    private void deleteMember(final Member member) {
+        unlinkGoogleAccount(member.getId());
+        memberRepository.delete(member);
+    }
+
     private void unlinkGoogleAccount(final Long memberId) {
         googleTokenManager.get(memberId).ifPresent(token -> {
             try {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -274,7 +274,9 @@ public class MemberCommandService {
     }
 
     private void deleteMember(final Member member) {
-        unlinkGoogleAccount(member.getId());
+        if (member.isSocialMember()) {
+            unlinkGoogleAccount(member.getId());
+        }
         memberRepository.delete(member);
     }
 

--- a/src/test/java/com/opus/opus/helper/IntegrationTest.java
+++ b/src/test/java/com/opus/opus/helper/IntegrationTest.java
@@ -1,10 +1,11 @@
 package com.opus.opus.helper;
 
 import com.opus.opus.global.security.JwtProvider;
+import com.opus.opus.global.util.AuthRedisUtil;
 import com.opus.opus.global.util.CacheRedisUtil;
 import com.opus.opus.global.util.FileStorageUtil;
+import com.opus.opus.global.util.GoogleTokenManager;
 import com.opus.opus.global.util.MailUtil;
-import com.opus.opus.global.util.AuthRedisUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -32,6 +33,9 @@ public abstract class IntegrationTest extends ApiTestHelper {
 
     @MockitoBean
     private MailUtil mailUtil;
+
+    @MockitoBean
+    protected GoogleTokenManager googleTokenManager;
 
     @MockitoBean
     protected FileStorageUtil fileStorageUtil;

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -4,6 +4,7 @@ import static com.opus.opus.member.MemberFixture.createMemberWithUniqueNum;
 import static com.opus.opus.modules.file.domain.FileImageType.PROFILE;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.EMAIL_AUTH_LIMIT_EXCEEDED;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.GENERAL_MEMBER_CANNOT_USE_SOCIAL_LOGIN;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_UPDATE_STUDENT_ID;
@@ -404,5 +405,50 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
         // then
         verify(fileStorageUtil, never()).deleteFile(any());
+    }
+
+    @Test
+    @DisplayName("[성공] 일반 회원 탈퇴 시 DB에서 조회되지 않는다.")
+    void 일반_회원_탈퇴_시_DB에서_조회되지_않는다() {
+        // when
+        memberCommandService.withdraw(teamLeader);
+
+        // then
+        assertThat(memberRepository.findById(teamLeader.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 소셜 회원 탈퇴 시 DB에서 조회되지 않는다.")
+    void 소셜_회원_탈퇴_시_DB에서_조회되지_않는다() {
+        // given
+        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("social@pusan.ac.kr", "google-abc123"));
+
+        // when
+        memberCommandService.withdraw(socialMember);
+
+        // then
+        assertThat(memberRepository.findById(socialMember.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 관리자 강제 탈퇴 시 해당 회원은 DB에서 조회되지 않는다.")
+    void 관리자_강제_탈퇴_시_해당_회원은_DB에서_조회되지_않는다() {
+        // when
+        memberCommandService.withdrawByAdmin(teamLeader.getId());
+
+        // then
+        assertThat(memberRepository.findById(teamLeader.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 회원을 강제 탈퇴하면 예외가 발생한다.")
+    void 존재하지_않는_회원을_강제_탈퇴하면_예외가_발생한다() {
+        // given
+        final Long nonExistentId = 999999L;
+
+        // when & then
+        assertThatThrownBy(() -> memberCommandService.withdrawByAdmin(nonExistentId))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(NOT_FOUND_MEMBER.errorMessage());
     }
 }

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -422,12 +422,37 @@ public class MemberCommandServiceTest extends IntegrationTest {
     void 소셜_회원_탈퇴_시_DB에서_조회되지_않는다() {
         // given
         final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("social@pusan.ac.kr", "google-abc123"));
+        when(googleTokenManager.get(socialMember.getId())).thenReturn(java.util.Optional.empty());
 
         // when
         memberCommandService.withdraw(socialMember);
 
         // then
         assertThat(memberRepository.findById(socialMember.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[성공] 일반 회원 탈퇴 시 Google 토큰 해제를 시도하지 않는다.")
+    void 일반_회원_탈퇴_시_Google_토큰_해제를_시도하지_않는다() {
+        // when
+        memberCommandService.withdraw(teamLeader);
+
+        // then
+        verify(googleTokenManager, never()).get(any());
+    }
+
+    @Test
+    @DisplayName("[성공] 소셜 회원 탈퇴 시 Google 토큰 해제를 시도한다.")
+    void 소셜_회원_탈퇴_시_Google_토큰_해제를_시도한다() {
+        // given
+        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("social2@pusan.ac.kr", "google-def456"));
+        when(googleTokenManager.get(socialMember.getId())).thenReturn(java.util.Optional.empty());
+
+        // when
+        memberCommandService.withdraw(socialMember);
+
+        // then
+        verify(googleTokenManager, times(1)).get(socialMember.getId());
     }
 
     @Test

--- a/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
@@ -3,6 +3,7 @@ package com.opus.opus.restdocs.docs;
 import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_MATCHING_IMAGE_ID;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_UPDATE_STUDENT_ID;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
 import static org.mockito.ArgumentMatchers.any;
@@ -446,6 +447,67 @@ public class MemberApiDocsTest extends RestDocsTest {
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description(
                                         String.format(authorizationHeaderDescription, "(회원)"))
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 회원 탈퇴가 정상적으로 이루어진다.")
+    void 회원_탈퇴가_정상적으로_이루어진다() throws Exception {
+        // Given
+        doNothing().when(memberCommandService).withdraw(any());
+
+        // When & Then
+        mockMvc.perform(delete("/members/me")
+                        .header(HttpHeaders.AUTHORIZATION, memberAccessToken))
+                .andExpect(status().isNoContent())
+                .andDo(document("withdraw-member",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "(회원)"))
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 관리자가 회원을 강제 탈퇴시킨다.")
+    void 관리자가_회원을_강제_탈퇴시킨다() throws Exception {
+        // Given
+        doNothing().when(memberCommandService).withdrawByAdmin(any());
+
+        // When & Then
+        mockMvc.perform(delete("/admin/members/{memberId}", 1L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin.access.token"))
+                .andExpect(status().isNoContent())
+                .andDo(document("admin-withdraw-member",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "(관리자)"))
+                        ),
+                        pathParameters(
+                                parameterWithName("memberId").description("탈퇴시킬 회원 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 회원을 강제 탈퇴하면 404를 반환한다.")
+    void 존재하지_않는_회원을_강제_탈퇴하면_에러를_반환한다() throws Exception {
+        // Given
+        willThrow(new MemberException(NOT_FOUND_MEMBER))
+                .given(memberCommandService).withdrawByAdmin(any());
+
+        // When & Then
+        mockMvc.perform(delete("/admin/members/{memberId}", 999L)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer admin.access.token"))
+                .andExpect(status().isNotFound())
+                .andDo(document("admin-withdraw-member-fail-not-found",
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "(관리자)"))
+                        ),
+                        pathParameters(
+                                parameterWithName("memberId").description("존재하지 않는 회원 ID")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #32 

## 📜 작업 내용

- 회원 탈퇴와 관리자 강제 회원 탈퇴 가능을 구현했습니다.

## 💬 리뷰 요구사항

- 태윤님이 미리 구현하신 `unlinkgoogleaccount()` 메서드를 이용하여 구글 연결도 끊어지도록 처리했습니다.

