### PR TITLE
Feature/#137 메인페이지 통계 지표 변경

### DIFF
--- a/src/main/java/com/opus/opus/modules/member/application/StatisticsQueryService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/StatisticsQueryService.java
@@ -49,7 +49,7 @@ public class StatisticsQueryService {
     }
 
     private StatisticsSummaryResponse queryStatisticsFromDb() {
-        final long totalMembers = memberConvenience.countActiveMembers();
+        final long totalMembers = memberConvenience.countAllMembers();
         final long totalProjects = teamConvenience.countSubmittedTeams();
         final long totalLikes = teamLikeConvenience.countAllLikes();
         final long totalContests = contestConvenience.countAllContests();

--- a/src/main/java/com/opus/opus/modules/member/application/StatisticsQueryService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/StatisticsQueryService.java
@@ -2,6 +2,7 @@ package com.opus.opus.modules.member.application;
 
 import com.opus.opus.global.util.CacheRedisUtil;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.response.StatisticsSummaryResponse;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamLikeConvenience;
@@ -20,6 +21,7 @@ public class StatisticsQueryService {
     private static final String STATISTICS_CACHE_KEY = "statistics:summary";
     private static final long STATISTICS_CACHE_TTL = 10L;
 
+    private final MemberConvenience memberConvenience;
     private final TeamConvenience teamConvenience;
     private final TeamLikeConvenience teamLikeConvenience;
     private final ContestConvenience contestConvenience;
@@ -47,9 +49,10 @@ public class StatisticsQueryService {
     }
 
     private StatisticsSummaryResponse queryStatisticsFromDb() {
+        final long totalMembers = memberConvenience.countActiveMembers();
         final long totalProjects = teamConvenience.countSubmittedTeams();
         final long totalLikes = teamLikeConvenience.countAllLikes();
         final long totalContests = contestConvenience.countAllContests();
-        return new StatisticsSummaryResponse(totalProjects, totalLikes, totalContests);
+        return new StatisticsSummaryResponse(totalMembers, totalProjects, totalLikes, totalContests);
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/member/application/convenience/MemberConvenience.java
@@ -158,6 +158,10 @@ public class MemberConvenience {
         return memberRepository.countByIsFakeFalse();
     }
 
+    public long countAllMembers() {
+        return memberRepository.countAllIncludingDeletedAndFake();
+    }
+
     public Map<Long, Member> getMembersByIds(final List<Long> memberIds) {
         return memberRepository.findAllById(memberIds)
                 .stream()

--- a/src/main/java/com/opus/opus/modules/member/application/convenience/MemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/member/application/convenience/MemberConvenience.java
@@ -154,6 +154,10 @@ public class MemberConvenience {
                 .collect(toMap(Member::getStudentId, Function.identity()));
     }
 
+    public long countActiveMembers() {
+        return memberRepository.countByIsFakeFalse();
+    }
+
     public Map<Long, Member> getMembersByIds(final List<Long> memberIds) {
         return memberRepository.findAllById(memberIds)
                 .stream()

--- a/src/main/java/com/opus/opus/modules/member/application/dto/response/StatisticsSummaryResponse.java
+++ b/src/main/java/com/opus/opus/modules/member/application/dto/response/StatisticsSummaryResponse.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.member.application.dto.response;
 
 public record StatisticsSummaryResponse(
+        long totalMembers,
         long totalProjects,
         long totalLikes,
         long totalContests

--- a/src/main/java/com/opus/opus/modules/member/domain/dao/MemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/dao/MemberRepository.java
@@ -30,4 +30,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByStudentIdIn(final List<String> studentIds);
 
     long countByIsFakeFalse();
+
+    @Query(value = "SELECT COUNT(*) FROM member", nativeQuery = true)
+    long countAllIncludingDeletedAndFake();
 }

--- a/src/main/java/com/opus/opus/modules/member/domain/dao/MemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/dao/MemberRepository.java
@@ -28,4 +28,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByEmailIn(final List<String> emails);
 
     List<Member> findAllByStudentIdIn(final List<String> studentIds);
+
+    long countByIsFakeFalse();
 }

--- a/src/test/java/com/opus/opus/member/application/StatisticsQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/StatisticsQueryServiceTest.java
@@ -64,6 +64,7 @@ public class StatisticsQueryServiceTest extends IntegrationTest {
     void 데이터가_없으면_모두_0을_반환한다() {
         final StatisticsSummaryResponse response = statisticsQueryService.getStatisticsSummary();
 
+        assertThat(response.totalMembers()).isZero();
         assertThat(response.totalContests()).isZero();
         assertThat(response.totalProjects()).isZero();
         assertThat(response.totalLikes()).isZero();

--- a/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
@@ -366,7 +366,7 @@ public class MemberApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[성공] 메인 페이지 통계 요약을 정상적으로 조회할 수 있다.")
     void 메인_페이지_통계_요약을_정상적으로_조회할_수_있다() throws Exception {
-        final StatisticsSummaryResponse response = new StatisticsSummaryResponse(42L, 128L, 5L);
+        final StatisticsSummaryResponse response = new StatisticsSummaryResponse(100L, 42L, 128L, 5L);
 
         when(statisticsQueryService.getStatisticsSummary()).thenReturn(response);
 
@@ -374,6 +374,7 @@ public class MemberApiDocsTest extends RestDocsTest {
                 .andExpect(status().isOk())
                 .andDo(document("statistics-summary",
                         responseFields(
+                                numberFieldWithPath("totalMembers", "총 가입자 수"),
                                 numberFieldWithPath("totalProjects", "등록된 프로젝트 수"),
                                 numberFieldWithPath("totalLikes", "총 좋아요 수"),
                                 numberFieldWithPath("totalContests", "진행된 대회 수")


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #137

## 📜 작업 내용

- 통계 API(`GET /statistics/summary`) 스펙 변경에 따라 `totalMembers`(총 가입자 수) 필드를 추가했습니다.

## 💬 리뷰 요구사항

- fake 회원 제외 기준이 적절한지 확인 부탁드립니다. 현재 `isFake = false` 조건만 사용


