### PR TITLE
BUG/#112 대회 전체 팀 조회 ROLE_관리자 권한 인증 실패

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -224,7 +224,7 @@ public class ContestController {
         return ResponseEntity.noContent().build();
     }
 
-    @Secured("ROLE_회원")
+    @Secured({"ROLE_회원", "ROLE_관리자"})
     @GetMapping("/{contestId}/teams")
     public ResponseEntity<List<TeamSummaryResponse>> getAllContestTeamSummaries(@PathVariable final Long contestId,
                                                                                 @LoginMember final Member member) {


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #112 

## 📜 작업 내용

- 대회 전체 팀 조회 (회원용) API 호출 시 관리자 권한 인증에 실패하는 버그가 발생하였습니다.
- @GetMapping("/{contestId}/teams") api에 @ Secured에 ROLE_회원만 포함해두어 발생한 문제입니다.
- @ Secured에 ROLE_관리자를 추가하였습니다.

## 💬 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요.

## ✨ 기타

- 오늘의 한마디
