### PR TITLE
Bug/#116 대회 트랙 팀 삭제 시 연관 데이터 미삭제

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -35,13 +35,16 @@ import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.ContestSort;
 import com.opus.opus.modules.contest.domain.ContestTemplate;
+import com.opus.opus.modules.contest.domain.dao.ContestAwardRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSortRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTemplateRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.file.exception.FileException;
+import com.opus.opus.modules.notice.domain.dao.NoticeRepository;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.domain.Team;
 import java.util.List;
@@ -61,8 +64,11 @@ public class ContestCommandService {
 
     private final ContestRepository contestRepository;
     private final ContestSortRepository contestSortRepository;
+    private final ContestAwardRepository contestAwardRepository;
+    private final ContestTrackRepository contestTrackRepository;
     private final FileRepository fileRepository;
     private final ContestTemplateRepository contestTemplateRepository;
+    private final NoticeRepository noticeRepository;
 
     private final ContestConvenience contestConvenience;
     private final ContestCategoryConvenience contestCategoryConvenience;
@@ -121,6 +127,17 @@ public class ContestCommandService {
     public void deleteContest(final Long contestId) {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         teamConvenience.validateAllTeamsDeletedInContest(contestId);
+
+        // 연관 데이터 삭제
+        fileRepository.findByReferenceIdAndReferenceTypeAndImageType(contestId, CONTEST, BANNER)
+                .ifPresent(file -> fileStorageUtil.deleteFile(file.getId()));
+
+        noticeRepository.deleteAll(noticeRepository.findAllByContestIdOrderByCreatedAtDesc(contestId));
+        contestAwardRepository.deleteAll(contestAwardRepository.findByContestId(contestId));
+        contestTrackRepository.deleteAll(contestTrackRepository.findAllByContestId(contestId));
+        contestSortRepository.findByContestId(contestId).ifPresent(contestSortRepository::delete);
+        contestTemplateRepository.findByContestId(contestId).ifPresent(contestTemplateRepository::delete);
+
         contestRepository.delete(contest);
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackCommandService.java
@@ -14,6 +14,7 @@ import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.FileImageType;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -27,6 +28,7 @@ public class ContestTrackCommandService {
 
     private final ContestTrackRepository contestTrackRepository;
     private final FileRepository fileRepository;
+    private final TeamRepository teamRepository;
 
     private final ContestTrackConvenience contestTrackConvenience;
     private final ContestConvenience contestConvenience;
@@ -54,12 +56,15 @@ public class ContestTrackCommandService {
     public void deleteTrack(final Long contestId, final Long trackId) {
         final ContestTrack contestTrack = contestTrackConvenience.getValidateExistTrack(contestId, trackId);
         teamConvenience.validateAllTeamsDeletedInTrack(trackId);
+        deleteIfExists(trackId, THUMBNAIL);
+        teamRepository.clearTrackIdByTrackId(trackId);
         contestTrackRepository.delete(contestTrack);
     }
 
     public void saveContestTrackDefaultThumbnail(final Long contestId, final Long trackId, final MultipartFile image) {
         contestTrackConvenience.getValidateExistTrack(contestId, trackId);
-        final Optional<File> existingFile = fileRepository.findByReferenceIdAndReferenceTypeAndImageType(trackId, TRACK, THUMBNAIL);
+        final Optional<File> existingFile = fileRepository.findByReferenceIdAndReferenceTypeAndImageType(trackId, TRACK,
+                THUMBNAIL);
         fileStorageUtil.storeFile(image, trackId, TRACK, THUMBNAIL);
         existingFile.ifPresent(file -> fileStorageUtil.deleteFile(file.getId()));
     }

--- a/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamCommandService.java
@@ -38,7 +38,9 @@ import com.opus.opus.modules.team.application.dto.response.TeamVoteToggleRespons
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.domain.TeamLike;
 import com.opus.opus.modules.team.domain.TeamVote;
+import com.opus.opus.modules.team.domain.dao.TeamContestAwardRepository;
 import com.opus.opus.modules.team.domain.dao.TeamLikeRepository;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.domain.dao.TeamVoteRepository;
 import com.opus.opus.modules.team.exception.TeamException;
@@ -60,15 +62,17 @@ public class TeamCommandService {
 
     private final FileStorageUtil fileStorageUtil;
 
+    private final TeamRepository teamRepository;
+    private final TeamVoteRepository teamVoteRepository;
+    private final TeamLikeRepository teamLikeRepository;
+    private final TeamMemberRepository teamMemberRepository;
+    private final TeamContestAwardRepository teamContestAwardRepository;
+    private final FileRepository fileRepository;
+
     private final TeamConvenience teamConvenience;
     private final TeamMemberConvenience teamMemberConvenience;
     private final ContestConvenience contestConvenience;
     private final ContestTrackConvenience contestTrackConvenience;
-
-    private final TeamRepository teamRepository;
-    private final TeamVoteRepository teamVoteRepository;
-    private final TeamLikeRepository teamLikeRepository;
-    private final FileRepository fileRepository;
     private final ContestTemplateConvenience contestTemplateConvenience;
     private final FileConvenience fileConvenience;
 
@@ -90,6 +94,10 @@ public class TeamCommandService {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
         deleteTeamImages(teamId);
         reorderAfterTeamDeletion(team);
+        teamMemberRepository.deleteAll(team.getTeamMembers());
+        teamVoteRepository.deleteAll(team.getTeamVotes());
+        teamLikeRepository.deleteAll(team.getTeamLikes());
+        teamContestAwardRepository.deleteAll(team.getTeamAwards());
         teamRepository.delete(team);
     }
 

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamRepository.java
@@ -46,4 +46,8 @@ public interface TeamRepository extends JpaRepository<Team, Long> {
                AND t.isDeleted = false
             """)
     void updateItemOrderAfterDeletion(@Param("contestId") Long contestId, @Param("deletedOrder") int deletedOrder);
+
+    @Modifying
+    @Query("UPDATE Team t SET t.trackId = null WHERE t.trackId = :trackId")
+    void clearTrackIdByTrackId(@Param("trackId") Long trackId);
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #116 

## 📜 작업 내용
- 대회 삭제 시 연관된 Sort, Template, Track, Award, File(Banner), Notice가 함께 삭제되도록 수정
- 트랙 삭제 시 File(Thumbnail) 파일이 함께 삭제되도록 수정
- 트랙 삭제 시 해당 트랙을 참조하던 Team의 trackId를 null로 초기화하도록 수정
- 팀 삭제 시 연관된 TeamMember, TeamVote, TeamLike, TeamContestAward가 함께 삭제되도록 수정

## 💬 리뷰 요구사항
- 트랙 삭제 시 Team.trackId null 초기화를 @ Modifying 벌크 쿼리로 처리했습니다. 

## ✨ 기타
- 월요일 정말 피곤허네요 🦧