### PR TITLE
Bug/#118 119 120 팀조회권한 트랙조회검증 대회이름중복

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestCommandService.java
@@ -112,9 +112,13 @@ public class ContestCommandService {
     }
 
     public void updateContest(final Long contestId, final ContestRequest request) {
-        contestConvenience.validateDuplicateContestName(request.contestName());
-        contestCategoryConvenience.getValidateExistCategory(request.categoryId());
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        contestCategoryConvenience.getValidateExistCategory(request.categoryId());
+
+        if (!contest.getContestName().equals(request.contestName())) {
+            contestConvenience.validateDuplicateContestName(request.contestName());
+        }
+
         contest.updateContest(request.categoryId(), request.contestName());
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestTrackQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestTrackQueryService.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.contest.application;
 
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestTrackResponse;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
@@ -14,8 +15,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestTrackQueryService {
 
     private final ContestTrackRepository contestTrackRepository;
+    private final ContestConvenience contestConvenience;
 
     public List<ContestTrackResponse> getAllContestTracks(final Long contestId) {
+        contestConvenience.getValidateExistContest(contestId);
         final List<ContestTrack> contestTracks = contestTrackRepository.findAllByContestId(contestId);
         return contestTracks.stream()
                 .map(ContestTrackResponse::from)

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestTrackRepository.java
@@ -2,13 +2,10 @@ package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestTrackRepository extends JpaRepository<ContestTrack, Long> {
     boolean existsByContestIdAndTrackName(final Long contestId, final String trackName);
-
-    Optional<ContestTrack> findByIdAndContestId(final Long trackId, final Long contestId);
 
     List<ContestTrack> findAllByContestId(final Long contestId);
 }

--- a/src/main/java/com/opus/opus/modules/team/api/TeamController.java
+++ b/src/main/java/com/opus/opus/modules/team/api/TeamController.java
@@ -66,7 +66,7 @@ public class TeamController {
         return ResponseEntity.noContent().build();
     }
 
-    @Secured("ROLE_회원")
+    @Secured({"ROLE_회원", "ROLE_관리자"})
     @GetMapping("/{teamId}")
     public ResponseEntity<TeamDetailResponse> getTeamDetail(@PathVariable final Long teamId,
                                                             @LoginMember final Member member) {


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #118 
close: #119 
close: #120 

## 📜 작업 내용

- (#118) 회원용 팀 조회 API에 `ROLE_관리자` 권한 검증 추가
- (#119) 유효하지 않은 `contestId`로 트랙 조회 요청 시 예외 처리 진
- (#120) 대회 수정 시 `contestName`이 기존 값과 동일하면 중복 검증 제외

## 💬 리뷰 요구사항

- 현재 대회 수정 API가 `PATCH`로 되어 있으나 모든 필드(`contestName`, `categoryId`)가 `@NotNull`로 필수 전송이라 실질적으로는 PUT입니다. `PUT`으로 변경하는게 좋을까요 PATCH로 유지하는게 좋을까요?

## ✨ 기타

- 오늘의 한마디
