### PR TITLE
Refactor/#130 삭제된 상훈을 참조하는 team_contest_award 미정리 해결

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/application/ContestAwardCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestAwardCommandService.java
@@ -9,6 +9,7 @@ import com.opus.opus.modules.contest.domain.ContestAward;
 import com.opus.opus.modules.contest.application.dto.request.ContestAwardRequest;
 import com.opus.opus.modules.contest.domain.dao.ContestAwardRepository;
 import com.opus.opus.modules.contest.exception.ContestAwardException;
+import com.opus.opus.modules.team.domain.dao.TeamContestAwardRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,8 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestAwardCommandService {
 
     private final ContestConvenience contestConvenience;
-
     private final ContestAwardRepository contestAwardRepository;
+    private final TeamContestAwardRepository teamContestAwardRepository;
 
     public void createContestAward(final Long contestId, final ContestAwardRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
@@ -55,6 +56,7 @@ public class ContestAwardCommandService {
                 .findByIdAndContestId(awardId, contestId)
                 .orElseThrow(() -> new ContestAwardException(NOT_FOUND_CONTEST_AWARD));
 
+        teamContestAwardRepository.deleteAllByContestAwardId(awardId);
         contestAwardRepository.delete(contestAward);
     }
 

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamContestAwardRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamContestAwardRepository.java
@@ -10,6 +10,8 @@ import org.springframework.data.repository.query.Param;
 public interface TeamContestAwardRepository extends JpaRepository<TeamContestAward, Long> {
     List<TeamContestAward> findByTeamId(final Long teamId);
 
+    void deleteAllByContestAwardId(final Long contestAwardId);
+
     @Query("""
             SELECT tca.team.id AS teamId, ca.awardName AS awardName, ca.awardColor AS awardColor
             FROM TeamContestAward tca


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #130

## 📜 작업 내용

- 삭제된 상훈을 참조하는 `team_contest_award`를 정리하지 않아, 프론트에서 상훈 삭제 후 팀 수상 조회 시 404 응답이 오는 에러가 발생하였습니다.
- 이를 해결하기 위해 상훈 삭제 시 `team_contest_award` 연관 데이터를 함께 삭제하도록 로직 추가하였습니다.

## 💬 리뷰 요구사항

- 프론트 PR은 다음 [링크](https://github.com/PNUops/opus-frontend/pull/231)를 참고해주세요!

## ✨ 기타

- 감사합니다!
