### PR TITLE
Feature/#139 비밀번호 변경 api 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -147,6 +147,47 @@ include::{snippets}/update-password/http-response.adoc[]
 .Request Fields
 include::{snippets}/update-password/request-fields.adoc[]
 
+== `PATCH`: 마이페이지에서 비밀번호 변경
+
+.HTTP Request
+include::{snippets}/update-password-mypage/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/update-password-mypage/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/update-password-mypage/request-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 저장된 비밀번호와 입력한 기존 비밀번호 불일치
+
+[%collapsible]
+
+====
+
+include::{snippets}/update-password-mypage-fail/http-request.adoc[]
+
+include::{snippets}/update-password-mypage-fail/http-response.adoc[]
+
+include::{snippets}/update-password-mypage-fail/request-fields.adoc[]
+
+====
+
+.❌ Case 2: 변경하려는 비밀번호가 기존 비밀번호와 동일
+
+[%collapsible]
+
+====
+
+include::{snippets}/update-password-mypage-fail2/http-request.adoc[]
+
+include::{snippets}/update-password-mypage-fail2/http-response.adoc[]
+
+include::{snippets}/update-password-mypage-fail2/request-fields.adoc[]
+
+====
+
 == `GET` : 가입 이메일 찾기
 
 .HTTP Request

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import com.opus.opus.global.util.CookieUtil;
 import com.opus.opus.global.security.annotation.LoginMember;
+import com.opus.opus.modules.member.application.dto.request.PasswordChangeRequest;
 import org.springframework.security.access.annotation.Secured;
 import com.opus.opus.modules.member.application.MemberCommandService;
 import com.opus.opus.modules.member.application.MemberQueryService;
@@ -204,7 +205,8 @@ public class MemberController {
                                                                  @RequestParam(required = false) @DateTimeFormat(pattern = "yyyy-MM-dd") final LocalDate endDate,
                                                                  @RequestParam(defaultValue = "0") final int page,
                                                                  @RequestParam(defaultValue = "10") final int size) {
-        final Page<MyCommentResponse> response = memberQueryService.getMyComments(member.getId(), sort, startDate, endDate, page, size);
+        final Page<MyCommentResponse> response = memberQueryService.getMyComments(member.getId(), sort, startDate,
+                endDate, page, size);
         return ResponseEntity.ok(response);
     }
 
