### PR TITLE
Feature/#127 팀원 등록 및 삭제에 팀장 권한 추가

### DIFF
--- a/src/main/java/com/opus/opus/modules/team/api/TeamMemberController.java
+++ b/src/main/java/com/opus/opus/modules/team/api/TeamMemberController.java
@@ -1,5 +1,7 @@
 package com.opus.opus.modules.team.api;
 
+import com.opus.opus.global.security.annotation.LoginMember;
+import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.TeamMemberCommandService;
 import com.opus.opus.modules.team.application.dto.request.TeamMemberCreateRequest;
 import jakarta.validation.Valid;
@@ -19,23 +21,25 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/teams/{teamId}/members")
-@Secured("ROLE_관리자")
+@Secured({"ROLE_회원", "ROLE_관리자"})
 public class TeamMemberController {
 
     private final TeamMemberCommandService teamMemberCommandService;
 
     @PostMapping
     public ResponseEntity<Void> createTeamMember(@PathVariable final Long teamId,
-                                                 @Valid @RequestBody final TeamMemberCreateRequest request) {
-        teamMemberCommandService.createTeamMember(teamId, request.memberStudentId(), request.memberName(),
+                                                 @Valid @RequestBody final TeamMemberCreateRequest request,
+                                                 @LoginMember final Member member) {
+        teamMemberCommandService.createTeamMember(member, teamId, request.memberStudentId(), request.memberName(),
                 request.roleType());
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
     @DeleteMapping("/{memberId}")
     public ResponseEntity<Void> deleteTeamMember(@PathVariable final Long teamId,
-                                                 @PathVariable final Long memberId) {
-        teamMemberCommandService.deleteTeamMember(teamId, memberId);
+                                                 @PathVariable final Long memberId,
+                                                 @LoginMember final Member member) {
+        teamMemberCommandService.deleteTeamMember(member, teamId, memberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/application/TeamMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/team/application/TeamMemberCommandService.java
@@ -24,9 +24,10 @@ public class TeamMemberCommandService {
     private final TeamMemberConvenience teamMemberConvenience;
     private final MemberConvenience memberConvenience;
 
-    public void createTeamMember(final Long teamId, final String studentId, final String name,
-                                 final TeamMemberRoleType roleType) {
+    public void createTeamMember(final Member loginMember, final Long teamId, final String studentId,
+                                 final String name, final TeamMemberRoleType roleType) {
         final Team team = teamConvenience.getValidateExistTeam(teamId);
+        teamMemberConvenience.validateTeamLeaderUnlessAdmin(teamId, loginMember);
         final Member member = memberConvenience.getOrCreateFakeMember(studentId, name);
         teamMemberConvenience.checkIsDuplicateTeamMember(teamId, member.getId());
         teamMemberRepository.save(
@@ -38,8 +39,9 @@ public class TeamMemberCommandService {
         );
     }
 
-    public void deleteTeamMember(final Long teamId, final Long memberId) {
+    public void deleteTeamMember(final Member loginMember, final Long teamId, final Long memberId) {
         teamConvenience.getValidateExistTeam(teamId);
+        teamMemberConvenience.validateTeamLeaderUnlessAdmin(teamId, loginMember);
         final TeamMember teamMember = teamMemberConvenience.getValidateExistTeamMember(teamId, memberId);
         teamMemberRepository.delete(teamMember);
     }

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
@@ -1,10 +1,12 @@
 package com.opus.opus.modules.team.application.convenience;
 
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.NOT_TEAM_LEADER;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_ALREADY_EXISTS;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
 
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
 import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.exception.TeamMemberException;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,15 @@ public class TeamMemberConvenience {
     public void validateTeamMemberUnlessAdmin(final Long teamId, final Member member) {
         if (!member.isAdmin()) {
             getValidateExistTeamMember(teamId, member.getId());
+        }
+    }
+
+    public void validateTeamLeaderUnlessAdmin(final Long teamId, final Member member) {
+        if (!member.isAdmin()) {
+            final TeamMember teamMember = getValidateExistTeamMember(teamId, member.getId());
+            if (!teamMember.getRoles().contains(TeamMemberRoleType.ROLE_팀장)) {
+                throw new TeamMemberException(NOT_TEAM_LEADER);
+            }
         }
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.team.application.convenience;
 
+import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀장;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.NOT_TEAM_LEADER;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_ALREADY_EXISTS;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
@@ -53,10 +54,16 @@ public class TeamMemberConvenience {
         }
     }
 
+    /*
+        [팀장/팀원 권한 검증 위치 변경]
+        ROLE_팀장, ROLE_팀원을 JwtProvider roles에 추가해 @Secured로 검증하는 방식은
+        매 요청마다 불필요한 TeamMember DB 조회가 발생하고, 해당 권한이 필요한 API도 많지 않아
+        @Secured는 ROLE_회원만 검증하고, 팀장/팀원 여부는 Service 레이어에서 검증하는 방식으로 결정
+     */
     public void validateTeamLeaderUnlessAdmin(final Long teamId, final Member member) {
         if (!member.isAdmin()) {
             final TeamMember teamMember = getValidateExistTeamMember(teamId, member.getId());
-            if (!teamMember.getRoles().contains(TeamMemberRoleType.ROLE_팀장)) {
+            if (!teamMember.getRoles().contains(ROLE_팀장)) {
                 throw new TeamMemberException(NOT_TEAM_LEADER);
             }
         }

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamMemberExceptionType.java
@@ -6,7 +6,8 @@ import org.springframework.http.HttpStatus;
 public enum TeamMemberExceptionType implements BaseExceptionType {
 
     TEAM_MEMBER_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 팀에 등록된 팀원입니다."),
-    TEAM_MEMBER_NOT_FOUND_IN_TEAM(HttpStatus.NOT_FOUND, "해당 팀의 팀원이 아닙니다.");
+    TEAM_MEMBER_NOT_FOUND_IN_TEAM(HttpStatus.NOT_FOUND, "해당 팀의 팀원이 아닙니다."),
+    NOT_TEAM_LEADER(HttpStatus.FORBIDDEN, "해당 팀의 팀장 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/test/java/com/opus/opus/restdocs/docs/TeamMemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/TeamMemberApiDocsTest.java
@@ -65,7 +65,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
     void 유효한_요청이면_정상적으로_팀원이_추가된다() throws Exception {
         final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
 
-        doNothing().when(teamMemberCommandService).createTeamMember(any(), any(), any(), any());
+        doNothing().when(teamMemberCommandService).createTeamMember(any(), any(), any(), any(), any());
 
         mockMvc.perform(post("/teams/{teamId}/members", 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
@@ -74,7 +74,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isCreated())
                 .andDo(document("add-team-member",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID")
@@ -99,7 +99,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isBadRequest())
                 .andDo(document("add-team-member-fail-empty-name",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID")
@@ -124,7 +124,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isBadRequest())
                 .andDo(document("add-team-member-fail-empty-student-id",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID")
@@ -143,7 +143,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
         final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
 
         willThrow(new TeamException(NOT_FOUND_TEAM)).given(teamMemberCommandService)
-                .createTeamMember(any(), any(), any(), any());
+                .createTeamMember(any(), any(), any(), any(), any());
 
         mockMvc.perform(post("/teams/{teamId}/members", 999)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
@@ -152,7 +152,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isNotFound())
                 .andDo(document("add-team-member-fail-team-not-found",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("존재하지 않는 팀 ID")
@@ -171,7 +171,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
         final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
 
         willThrow(new MemberException(MISMATCH_STUDENT_ID_AND_NAME)).given(teamMemberCommandService)
-                .createTeamMember(any(), any(), any(), any());
+                .createTeamMember(any(), any(), any(), any(), any());
 
         mockMvc.perform(post("/teams/{teamId}/members", 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
@@ -180,7 +180,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isBadRequest())
                 .andDo(document("add-team-member-fail-mismatch",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID")
@@ -199,7 +199,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
         final TeamMemberCreateRequest request = new TeamMemberCreateRequest("이옵스", "202612345", ROLE_팀원);
 
         willThrow(new TeamMemberException(TEAM_MEMBER_ALREADY_EXISTS)).given(teamMemberCommandService)
-                .createTeamMember(any(), any(), any(), any());
+                .createTeamMember(any(), any(), any(), any(), any());
 
         mockMvc.perform(post("/teams/{teamId}/members", 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
@@ -208,7 +208,7 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isConflict())
                 .andDo(document("add-team-member-fail-already-exists",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID")
@@ -226,14 +226,14 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 유효한 요청이면 정상적으로 팀원이 삭제된다.")
     void 유효한_요청이면_정상적으로_팀원이_삭제된다() throws Exception {
-        doNothing().when(teamMemberCommandService).deleteTeamMember(any(), any());
+        doNothing().when(teamMemberCommandService).deleteTeamMember(any(), any(), any());
 
         mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 1, 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNoContent())
                 .andDo(document("delete-team-member",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID"),
@@ -246,14 +246,14 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
     @DisplayName("[실패] 존재하지 않는 팀 ID인 경우 404 에러를 반환한다.")
     void 삭제_존재하지_않는_팀_ID인_경우_에러를_반환한다() throws Exception {
         willThrow(new TeamException(NOT_FOUND_TEAM)).given(teamMemberCommandService)
-                .deleteTeamMember(any(), any());
+                .deleteTeamMember(any(), any(), any());
 
         mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 999, 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNotFound())
                 .andDo(document("delete-team-member-fail-team-not-found",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("존재하지 않는 팀 ID"),
@@ -266,14 +266,14 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
     @DisplayName("[실패] 존재하지 않는 멤버 ID인 경우 404 에러를 반환한다.")
     void 존재하지_않는_멤버_ID인_경우_에러를_반환한다() throws Exception {
         willThrow(new MemberException(NOT_FOUND_MEMBER)).given(teamMemberCommandService)
-                .deleteTeamMember(any(), any());
+                .deleteTeamMember(any(), any(), any());
 
         mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 1, 999)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNotFound())
                 .andDo(document("delete-team-member-fail-member-not-found",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID"),
@@ -287,14 +287,14 @@ public class TeamMemberApiDocsTest extends RestDocsTest {
     void 삭제_대상_팀원이_해당_팀에_없을_경우_에러를_반환한다() throws Exception {
         willThrow(new TeamMemberException(TEAM_MEMBER_NOT_FOUND_IN_TEAM))
                 .given(teamMemberCommandService)
-                .deleteTeamMember(any(), any());
+                .deleteTeamMember(any(), any(), any());
 
         mockMvc.perform(delete("/teams/{teamId}/members/{memberId}", 1, 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
                 .andExpect(status().isNotFound())
                 .andDo(document("delete-team-member-fail-not-in-team",
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자 또는 팀장)")
                         ),
                         pathParameters(
                                 parameterWithName("teamId").description("팀 ID"),

--- a/src/test/java/com/opus/opus/team/application/TeamMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/team/application/TeamMemberCommandServiceTest.java
@@ -1,8 +1,10 @@
 package com.opus.opus.team.application;
 
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.MISMATCH_STUDENT_ID_AND_NAME;
 import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀원;
 import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀장;
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.NOT_TEAM_LEADER;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -20,6 +22,7 @@ import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.exception.TeamMemberException;
 import com.opus.opus.team.TeamFixture;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,22 +42,30 @@ public class TeamMemberCommandServiceTest extends IntegrationTest {
 
     private Team team;
     private Member member;
+    private Member admin;
     private TeamMemberCreateRequest request;
 
     @BeforeEach
     void setUp() {
         team = teamRepository.save(TeamFixture.createTeam());
         member = memberRepository.save(MemberFixture.createMember());
+        admin = memberRepository.save(Member.generalMember()
+                .name("관리자")
+                .email("admin@pusan.ac.kr")
+                .password("{noop}12345678")
+                .studentId("000000000")
+                .roles(Set.of(ROLE_관리자))
+                .build());
         request = new TeamMemberCreateRequest("이사람", "123456789", ROLE_팀원);
     }
 
     @Test
-    @DisplayName("[성공] 회원가입한 학번과 이름이 없으면 가짜 회원을 생성 후 팀원으로 추가한다.")
-    void 회원가입한_학번과_이름이_없으면_가짜_회원을_생성_후_팀원으로_추가한다() {
+    @DisplayName("[성공] 관리자가 회원가입한 학번과 이름이 없으면 가짜 회원을 생성 후 팀원으로 추가한다.")
+    void 관리자가_회원가입한_학번과_이름이_없으면_가짜_회원을_생성_후_팀원으로_추가한다() {
         final String notExistStudentId = "202654321";
         final String notExistStudentName = "문스옵";
 
-        teamMemberCommandService.createTeamMember(team.getId(), notExistStudentId, notExistStudentName,
+        teamMemberCommandService.createTeamMember(admin, team.getId(), notExistStudentId, notExistStudentName,
                 request.roleType());
 
         final Member fakeMember = memberRepository.findByStudentId(notExistStudentId).orElseThrow();
@@ -67,12 +78,12 @@ public class TeamMemberCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 이미 회원가입한 회원의 학번과 이름으로 팀원으로 추가될 때 기존 회원을 팀원으로 추가한다")
-    void 이미_회원가입한_회원의_학번과_이름으로_팀원으로_추가될_때_기존_회원을_팀원으로_추가한다() {
+    @DisplayName("[성공] 관리자가 이미 회원가입한 회원의 학번과 이름으로 팀원으로 추가될 때 기존 회원을 팀원으로 추가한다")
+    void 관리자가_이미_회원가입한_회원의_학번과_이름으로_팀원으로_추가될_때_기존_회원을_팀원으로_추가한다() {
         final String signedUpStudentId = member.getStudentId();
         final String signedUpStudentName = member.getName();
 
-        teamMemberCommandService.createTeamMember(team.getId(), signedUpStudentId, signedUpStudentName,
+        teamMemberCommandService.createTeamMember(admin, team.getId(), signedUpStudentId, signedUpStudentName,
                 request.roleType());
 
         final TeamMember teamMember = teamMemberRepository.findByTeamIdAndMemberId(team.getId(), member.getId())
@@ -81,22 +92,23 @@ public class TeamMemberCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[실패] 이미 회원가입한 회원의 학번인데 저장된 이름과 같지 않으면 팀원으로 추가 불가하다.")
-    void 이미_회원가입한_회원의_학번인데_저장된_이름과_같지_않으면_팀원으로_추가_불가하다() {
+    @DisplayName("[실패] 관리자가 이미 회원가입한 회원의 학번인데 저장된 이름과 같지 않으면 팀원으로 추가 불가하다.")
+    void 관리자가_이미_회원가입한_회원의_학번인데_저장된_이름과_같지_않으면_팀원으로_추가_불가하다() {
         final String studentId = member.getStudentId();
         final String wrongStudentName = "이옵스아님";
 
         assertThatThrownBy(() -> {
-            teamMemberCommandService.createTeamMember(team.getId(), studentId, wrongStudentName, request.roleType());
+            teamMemberCommandService.createTeamMember(admin, team.getId(), studentId, wrongStudentName,
+                    request.roleType());
         }).isInstanceOf(MemberException.class).hasMessage(MISMATCH_STUDENT_ID_AND_NAME.errorMessage());
     }
 
     @Test
-    @DisplayName("[성공] roleType이 팀장이라면 팀장으로 저장된다.")
-    void roleType이_팀장이라면_팀장으로_저장된다() {
+    @DisplayName("[성공] 관리자가 roleType이 팀장이라면 팀장으로 저장된다.")
+    void 관리자가_roleType이_팀장이라면_팀장으로_저장된다() {
         final TeamMemberCreateRequest teamLeaderRequest = new TeamMemberCreateRequest("나팀장", "202798743", ROLE_팀장);
 
-        teamMemberCommandService.createTeamMember(team.getId(), teamLeaderRequest.memberStudentId(),
+        teamMemberCommandService.createTeamMember(admin, team.getId(), teamLeaderRequest.memberStudentId(),
                 teamLeaderRequest.memberName(), teamLeaderRequest.roleType());
 
         final Member addedMember = memberRepository.findByStudentId(teamLeaderRequest.memberStudentId())
@@ -107,15 +119,60 @@ public class TeamMemberCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 팀원이 정상적으로 삭제된다.")
-    void 팀원이_정상적으로_삭제된다() {
-        teamMemberCommandService.createTeamMember(team.getId(), request.memberStudentId(), request.memberName(),
-                request.roleType());
+    @DisplayName("[성공] 관리자가 팀원을 정상적으로 삭제한다.")
+    void 관리자가_팀원을_정상적으로_삭제한다() {
+        teamMemberCommandService.createTeamMember(admin, team.getId(), request.memberStudentId(),
+                request.memberName(), request.roleType());
         final Member addedMember = memberRepository.findByStudentId(request.memberStudentId()).get();
 
-        teamMemberCommandService.deleteTeamMember(team.getId(), addedMember.getId());
+        teamMemberCommandService.deleteTeamMember(admin, team.getId(), addedMember.getId());
 
         assertThat(teamMemberRepository.existsByTeamIdAndMemberId(team.getId(), addedMember.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("[성공] 팀장이 팀원을 추가할 수 있다.")
+    void 팀장이_팀원을_추가할_수_있다() {
+        // given: member를 팀장으로 등록
+        teamMemberCommandService.createTeamMember(admin, team.getId(), member.getStudentId(), member.getName(),
+                ROLE_팀장);
+
+        // when: 팀장이 새 팀원을 추가
+        teamMemberCommandService.createTeamMember(member, team.getId(), "987654321", "새팀원", ROLE_팀원);
+
+        // then
+        final Member addedMember = memberRepository.findByStudentId("987654321").orElseThrow();
+        assertThat(teamMemberRepository.existsByTeamIdAndMemberId(team.getId(), addedMember.getId())).isTrue();
+    }
+
+    @Test
+    @DisplayName("[성공] 팀장이 팀원을 삭제할 수 있다.")
+    void 팀장이_팀원을_삭제할_수_있다() {
+        // given: member를 팀장으로 등록, 다른 팀원 추가
+        teamMemberCommandService.createTeamMember(admin, team.getId(), member.getStudentId(), member.getName(),
+                ROLE_팀장);
+        teamMemberCommandService.createTeamMember(admin, team.getId(), request.memberStudentId(),
+                request.memberName(), request.roleType());
+        final Member addedMember = memberRepository.findByStudentId(request.memberStudentId()).get();
+
+        // when: 팀장이 팀원을 삭제
+        teamMemberCommandService.deleteTeamMember(member, team.getId(), addedMember.getId());
+
+        // then
+        assertThat(teamMemberRepository.existsByTeamIdAndMemberId(team.getId(), addedMember.getId())).isFalse();
+    }
+
+    @Test
+    @DisplayName("[실패] 팀원(팀장이 아닌)은 팀원을 추가할 수 없다.")
+    void 팀원은_팀원을_추가할_수_없다() {
+        // given: member를 팀원으로 등록
+        teamMemberCommandService.createTeamMember(admin, team.getId(), member.getStudentId(), member.getName(),
+                ROLE_팀원);
+
+        // when & then
+        assertThatThrownBy(() -> {
+            teamMemberCommandService.createTeamMember(member, team.getId(), "987654321", "새팀원", ROLE_팀원);
+        }).isInstanceOf(TeamMemberException.class).hasMessage(NOT_TEAM_LEADER.errorMessage());
     }
 
     @Test
@@ -124,7 +181,7 @@ public class TeamMemberCommandServiceTest extends IntegrationTest {
         final Team otherTeam = teamRepository.save(TeamFixture.createTeam());
 
         assertThatThrownBy(() -> {
-            teamMemberCommandService.deleteTeamMember(otherTeam.getId(), member.getId());
+            teamMemberCommandService.deleteTeamMember(admin, otherTeam.getId(), member.getId());
         }).isInstanceOf(TeamMemberException.class).hasMessage(TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
     }
 }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #127 

## 📜 작업 내용

- 프론트 담당자님의 요청에 따라 관리자 권한만 있던 팀원 수정 및 삭제 api에 팀장 권한을 추가했습니다.

## 💬 리뷰 요구사항

- 확인 부탁드립니다!

## ✨ 기타

- 오늘의 한마디
