### PR TITLE
Refactor/#123 수상 내역 조회 Projection 적용 

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -42,9 +42,9 @@ import com.opus.opus.modules.team.application.dto.ImageResponse;
 import com.opus.opus.modules.team.application.dto.response.MemberVoteCountResponse;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.domain.TeamVote;
-import com.opus.opus.modules.team.domain.dao.TeamAwardResult;
 import com.opus.opus.modules.team.domain.dao.TeamRankingResult;
 import com.opus.opus.modules.team.domain.dao.VoteStatisticsResult;
+import com.opus.opus.modules.team.domain.dao.projection.TeamAwardProjection;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -248,7 +248,7 @@ public class ContestQueryService {
         final List<Team> teams = getSortedTeams(contestId, member);
 
         final VoteLikeResult voteLikeResult = getVoteLikeResult(contestId, member, contest.isVotingPeriod());
-        final Map<Long, List<TeamAwardResult>> teamAwardResultMap = teamContestAwardConvenience.getTeamAwardResultMap(
+        final Map<Long, List<TeamAwardProjection>> teamAwardResultMap = teamContestAwardConvenience.getTeamAwardProjectionMap(
                 teams);
 
         return buildTeamSummaryResponses(teams, teamAwardResultMap, voteLikeResult);
@@ -270,7 +270,7 @@ public class ContestQueryService {
     }
 
     private List<TeamSummaryResponse> buildTeamSummaryResponses(final List<Team> teams,
-                                                                final Map<Long, List<TeamAwardResult>> teamAwardResultMap,
+                                                                final Map<Long, List<TeamAwardProjection>> teamAwardResultMap,
                                                                 final VoteLikeResult voteLikeResult
     ) {
         return teams.stream()

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/TeamSummaryResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/TeamSummaryResponse.java
@@ -1,7 +1,7 @@
 package com.opus.opus.modules.contest.application.dto.response;
 
 import com.opus.opus.modules.team.domain.Team;
-import com.opus.opus.modules.team.domain.dao.TeamAwardResult;
+import com.opus.opus.modules.team.domain.dao.projection.TeamAwardProjection;
 import java.util.List;
 
 public record TeamSummaryResponse(
@@ -14,7 +14,7 @@ public record TeamSummaryResponse(
 ) {
     public static TeamSummaryResponse of(
             final Team team,
-            final List<TeamAwardResult> teamAwardResults,
+            final List<TeamAwardProjection> teamAwardResults,
             final Boolean isLiked,
             final Boolean isVoted
     ) {
@@ -25,7 +25,7 @@ public record TeamSummaryResponse(
                 isLiked,
                 isVoted,
                 teamAwardResults.stream()
-                        .map(result -> new AwardInfo(result.awardName(), result.awardColor()))
+                        .map(result -> new AwardInfo(result.getAwardName(), result.getAwardColor()))
                         .toList()
         );
     }

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamContestAwardConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamContestAwardConvenience.java
@@ -1,7 +1,7 @@
 package com.opus.opus.modules.team.application.convenience;
 
 import com.opus.opus.modules.team.domain.Team;
-import com.opus.opus.modules.team.domain.dao.TeamAwardResult;
+import com.opus.opus.modules.team.domain.dao.projection.TeamAwardProjection;
 import com.opus.opus.modules.team.domain.dao.TeamContestAwardRepository;
 import java.util.Collections;
 import java.util.List;
@@ -18,7 +18,7 @@ public class TeamContestAwardConvenience {
 
     private final TeamContestAwardRepository teamContestAwardRepository;
 
-    public List<TeamAwardResult> findTeamAwardsByTeams(final List<Team> teams) {
+    public List<TeamAwardProjection> findTeamAwardsByTeams(final List<Team> teams) {
         final List<Long> teamIds = teams.stream().map(Team::getId).toList();
 
         if (teamIds.isEmpty()) {
@@ -28,10 +28,10 @@ public class TeamContestAwardConvenience {
         return teamContestAwardRepository.findTeamAwardsByTeamIds(teamIds);
     }
 
-    public Map<Long, List<TeamAwardResult>> getTeamAwardResultMap(final List<Team> teams) {
-        final List<TeamAwardResult> teamAwardResults = findTeamAwardsByTeams(teams);
+    public Map<Long, List<TeamAwardProjection>> getTeamAwardProjectionMap(final List<Team> teams) {
+        final List<TeamAwardProjection> teamAwardResults = findTeamAwardsByTeams(teams);
 
         return teamAwardResults.stream()
-                .collect(Collectors.groupingBy(TeamAwardResult::teamId));
+                .collect(Collectors.groupingBy(TeamAwardProjection::getTeamId));
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamAwardResult.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamAwardResult.java
@@ -1,8 +1,0 @@
-package com.opus.opus.modules.team.domain.dao;
-
-public record TeamAwardResult(
-        Long teamId,
-        String awardName,
-        String awardColor
-) {
-}

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamContestAwardRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamContestAwardRepository.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.team.domain.dao;
 
 import com.opus.opus.modules.team.domain.TeamContestAward;
+import com.opus.opus.modules.team.domain.dao.projection.TeamAwardProjection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,12 +11,10 @@ public interface TeamContestAwardRepository extends JpaRepository<TeamContestAwa
     List<TeamContestAward> findByTeamId(final Long teamId);
 
     @Query("""
-            SELECT new com.opus.opus.modules.team.domain.dao.TeamAwardResult(
-                tca.team.id, ca.awardName, ca.awardColor
-            )
+            SELECT tca.team.id AS teamId, ca.awardName AS awardName, ca.awardColor AS awardColor
             FROM TeamContestAward tca
             JOIN ContestAward ca ON tca.contestAwardId = ca.id
             WHERE tca.team.id IN :teamIds
             """)
-    List<TeamAwardResult> findTeamAwardsByTeamIds(@Param("teamIds") List<Long> teamIds);
+    List<TeamAwardProjection> findTeamAwardsByTeamIds(@Param("teamIds") List<Long> teamIds);
 }

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/projection/TeamAwardProjection.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/projection/TeamAwardProjection.java
@@ -1,0 +1,7 @@
+package com.opus.opus.modules.team.domain.dao.projection;
+
+public interface TeamAwardProjection {
+    Long getTeamId();
+    String getAwardName();
+    String getAwardColor();
+}


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #123 

## 📜 작업 내용

- 기존에 팀 조회 및 대회 팀 전체보기에서 팀의 수상 내역을 조회할 때 사용하던 `TeamAwardResult` record 기반 반환 방식을 `TeamAwardProjection` Projection Interface 기반 방식으로 변경하였습니다.
- 관련 인터페이스를 `dao/projection` 패키지를 생성하여 정리했습니다.

## 💬 리뷰 요구사항

- 확인 부탁드립니다!

## ✨ 기타

- 오늘의 한마디