@@ -225,7 +227,16 @@ public class MemberController {
                                                                            @RequestParam(required = false) final Long contestId,
                                                                            @RequestParam(defaultValue = "0") final int page,
                                                                            @RequestParam(defaultValue = "12") final int size) {
-        final Page<MyLikedProjectResponse> response = memberQueryService.getMyLikedProjects(member.getId(), sort, startDate, endDate, categoryId, contestId, page, size);
+        final Page<MyLikedProjectResponse> response = memberQueryService.getMyLikedProjects(member.getId(), sort,
+                startDate, endDate, categoryId, contestId, page, size);
         return ResponseEntity.ok(response);
+    }
+
+    @Secured({"ROLE_회원", "ROLE_관리자"})
+    @PatchMapping("/members/me/password-change")
+    public ResponseEntity<Void> changeNewPassword(@LoginMember final Member member,
+                                                  @Valid @RequestBody final PasswordChangeRequest request) {
+        memberCommandService.changeNewPassword(member, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/api/MemberController.java
+++ b/src/main/java/com/opus/opus/modules/member/api/MemberController.java
@@ -5,7 +5,7 @@ import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import com.opus.opus.global.util.CookieUtil;
 import com.opus.opus.global.security.annotation.LoginMember;
-import com.opus.opus.modules.member.application.dto.request.PasswordChangeRequest;
+import com.opus.opus.modules.member.application.dto.request.PasswordUpdateMyPageRequest;
 import org.springframework.security.access.annotation.Secured;
 import com.opus.opus.modules.member.application.MemberCommandService;
 import com.opus.opus.modules.member.application.MemberQueryService;
@@ -233,10 +233,10 @@ public class MemberController {
     }
 
     @Secured({"ROLE_회원", "ROLE_관리자"})
-    @PatchMapping("/members/me/password-change")
-    public ResponseEntity<Void> changeNewPassword(@LoginMember final Member member,
-                                                  @Valid @RequestBody final PasswordChangeRequest request) {
-        memberCommandService.changeNewPassword(member, request);
+    @PatchMapping("/members/me/password-reset")
+    public ResponseEntity<Void> updatePasswordInMyPage(@LoginMember final Member member,
+                                                  @Valid @RequestBody final PasswordUpdateMyPageRequest request) {
+        memberCommandService.updatePasswordInMyPage(member, request);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -23,6 +23,7 @@ import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthRequest;
 import com.opus.opus.modules.member.application.dto.request.GithubUrlUpdateRequest;
+import com.opus.opus.modules.member.application.dto.request.PasswordChangeRequest;
 import com.opus.opus.modules.member.application.dto.request.PasswordUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.ProfileVisibilityUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.StudentIdUpdateRequest;
@@ -175,6 +176,12 @@ public class MemberCommandService {
         member.updatePassword(passwordEncoder.encode(request.newPassword()));
 
         authRedisUtil.delete(signInVerifiedKey(email));
+    }
+
+    public void changeNewPassword(final Member member, final PasswordChangeRequest request) {
+        checkCorrectPassword(member.getPassword(), request.password());
+        checkEqualPassword(request.newPassword(), member);
+        member.updatePassword(request.newPassword());
     }
 
     private void verifyVerifiedKey(final String verifiedKey) {

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -23,7 +23,7 @@ import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthRequest;
 import com.opus.opus.modules.member.application.dto.request.GithubUrlUpdateRequest;
-import com.opus.opus.modules.member.application.dto.request.PasswordChangeRequest;
+import com.opus.opus.modules.member.application.dto.request.PasswordUpdateMyPageRequest;
 import com.opus.opus.modules.member.application.dto.request.PasswordUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.ProfileVisibilityUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.StudentIdUpdateRequest;
@@ -178,7 +178,7 @@ public class MemberCommandService {
         authRedisUtil.delete(signInVerifiedKey(email));
     }
 
-    public void changeNewPassword(final Member member, final PasswordChangeRequest request) {
+    public void updatePasswordInMyPage(final Member member, final PasswordUpdateMyPageRequest request) {
         checkCorrectPassword(member.getPassword(), request.password());
         checkEqualPassword(request.newPassword(), member);
         member.updatePassword(request.newPassword());

--- a/src/main/java/com/opus/opus/modules/member/application/dto/request/PasswordChangeRequest.java
+++ b/src/main/java/com/opus/opus/modules/member/application/dto/request/PasswordChangeRequest.java
@@ -1,0 +1,18 @@
+package com.opus.opus.modules.member.application.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+public record PasswordChangeRequest(
+
+        @NotNull(message = "기존 비밀번호를 입력해주세요.")
+        String password,
+
+        @NotNull(message = "새로운 비밀번호를 입력해주세요.")
+        @Pattern(
+                regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&~])[A-Za-z\\d@$!%*#?&~]{8,16}$",
+                message = "비밀번호는 8~16자여야 하며, 영문·숫자·특수문자를 모두 포함해야 합니다."
+        )
+        String newPassword
+) {
+}

--- a/src/main/java/com/opus/opus/modules/member/application/dto/request/PasswordUpdateMyPageRequest.java
+++ b/src/main/java/com/opus/opus/modules/member/application/dto/request/PasswordUpdateMyPageRequest.java
@@ -3,7 +3,7 @@ package com.opus.opus.modules.member.application.dto.request;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
-public record PasswordChangeRequest(
+public record PasswordUpdateMyPageRequest(
 
         @NotNull(message = "기존 비밀번호를 입력해주세요.")
         String password,

--- a/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
@@ -1,7 +1,9 @@
 package com.opus.opus.restdocs.docs;
 
 import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_EXISTS_MATCHING_IMAGE_ID;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_CHANGE_SAME_PASSWORD;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_PASSWORD;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_UPDATE_STUDENT_ID;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
@@ -39,6 +41,7 @@ import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthRequest;
 import com.opus.opus.modules.member.application.dto.request.GithubUrlUpdateRequest;
+import com.opus.opus.modules.member.application.dto.request.PasswordUpdateMyPageRequest;
 import com.opus.opus.modules.member.application.dto.request.PasswordUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.SignInRequest;
 import com.opus.opus.modules.member.application.dto.request.SignUpRequest;
@@ -293,6 +296,67 @@ public class MemberApiDocsTest extends RestDocsTest {
                         requestFields(
                                 stringFieldWithPath("email", "가입 이메일"),
                                 stringFieldWithPath("newPassword", "새로운 비밀번호")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 정상적으로 마이페이지에서 비밀번호는 변경된다.")
+    void 유효한_요청이면_정상적으로_마이페이지에서_비밀번호는_변경된다() throws Exception {
+        final PasswordUpdateMyPageRequest request = new PasswordUpdateMyPageRequest(member.getPassword(),
+                "newPassword1!");
+
+        doNothing().when(memberCommandService).updatePasswordInMyPage(member, request);
+
+        mockMvc.perform(patch("/members/me/password-reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-password-mypage",
+                        requestFields(
+                                stringFieldWithPath("password", "기존 비밀번호"),
+                                stringFieldWithPath("newPassword", "새로운 비밀번호")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 입력한 기존 비밀번호가 저장된 비밀번호와 일치하지 않으면 비밀번호는 변경되지 않는다.")
+    void 입력한_기존_비밀번호가_저장된_비밀번호와_일치하지_않으면_비밀번호는_변경되지_않는다() throws Exception {
+        final PasswordUpdateMyPageRequest request = new PasswordUpdateMyPageRequest("wrongPassword!", "newPassword1!");
+
+        willThrow(new MemberException(CANNOT_MATCH_PASSWORD)).given(memberCommandService)
+                .updatePasswordInMyPage(any(), any());
+
+        mockMvc.perform(patch("/members/me/password-reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("update-password-mypage-fail",
+                        requestFields(
+                                stringFieldWithPath("password", "기존 비밀번호와 일치하지 않는 비밀번호"),
+                                stringFieldWithPath("newPassword", "새로운 비밀번호")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 변경하려는 비밀번호가 기존 비밀번호와 일치하면 비밀번호는 변경되지 않는다.")
+    void 변경하려는_비밀번호가_기존_비밀번호와_일치하면_비밀번호는_변경되지_않는다() throws Exception {
+        final PasswordUpdateMyPageRequest request = new PasswordUpdateMyPageRequest(member.getPassword(),
+                member.getPassword());
+
+        willThrow(new MemberException(CANNOT_CHANGE_SAME_PASSWORD)).given(memberCommandService)
+                .updatePasswordInMyPage(any(), any());
+
+        mockMvc.perform(patch("/members/me/password-reset")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("update-password-mypage-fail2",
+                        requestFields(
+                                stringFieldWithPath("password", "기존 비밀번호"),
+                                stringFieldWithPath("newPassword", "기존 비밀번호와 동일한 비밀번호")
                         )
                 ));
     }
@@ -656,7 +720,8 @@ public class MemberApiDocsTest extends RestDocsTest {
         final List<MyCommentResponse> content = List.of(
                 new MyCommentResponse(
                         new CommentInfo(1L, "인정합니다.", of(2026, 1, 1, 0, 0), "홍지연"),
-                        new ProjectInfo(1L, "제6회창의융합해커톤대회", "해커톤", "창업트랙", 5L, "TeamName", "Project Name", "Artify는 일상 속 모든 순간을 예술로 재해석하는 크리에이티브 플랫폼입니다.")
+                        new ProjectInfo(1L, "제6회창의융합해커톤대회", "해커톤", "창업트랙", 5L, "TeamName", "Project Name",
+                                "Artify는 일상 속 모든 순간을 예술로 재해석하는 크리에이티브 플랫폼입니다.")
                 )
         );
         final Page<MyCommentResponse> page = new PageImpl<>(content,


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #139 

## 📜 작업 내용

- 마이페이지에서 비밀번호 변경이 가능하도록 API를 개발했습니다.
- 기존 비밀번호를 입력해서 확인 후, 기존 비밀번호와 다른 비밀번호로 변경 가능합니다.  

## 💬 리뷰 요구사항

- 없습니당~

## ✨ 기타

- 금요일이라서 기분이 좋아요😊
