### PR TITLE
Feature/#132 학번으로 이메일 조회 시 이메일 마스킹 처리 추가 

### DIFF
--- a/src/main/java/com/opus/opus/modules/member/application/MemberQueryService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberQueryService.java
@@ -2,40 +2,38 @@ package com.opus.opus.modules.member.application;
 
 import static com.opus.opus.modules.file.domain.FileImageType.PROFILE;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.MEMBER;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_DATE_ORDER;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_DATE_RANGE;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_SORT_VALUE;
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
 
 import com.opus.opus.global.util.FileStorageUtil;
 import com.opus.opus.modules.file.application.convenience.FileConvenience;
 import com.opus.opus.modules.file.domain.File;
-import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_DATE_ORDER;
-import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_DATE_RANGE;
-import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_SORT_VALUE;
-import static org.springframework.data.domain.Sort.Direction.ASC;
-import static org.springframework.data.domain.Sort.Direction.DESC;
-
-import static java.util.stream.Collectors.groupingBy;
-import static java.util.stream.Collectors.toList;
-
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
-import com.opus.opus.modules.member.application.dto.response.AccountInfoResponse;
 import com.opus.opus.modules.member.application.dto.request.SearchConditionRequest;
+import com.opus.opus.modules.member.application.dto.response.AccountInfoResponse;
 import com.opus.opus.modules.member.application.dto.response.EmailFindResponse;
-import com.opus.opus.modules.member.application.dto.response.MyProjectResponse;
-import com.opus.opus.modules.member.domain.dao.MyVoteResponse;
 import com.opus.opus.modules.member.application.dto.response.MyCommentResponse;
 import com.opus.opus.modules.member.application.dto.response.MyLikePreviewResponse;
 import com.opus.opus.modules.member.application.dto.response.MyLikedProjectResponse;
+import com.opus.opus.modules.member.application.dto.response.MyProjectResponse;
 import com.opus.opus.modules.member.domain.Member;
-import com.opus.opus.modules.team.domain.dao.MyProjectFlatResult;
-import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
-import com.opus.opus.modules.team.domain.dao.TeamVoteRepository;
-import java.util.LinkedHashMap;
-import java.util.List;
+import com.opus.opus.modules.member.domain.dao.MyVoteResponse;
 import com.opus.opus.modules.member.exception.MemberException;
+import com.opus.opus.modules.team.application.dto.ImageResponse;
+import com.opus.opus.modules.team.domain.dao.MyProjectFlatResult;
 import com.opus.opus.modules.team.domain.dao.TeamCommentRepository;
 import com.opus.opus.modules.team.domain.dao.TeamLikeRepository;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import com.opus.opus.modules.team.domain.dao.TeamVoteRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import com.opus.opus.modules.team.application.dto.ImageResponse;
+import java.util.LinkedHashMap;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.misc.Pair;
 import org.springframework.core.io.Resource;
@@ -64,11 +62,34 @@ public class MemberQueryService {
 
     public EmailFindResponse getMyEmail(final String studentId) {
         final Member member = memberConvenience.getValidateExistMemberByStudentId(studentId);
-        return new EmailFindResponse(member.getEmail());
+        return new EmailFindResponse(maskEmail(member.getEmail()));
+    }
+
+    private String maskEmail(final String email) {
+        final int atIndex = email.indexOf('@');
+        final String local = email.substring(0, atIndex);
+        final String domain = email.substring(atIndex);
+        return maskLocal(local) + domain;
+    }
+
+    private String maskLocal(final String local) {
+        final int length = local.length();
+        // 이메일 로컬 파트 마스킹
+        if (length == 1) {
+            // 1자: * (ex. a → *)
+            return "*";
+        }
+        if (length <= 3) {
+            // 2~3자: 첫 1자리 노출 (ex. ab → a*, abc → a**)
+            return local.charAt(0) + "*".repeat(length - 1);
+        }
+        // 4자 이상: 첫 3자리 노출, 나머지 문자는 * 처리 (ex. abcde → abd**)
+        return local.substring(0, 3) + "*".repeat(length - 3);
     }
 
     public ImageResponse getProfileImage(final Member member) {
-        final File profileFile = fileConvenience.findByReferenceIdAndReferenceTypeAndImageType(member.getId(), MEMBER, PROFILE);
+        final File profileFile = fileConvenience.findByReferenceIdAndReferenceTypeAndImageType(member.getId(), MEMBER,
+                PROFILE);
         final Pair<Resource, String> storageResult = fileStorageUtil.findFileAndType(profileFile.getId());
         return new ImageResponse(storageResult.a, storageResult.b);
     }
@@ -95,7 +116,8 @@ public class MemberQueryService {
                                                  final int page, final int size) {
         validateDateRange(startDate, endDate);
         final SearchConditionRequest condition = createSearchCondition(sort, startDate, endDate, page, size);
-        return teamCommentRepository.findMyComments(memberId, condition.startDateTime(), condition.endDateTime(), condition.pageable())
+        return teamCommentRepository.findMyComments(memberId, condition.startDateTime(), condition.endDateTime(),
+                        condition.pageable())
                 .map(MyCommentResponse::from);
     }
 
@@ -112,11 +134,13 @@ public class MemberQueryService {
                                                            final int page, final int size) {
         validateDateRange(startDate, endDate);
         final SearchConditionRequest searchCondition = createSearchCondition(sort, startDate, endDate, page, size);
-        return teamLikeRepository.findMyLikedProjects(memberId, searchCondition.startDateTime(), searchCondition.endDateTime(), categoryId, contestId, searchCondition.pageable())
+        return teamLikeRepository.findMyLikedProjects(memberId, searchCondition.startDateTime(),
+                        searchCondition.endDateTime(), categoryId, contestId, searchCondition.pageable())
                 .map(MyLikedProjectResponse::from);
     }
 
-    private SearchConditionRequest createSearchCondition(final String sort, final LocalDate startDate, final LocalDate endDate, final int page, final int size) {
+    private SearchConditionRequest createSearchCondition(final String sort, final LocalDate startDate,
+                                                         final LocalDate endDate, final int page, final int size) {
         final Sort.Direction direction = parseSortDirection(sort);
         final Pageable pageable = PageRequest.of(page, size, Sort.by(direction, "createdAt"));
         final LocalDateTime startDateTime = startDate != null ? startDate.atStartOfDay() : null;

--- a/src/test/java/com/opus/opus/member/application/MemberQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberQueryServiceTest.java
@@ -120,7 +120,7 @@ public class MemberQueryServiceTest extends IntegrationTest {
     void 가입된_회원은_이메일_찾기를_할_수_있다() {
         final EmailFindResponse response = memberQueryService.getMyEmail(member.getStudentId());
 
-        assertThat(response.email()).isEqualTo(member.getEmail());
+        assertThat(response.email()).isEqualTo("exa****@pusan.ac.kr");
     }
 
     @Test


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #132 

## 📜 작업 내용

- 7차 QA에서 타인의 학번으로 가입 이메일을 조회할 수 있다는 개인정보 노출 우려가 제기되었습니다.
- 학번으로 이메일 찾기 기능에서 이메일을 마스킹 처리하여 반환하도록 하였습니다.
- 로컬 파트의 길이에 따른 마스킹 정책 : 
  - 1자 → *
  - 2~3자 → 앞 1자리 노출
  - 4자 이상 → 앞 3자리 노출
  - 도메인은 전체 노출

## 💬 리뷰 요구사항

- 마스킹 정책이 적절한지 확인 부탁드립니다.

## ✨ 기타

- 오늘의 한마디
