### PR TITLE
Feature/#148 교직원 회원가입 로직 분리

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/member.adoc
@@ -84,7 +84,9 @@ include::{snippets}/signup-auth-confirm-fail2/request-fields.adoc[]
 
 ====
 
-== `POST`: 회원가입
+== `POST`: 회원가입 (학생)
+
+NOTE: `memberType`은 `STUDENT` 또는 `STAFF`로 전달합니다. 학생은 `STUDENT`로 가입하며 `ROLE_학생` 권한이 부여됩니다.
 
 .HTTP Request
 include::{snippets}/signup/http-request.adoc[]
@@ -94,6 +96,49 @@ include::{snippets}/signup/http-response.adoc[]
 
 .Request Fields
 include::{snippets}/signup/request-fields.adoc[]
+
+== `POST`: 회원가입 (교직원)
+
+NOTE: `memberType`을 `STAFF`로 전달하면 교직원 정보(`StaffInfo`)와 이메일·이름이 일치하는지 대조한 뒤, 일치하는 교직원 정보에 저장된 권한으로 가입됩니다.
+
+.HTTP Request
+include::{snippets}/signup-staff/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/signup-staff/http-response.adoc[]
+
+.Request Fields
+include::{snippets}/signup-staff/request-fields.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 일치하는 교직원 정보 없음
+
+[%collapsible]
+
+====
+
+include::{snippets}/signup-staff-fail/http-request.adoc[]
+
+include::{snippets}/signup-staff-fail/http-response.adoc[]
+
+include::{snippets}/signup-staff-fail/request-fields.adoc[]
+
+====
+
+.❌ Case 2: 회원 유형이 STUDENT, STAFF가 아님
+
+[%collapsible]
+
+====
+
+include::{snippets}/signup-invalid-type/http-request.adoc[]
+
+include::{snippets}/signup-invalid-type/http-response.adoc[]
+
+include::{snippets}/signup-invalid-type/request-fields.adoc[]
+
+====
 
 == `POST`: 로그인
 

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -9,15 +9,15 @@ import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_UPDATE_STUDENT_ID;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.EMAIL_AUTH_LIMIT_EXCEEDED;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_STAFF_INFO;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_VERIFIED_EMAIL_AUTH;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.SOCIAL_MEMBER_CANNOT_USE_GENERAL_LOGIN;
 
 import com.opus.opus.global.security.JwtProvider;
 import com.opus.opus.global.util.AuthRedisUtil;
-import com.opus.opus.modules.file.application.FileCommandService;
 import com.opus.opus.global.util.GoogleTokenManager;
 import com.opus.opus.global.util.MailUtil;
-import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.application.FileCommandService;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.application.dto.request.EmailAuthConfirmRequest;
@@ -26,13 +26,15 @@ import com.opus.opus.modules.member.application.dto.request.GithubUrlUpdateReque
 import com.opus.opus.modules.member.application.dto.request.PasswordUpdateMyPageRequest;
 import com.opus.opus.modules.member.application.dto.request.PasswordUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.ProfileVisibilityUpdateRequest;
-import com.opus.opus.modules.member.application.dto.request.StudentIdUpdateRequest;
 import com.opus.opus.modules.member.application.dto.request.SignInRequest;
 import com.opus.opus.modules.member.application.dto.request.SignUpRequest;
+import com.opus.opus.modules.member.application.dto.request.StudentIdUpdateRequest;
 import com.opus.opus.modules.member.application.dto.response.SignInResponse;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.MemberRoleType;
+import com.opus.opus.modules.member.domain.StaffInfo;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.member.domain.dao.StaffInfoRepository;
 import com.opus.opus.modules.member.exception.MemberException;
 import java.security.SecureRandom;
 import java.util.ArrayList;
@@ -53,6 +55,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class MemberCommandService {
 
     private final MemberRepository memberRepository;
+    private final StaffInfoRepository staffInfoRepository;
     private final FileRepository fileRepository;
 
     private final MemberConvenience memberConvenience;
@@ -85,25 +88,18 @@ public class MemberCommandService {
 
     private static final String VERIFIED_VALUE = "true";
 
+    private static final String STAFF_MEMBER_TYPE = "STAFF";
+
     public void signUp(final SignUpRequest request) {
         final String email = request.email();
         verifyVerifiedKey(signUpVerifiedKey(email));
 
         final String encodingPassword = passwordEncoder.encode(request.password());
 
-        // 가짜 회원 여부 먼저 확인
-        final Optional<Member> fakeMember = memberRepository.findByEmail(email)
-                .filter(Member::isFakeMember);
-
-        if (fakeMember.isPresent()) { // 가짜 회원이 등록되어있는 경우 일반 회원으로 전환
-            fakeMember.get().convertFakeToGeneral(email, encodingPassword, request.studentId());
+        if (isStaffSignUp(request.memberType())) {
+            signUpStaff(request, encodingPassword);
         } else {
-            memberConvenience.checkIsDuplicateEmail(email);
-            memberRepository.findByStudentIdAndName(request.studentId(), request.name())
-                    .ifPresentOrElse(
-                            member -> member.updateTeamLeaderInfo(email, encodingPassword),
-                            () -> registerNewMember(request.name(), request.studentId(), email, encodingPassword)
-                    );
+            signUpStudent(request, encodingPassword);
         }
 
         authRedisUtil.delete(signUpVerifiedKey(email));
@@ -188,6 +184,45 @@ public class MemberCommandService {
         if (authRedisUtil.get(verifiedKey) == null) {
             throw new MemberException(NOT_VERIFIED_EMAIL_AUTH);
         }
+    }
+
+    private boolean isStaffSignUp(final String memberType) {
+        return STAFF_MEMBER_TYPE.equals(memberType);
+    }
+
+    private void signUpStudent(final SignUpRequest request, final String encodingPassword) {
+        final String email = request.email();
+
+        // 가짜 회원 여부 먼저 확인
+        final Optional<Member> fakeMember = memberRepository.findByEmail(email)
+                .filter(Member::isFakeMember);
+
+        if (fakeMember.isPresent()) { // 가짜 회원이 등록되어있는 경우 일반 회원으로 전환
+            fakeMember.get().convertFakeToGeneral(email, encodingPassword, request.studentId());
+        } else {
+            memberConvenience.checkIsDuplicateEmail(email);
+            memberRepository.findByStudentIdAndName(request.studentId(), request.name())
+                    .ifPresentOrElse(
+                            member -> member.updateTeamLeaderInfo(email, encodingPassword),
+                            () -> registerNewMember(request.name(), request.studentId(), email, encodingPassword)
+                    );
+        }
+    }
+
+    private void signUpStaff(final SignUpRequest request, final String encodingPassword) {
+        final StaffInfo staffInfo = staffInfoRepository.findByEmailAndName(request.email(), request.name())
+                .orElseThrow(() -> new MemberException(NOT_FOUND_STAFF_INFO));
+
+        memberConvenience.checkIsDuplicateEmail(request.email());
+        memberConvenience.checkIsDuplicateStudentId(request.studentId());
+
+        memberRepository.save(Member.generalMember()
+                .name(request.name())
+                .studentId(request.studentId())
+                .email(request.email())
+                .password(encodingPassword)
+                .roles(Set.of(staffInfo.getRole()))
+                .build());
     }
 
     private void registerNewMember(final String name, final String studentId, final String email,

--- a/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/member/application/MemberCommandService.java
@@ -213,6 +213,9 @@ public class MemberCommandService {
         final StaffInfo staffInfo = staffInfoRepository.findByEmailAndName(request.email(), request.name())
                 .orElseThrow(() -> new MemberException(NOT_FOUND_STAFF_INFO));
 
+        final MemberRoleType role = staffInfo.getRole();
+        validateStaffRole(role);
+
         memberConvenience.checkIsDuplicateEmail(request.email());
         memberConvenience.checkIsDuplicateStudentId(request.studentId());
 
@@ -221,8 +224,14 @@ public class MemberCommandService {
                 .studentId(request.studentId())
                 .email(request.email())
                 .password(encodingPassword)
-                .roles(Set.of(staffInfo.getRole()))
+                .roles(Set.of(role))
                 .build());
+    }
+
+    private void validateStaffRole(final MemberRoleType role) {
+        if (role != MemberRoleType.ROLE_교수 && role != MemberRoleType.ROLE_직원) {
+            throw new MemberException(NOT_FOUND_STAFF_INFO);
+        }
     }
 
     private void registerNewMember(final String name, final String studentId, final String email,

--- a/src/main/java/com/opus/opus/modules/member/application/dto/request/SignUpRequest.java
+++ b/src/main/java/com/opus/opus/modules/member/application/dto/request/SignUpRequest.java
@@ -19,6 +19,13 @@ public record SignUpRequest(
                 regexp = "^(?=.*[A-Za-z])(?=.*\\d)(?=.*[@$!%*#?&~])[A-Za-z\\d@$!%*#?&~]{8,16}$",
                 message = "비밀번호는 8~16자여야 하며, 영문·숫자·특수문자를 모두 포함해야 합니다."
         )
-        String password
+        String password,
+
+        @NotNull(message = "회원 유형을 입력해주세요.")
+        @Pattern(
+                regexp = "STUDENT|STAFF",
+                message = "회원 유형은 STUDENT 또는 STAFF만 가능합니다."
+        )
+        String memberType
 ) {
 }

--- a/src/main/java/com/opus/opus/modules/member/domain/StaffInfo.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/StaffInfo.java
@@ -1,0 +1,42 @@
+package com.opus.opus.modules.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StaffInfo {
+
+    private static final int MAX_ROLE_NAME_LENGTH = 20;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = MAX_ROLE_NAME_LENGTH)
+    private MemberRoleType role;
+
+    @Builder
+    private StaffInfo(final String name, final String email, final MemberRoleType role) {
+        this.name = name;
+        this.email = email;
+        this.role = role;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/member/domain/dao/StaffInfoRepository.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/dao/StaffInfoRepository.java
@@ -1,0 +1,10 @@
+package com.opus.opus.modules.member.domain.dao;
+
+import com.opus.opus.modules.member.domain.StaffInfo;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StaffInfoRepository extends JpaRepository<StaffInfo, Long> {
+
+    Optional<StaffInfo> findByEmailAndName(final String email, final String name);
+}

--- a/src/main/java/com/opus/opus/modules/member/exception/MemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/member/exception/MemberExceptionType.java
@@ -16,6 +16,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     CANNOT_MATCH_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "이메일 인증 코드가 일치하지 않습니다."),
     CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE(HttpStatus.BAD_REQUEST, "이메일 인증 코드 만료 시간이 초과되었습니다."),
     MISMATCH_STUDENT_ID_AND_NAME(HttpStatus.BAD_REQUEST, "입력한 학번과 이름이 일치하지 않습니다."),
+    NOT_FOUND_STAFF_INFO(HttpStatus.BAD_REQUEST, "일치하는 교직원 정보가 없습니다."),
     EMAIL_AUTH_LIMIT_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS, "24시간 내 요청 횟수를 초과했습니다. 24시간 후 다시 시도해주세요."),
     SOCIAL_MEMBER_CANNOT_USE_GENERAL_LOGIN(HttpStatus.BAD_REQUEST, "소셜 로그인 회원은 일반 로그인을 사용할 수 없습니다."),
     GENERAL_MEMBER_CANNOT_USE_SOCIAL_LOGIN(HttpStatus.BAD_REQUEST, "일반 회원으로 가입된 이메일입니다. 일반 로그인을 이용해주세요."),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -145,8 +145,9 @@ CREATE TABLE `staff_info` (
   `id` bigint NOT NULL AUTO_INCREMENT,
   `name` varchar(255) NOT NULL,
   `email` varchar(255) NOT NULL,
-  `role` enum('ROLE_학생','ROLE_관리자','ROLE_교수','ROLE_직원','ROLE_외부멘토') NOT NULL,
-  PRIMARY KEY (`id`)
+  `role` enum('ROLE_교수','ROLE_직원') NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_staff_info_email_name` (`email`,`name`)
 );
 
 CREATE TABLE `notification` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -7,6 +7,7 @@ DROP TABLE IF EXISTS `team_comment`;
 DROP TABLE IF EXISTS `team_contest_award`;
 DROP TABLE IF EXISTS `team_member`;
 DROP TABLE IF EXISTS `member_roles`;
+DROP TABLE IF EXISTS `staff_info`;
 DROP TABLE IF EXISTS `team`;
 DROP TABLE IF EXISTS `contest_sort`;
 DROP TABLE IF EXISTS `contest_track`;
@@ -138,6 +139,14 @@ CREATE TABLE `member_roles` (
   `member_id` bigint NOT NULL,
   `role` enum('ROLE_학생','ROLE_관리자','ROLE_교수','ROLE_직원','ROLE_외부멘토') NOT NULL,
   PRIMARY KEY (`member_id`,`role`)
+);
+
+CREATE TABLE `staff_info` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) NOT NULL,
+  `email` varchar(255) NOT NULL,
+  `role` enum('ROLE_학생','ROLE_관리자','ROLE_교수','ROLE_직원','ROLE_외부멘토') NOT NULL,
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `notification` (

--- a/src/test/java/com/opus/opus/member/StaffInfoFixture.java
+++ b/src/test/java/com/opus/opus/member/StaffInfoFixture.java
@@ -1,0 +1,25 @@
+package com.opus.opus.member;
+
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
+
+import com.opus.opus.modules.member.domain.MemberRoleType;
+import com.opus.opus.modules.member.domain.StaffInfo;
+
+public class StaffInfoFixture {
+
+    public static StaffInfo createStaffInfo(final String name, final String email, final MemberRoleType role) {
+        return StaffInfo.builder()
+                .name(name)
+                .email(email)
+                .role(role)
+                .build();
+    }
+
+    public static StaffInfo createStaffInfo() {
+        return StaffInfo.builder()
+                .name("교직원")
+                .email("staff@pusan.ac.kr")
+                .role(ROLE_교수)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -289,20 +289,6 @@ public class MemberCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[실패] 교직원 회원가입 시 교직원 권한이 아닌 정보로는 가입이 불가하다.")
-    void 교직원_회원가입_시_교직원_권한이_아닌_정보로는_가입이_불가하다() {
-        staffInfoRepository.save(
-                StaffInfoFixture.createStaffInfo("관리자", emailAuthRequest.email(), MemberRoleType.ROLE_관리자));
-        verifySignUpEmail();
-        final SignUpRequest request = new SignUpRequest("관리자", "S202512345", emailAuthRequest.email(), "qwer123!",
-                "STAFF");
-
-        assertThatThrownBy(() -> memberCommandService.signUp(request))
-                .isInstanceOf(MemberException.class)
-                .hasMessage(NOT_FOUND_STAFF_INFO.errorMessage());
-    }
-
-    @Test
     @DisplayName("[성공] 가입된 회원은 로그인 할 수 있다.")
     void 가입된_회원은_로그인_할_수_있다() {
         final SignInRequest request = new SignInRequest(teamLeader.getEmail(), "123456789");

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -289,6 +289,20 @@ public class MemberCommandServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[실패] 교직원 회원가입 시 교직원 권한이 아닌 정보로는 가입이 불가하다.")
+    void 교직원_회원가입_시_교직원_권한이_아닌_정보로는_가입이_불가하다() {
+        staffInfoRepository.save(
+                StaffInfoFixture.createStaffInfo("관리자", emailAuthRequest.email(), MemberRoleType.ROLE_관리자));
+        verifySignUpEmail();
+        final SignUpRequest request = new SignUpRequest("관리자", "S202512345", emailAuthRequest.email(), "qwer123!",
+                "STAFF");
+
+        assertThatThrownBy(() -> memberCommandService.signUp(request))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(NOT_FOUND_STAFF_INFO.errorMessage());
+    }
+
+    @Test
     @DisplayName("[성공] 가입된 회원은 로그인 할 수 있다.")
     void 가입된_회원은_로그인_할_수_있다() {
         final SignInRequest request = new SignInRequest(teamLeader.getEmail(), "123456789");

--- a/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/member/application/MemberCommandServiceTest.java
@@ -1,10 +1,12 @@
 package com.opus.opus.member.application;
 
 import static com.opus.opus.member.MemberFixture.createMemberWithUniqueNum;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_학생;
 import static com.opus.opus.modules.file.domain.FileImageType.PROFILE;
 import static com.opus.opus.modules.file.domain.ReferenceDomainType.MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_STAFF_INFO;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.EMAIL_AUTH_LIMIT_EXCEEDED;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.GENERAL_MEMBER_CANNOT_USE_SOCIAL_LOGIN;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_UPDATE_STUDENT_ID;
@@ -23,6 +25,7 @@ import static org.mockito.Mockito.when;
 import com.opus.opus.global.security.oauth2.GoogleOAuth2UserService;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
+import com.opus.opus.member.StaffInfoFixture;
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.dao.FileRepository;
 import com.opus.opus.file.FileFixture;
@@ -36,7 +39,9 @@ import com.opus.opus.modules.member.application.dto.request.ProfileVisibilityUpd
 import com.opus.opus.modules.member.application.dto.request.StudentIdUpdateRequest;
 import com.opus.opus.modules.member.application.dto.response.SignInResponse;
 import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.MemberRoleType;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.member.domain.dao.StaffInfoRepository;
 import com.opus.opus.modules.member.exception.MemberException;
 import org.springframework.mock.web.MockMultipartFile;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +65,9 @@ public class MemberCommandServiceTest extends IntegrationTest {
     private MemberRepository memberRepository;
 
     @Autowired
+    private StaffInfoRepository staffInfoRepository;
+
+    @Autowired
     private FileRepository fileRepository;
 
     private Member teamLeader;
@@ -75,6 +83,13 @@ public class MemberCommandServiceTest extends IntegrationTest {
         authRedisUtil.delete("signup:email:verified:" + emailAuthRequest.email());
         authRedisUtil.delete("signin:email:auth:" + emailAuthRequest.email());
         authRedisUtil.delete("signin:email:verified:" + emailAuthRequest.email());
+    }
+
+    private void verifySignUpEmail() {
+        memberCommandService.signUpEmailAuth(emailAuthRequest);
+        final EmailAuthConfirmRequest emailAuthConfirmRequest = new EmailAuthConfirmRequest(emailAuthRequest.email(),
+                authRedisUtil.get("signup:email:auth:" + emailAuthRequest.email()));
+        memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
     }
 
     @Test
@@ -167,7 +182,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
     @Test
     @DisplayName("[성공] 인증 코드 TTL은 5분이다.")
-    @Disabled // 테스트에 따라 4와 5가 랜덤. 필요 시 Disable 해제하고 테스트
+    @Disabled
+        // 테스트에 따라 4와 5가 랜덤. 필요 시 Disable 해제하고 테스트
     void 인증_코드_TTL은_5분이다() {
         memberCommandService.signUpEmailAuth(emailAuthRequest);
 
@@ -177,7 +193,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
 
     @Test
     @DisplayName("[성공] 인증 완료 코드 TTL은 10분이다.")
-    @Disabled // 테스트에 따라 9와 10이 랜덤. 필요 시 Disable 해제하고 테스트
+    @Disabled
+        // 테스트에 따라 9와 10이 랜덤. 필요 시 Disable 해제하고 테스트
     void 인증_완료_코드_TTL은_10분이다() {
         memberCommandService.signUpEmailAuth(emailAuthRequest);
         final EmailAuthConfirmRequest emailAuthConfirmRequest = new EmailAuthConfirmRequest(emailAuthRequest.email(),
@@ -186,29 +203,29 @@ public class MemberCommandServiceTest extends IntegrationTest {
         memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
 
         // 인증 시간은 테스트 시작부터 줄어들기 때문에(내림 처리됨) 9분으로 설정 (실제는 10분)
-        assertThat(authRedisUtil.ttl("signup:email:verified:" + emailAuthRequest.email(), TimeUnit.MINUTES)).isEqualTo(9);
+        assertThat(authRedisUtil.ttl("signup:email:verified:" + emailAuthRequest.email(), TimeUnit.MINUTES)).isEqualTo(
+                9);
     }
 
     @Test
-    @DisplayName("[성공] 인증 완료 코드가 있다면 회원가입은 정상적으로 이뤄진다.")
-    void 인증_완료_코드가_있다면_회원가입은_정상적으로_이뤄진다() {
-        memberCommandService.signUpEmailAuth(emailAuthRequest);
-        final EmailAuthConfirmRequest emailAuthConfirmRequest = new EmailAuthConfirmRequest(emailAuthRequest.email(),
-                authRedisUtil.get("signup:email:auth:" + emailAuthRequest.email()));
-        memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
-        final SignUpRequest request = new SignUpRequest("이름", "202512345", "qwer1234@pusan.ac.kr", "qwer123!");
+    @DisplayName("[성공] 학생 회원가입 시 인증 완료 코드가 있다면 학생 권한으로 가입된다.")
+    void 학생_회원가입_시_인증_완료_코드가_있다면_학생_권한으로_가입된다() {
+        verifySignUpEmail();
+        final SignUpRequest request = new SignUpRequest("이름", "202512345", emailAuthRequest.email(), "qwer123!",
+                "STUDENT");
 
         memberCommandService.signUp(request);
 
         final Member member = memberRepository.findByStudentId("202512345").orElseThrow();
         assertThat(member.getName()).isEqualTo("이름");
+        assertThat(member.getRoles()).containsExactly(ROLE_학생);
     }
 
     @Test
     @DisplayName("[실패] 인증 완료 코드가 없다면 회원가입은 불가하다.")
     void 인증_완료_코드가_없다면_회원가입은_불가하다() {
         final SignUpRequest notExistAuthCodeRequest = new SignUpRequest("이름", "202512345", "qwer1234@pusan.ac.kr",
-                "qwer123!");
+                "qwer123!", "STUDENT");
 
         assertThatThrownBy(() -> {
             memberCommandService.signUp(notExistAuthCodeRequest);
@@ -218,13 +235,9 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 관리자가 권한을 등록한 회원은 가입 시 이메일과 비밀번호가 업데이트 된다. ")
     void 관리자가_권한을_등록한_회원은_가입_시_이메일과_비밀번호가_업데이트_된다() {
-        memberCommandService.signUpEmailAuth(emailAuthRequest);
-        final EmailAuthConfirmRequest emailAuthConfirmRequest = new EmailAuthConfirmRequest(emailAuthRequest.email(),
-                authRedisUtil.get("signup:email:auth:" + emailAuthRequest.email()));
-        memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
+        verifySignUpEmail();
         final SignUpRequest teamLeaderRequest = new SignUpRequest(teamLeader.getName(), teamLeader.getStudentId(),
-                "qwer1234@pusan.ac.kr",
-                "changePassword");
+                emailAuthRequest.email(), "qwer123!", "STUDENT");
 
         memberCommandService.signUp(teamLeaderRequest);
 
@@ -236,16 +249,43 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 회원가입이 완료되면 인증 완료 코드는 삭제된다.")
     void 회원가입이_완료되면_인증_완료_코드는_삭제된다() {
-        memberCommandService.signUpEmailAuth(emailAuthRequest);
-        final EmailAuthConfirmRequest emailAuthConfirmRequest = new EmailAuthConfirmRequest(emailAuthRequest.email(),
-                authRedisUtil.get("signup:email:auth:" + emailAuthRequest.email()));
-        memberCommandService.confirmSignUpEmailAuth(emailAuthConfirmRequest);
+        verifySignUpEmail();
         final SignUpRequest teamLeaderRequest = new SignUpRequest(teamLeader.getName(), teamLeader.getStudentId(),
-                "qwer1234@pusan.ac.kr", "changePassword");
+                emailAuthRequest.email(), "qwer123!", "STUDENT");
 
         memberCommandService.signUp(teamLeaderRequest);
 
         assertThat(authRedisUtil.get("signup:email:verified:" + emailAuthRequest.email())).isNull();
+    }
+
+    @Test
+    @DisplayName("[성공] 교직원 회원가입 시 일치하는 교직원 정보의 권한으로 가입된다.")
+    void 교직원_회원가입_시_일치하는_교직원_정보의_권한으로_가입된다() {
+        staffInfoRepository.save(
+                StaffInfoFixture.createStaffInfo("교수님", emailAuthRequest.email(), MemberRoleType.ROLE_교수));
+        verifySignUpEmail();
+        final SignUpRequest request = new SignUpRequest("교수님", "S202512345", emailAuthRequest.email(), "qwer123!",
+                "STAFF");
+
+        memberCommandService.signUp(request);
+
+        final Member member = memberRepository.findByEmail(emailAuthRequest.email()).orElseThrow();
+        assertThat(member.getName()).isEqualTo("교수님");
+        assertThat(member.getRoles()).containsExactly(MemberRoleType.ROLE_교수);
+    }
+
+    @Test
+    @DisplayName("[실패] 교직원 회원가입 시 일치하는 교직원 정보가 없으면 가입이 불가하다.")
+    void 교직원_회원가입_시_일치하는_교직원_정보가_없으면_가입이_불가하다() {
+        staffInfoRepository.save(
+                StaffInfoFixture.createStaffInfo("다른교수", emailAuthRequest.email(), MemberRoleType.ROLE_교수));
+        verifySignUpEmail();
+        final SignUpRequest request = new SignUpRequest("없는교직원", "S202512345", emailAuthRequest.email(), "qwer123!",
+                "STAFF");
+
+        assertThatThrownBy(() -> memberCommandService.signUp(request))
+                .isInstanceOf(MemberException.class)
+                .hasMessage(NOT_FOUND_STAFF_INFO.errorMessage());
     }
 
     @Test
@@ -276,7 +316,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 신규 소셜 회원은 자동 가입된다.")
     void 신규_소셜_회원은_자동_가입된다() {
-        ReflectionTestUtils.invokeMethod(googleOAuth2UserService, "registerNewSocialMember", "김태윤", "pykido@gmail.com", "google-sub-999");
+        ReflectionTestUtils.invokeMethod(googleOAuth2UserService, "registerNewSocialMember", "김태윤", "pykido@gmail.com",
+                "google-sub-999");
 
         final Member savedMember = memberRepository.findByEmail("pykido@gmail.com").orElseThrow();
         assertThat(savedMember.isSocialMember()).isTrue();
@@ -286,7 +327,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 학번 수정이 정상적으로 이루어진다.")
     void 학번_수정이_정상적으로_이루어진다() {
-        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("cscs@pusan.ac.kr", "google-123456789"));
+        final Member socialMember = memberRepository.save(
+                MemberFixture.createSocialMember("cscs@pusan.ac.kr", "google-123456789"));
         final StudentIdUpdateRequest request = new StudentIdUpdateRequest("202512345");
         assertThat(socialMember.getStudentId()).isNull();
 
@@ -310,7 +352,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 부산대 메일이 아닌 소셜 회원은 학번 수정이 불가하다.")
     void 부산대_메일이_아닌_소셜_회원은_학번_수정이_불가하다() {
-        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("cscs@gmail.com", "google-999"));
+        final Member socialMember = memberRepository.save(
+                MemberFixture.createSocialMember("cscs@gmail.com", "google-999"));
         final StudentIdUpdateRequest request = new StudentIdUpdateRequest("202512345");
 
         assertThatThrownBy(() ->
@@ -322,7 +365,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 이미 학번이 있는 소셜 회원은 학번 수정이 불가하다.")
     void 이미_학번이_있는_소셜_회원은_학번_수정이_불가하다() {
-        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("already@pusan.ac.kr", "google-999"));
+        final Member socialMember = memberRepository.save(
+                MemberFixture.createSocialMember("already@pusan.ac.kr", "google-999"));
         socialMember.updateStudentId("202011111");
         memberRepository.save(socialMember);
         final StudentIdUpdateRequest request = new StudentIdUpdateRequest("202512345");
@@ -336,7 +380,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 중복된 학번으로는 수정이 불가하다.")
     void 중복된_학번으로는_수정이_불가하다() {
-        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("cscs@pusan.ac.kr", "google-123456789"));
+        final Member socialMember = memberRepository.save(
+                MemberFixture.createSocialMember("cscs@pusan.ac.kr", "google-123456789"));
         final StudentIdUpdateRequest request = new StudentIdUpdateRequest(teamLeader.getStudentId());
 
         assertThatThrownBy(() ->
@@ -348,7 +393,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 기존 프로필 이미지가 없어도 새 이미지 저장이 호출된다.")
     void 기존_프로필_이미지가_없어도_새_이미지_저장이_호출된다() {
         // given
-        final MockMultipartFile image = new MockMultipartFile("image", "profile.jpg", "image/jpeg", "content".getBytes());
+        final MockMultipartFile image = new MockMultipartFile("image", "profile.jpg", "image/jpeg",
+                "content".getBytes());
 
         // when
         memberCommandService.modifyProfileImage(teamLeader, image);
@@ -362,7 +408,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     void 기존_프로필_이미지가_있으면_새_이미지_저장_후_기존_이미지_삭제가_호출된다() {
         // given
         final File savedFile = fileRepository.save(FileFixture.createMemberProfileFile(teamLeader.getId()));
-        final MockMultipartFile image = new MockMultipartFile("image", "new_profile.jpg", "image/jpeg", "content".getBytes());
+        final MockMultipartFile image = new MockMultipartFile("image", "new_profile.jpg", "image/jpeg",
+                "content".getBytes());
 
         // when
         memberCommandService.modifyProfileImage(teamLeader, image);
@@ -375,7 +422,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 기존 프로필 이미지가 없으면 이미지 변경 시 삭제가 호출되지 않는다.")
     void 기존_프로필_이미지가_없으면_이미지_변경_시_삭제가_호출되지_않는다() {
         // given
-        final MockMultipartFile image = new MockMultipartFile("image", "profile.jpg", "image/jpeg", "content".getBytes());
+        final MockMultipartFile image = new MockMultipartFile("image", "profile.jpg", "image/jpeg",
+                "content".getBytes());
 
         // when
         memberCommandService.modifyProfileImage(teamLeader, image);
@@ -421,7 +469,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 소셜 회원 탈퇴 시 DB에서 조회되지 않는다.")
     void 소셜_회원_탈퇴_시_DB에서_조회되지_않는다() {
         // given
-        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("social@pusan.ac.kr", "google-abc123"));
+        final Member socialMember = memberRepository.save(
+                MemberFixture.createSocialMember("social@pusan.ac.kr", "google-abc123"));
         when(googleTokenManager.get(socialMember.getId())).thenReturn(java.util.Optional.empty());
 
         // when
@@ -445,7 +494,8 @@ public class MemberCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 소셜 회원 탈퇴 시 Google 토큰 해제를 시도한다.")
     void 소셜_회원_탈퇴_시_Google_토큰_해제를_시도한다() {
         // given
-        final Member socialMember = memberRepository.save(MemberFixture.createSocialMember("social2@pusan.ac.kr", "google-def456"));
+        final Member socialMember = memberRepository.save(
+                MemberFixture.createSocialMember("social2@pusan.ac.kr", "google-def456"));
         when(googleTokenManager.get(socialMember.getId())).thenReturn(java.util.Optional.empty());
 
         // when

--- a/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/MemberApiDocsTest.java
@@ -6,6 +6,7 @@ import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_MATCH_PASSWORD;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_UPDATE_STUDENT_ID;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_STAFF_INFO;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.CANNOT_VERIFY_EXPIRED_EMAIL_AUTH_CODE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.INVALID_DATE_RANGE;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_PUSAN_UNIVERSITY_EMAIL;
@@ -196,10 +197,10 @@ public class MemberApiDocsTest extends RestDocsTest {
     }
 
     @Test
-    @DisplayName("[성공] 유효한 요청이면 회원가입은 정상적으로 이뤄진다.")
-    void 유효한_요청이면_회원가입은_정상적으로_이뤄진다() throws Exception {
+    @DisplayName("[성공] 학생 회원가입은 정상적으로 이뤄진다.")
+    void 학생_회원가입은_정상적으로_이뤄진다() throws Exception {
         final SignUpRequest request = new SignUpRequest(member.getName(), member.getStudentId(), member.getEmail(),
-                "qwer123!");
+                "qwer123!", "STUDENT");
 
         doNothing().when(memberCommandService).signUp(any());
 
@@ -212,7 +213,75 @@ public class MemberApiDocsTest extends RestDocsTest {
                                 stringFieldWithPath("name", "회원 이름"),
                                 stringFieldWithPath("studentId", "회원의 학번"),
                                 stringFieldWithPath("email", "회원의 이메일"),
-                                stringFieldWithPath("password", "회원의 비밀번호")
+                                stringFieldWithPath("password", "회원의 비밀번호"),
+                                stringFieldWithPath("memberType", "회원 유형 (STUDENT, STAFF)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 교직원 회원가입은 정상적으로 이뤄진다.")
+    void 교직원_회원가입은_정상적으로_이뤄진다() throws Exception {
+        final SignUpRequest request = new SignUpRequest(member.getName(), member.getStudentId(), member.getEmail(),
+                "qwer123!", "STAFF");
+
+        doNothing().when(memberCommandService).signUp(any());
+
+        mockMvc.perform(post("/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("signup-staff",
+                        requestFields(
+                                stringFieldWithPath("name", "교직원 이름"),
+                                stringFieldWithPath("studentId", "교직원의 교번"),
+                                stringFieldWithPath("email", "교직원의 이메일"),
+                                stringFieldWithPath("password", "교직원의 비밀번호"),
+                                stringFieldWithPath("memberType", "회원 유형 (STUDENT, STAFF)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 교직원 회원가입 시 일치하는 교직원 정보가 없으면 400 에러를 반환한다.")
+    void 교직원_회원가입_시_일치하는_교직원_정보가_없으면_에러를_반환한다() throws Exception {
+        final SignUpRequest request = new SignUpRequest(member.getName(), member.getStudentId(), member.getEmail(),
+                "qwer123!", "STAFF");
+
+        willThrow(new MemberException(NOT_FOUND_STAFF_INFO)).given(memberCommandService).signUp(any());
+
+        mockMvc.perform(post("/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("signup-staff-fail",
+                        requestFields(
+                                stringFieldWithPath("name", "교직원 이름"),
+                                stringFieldWithPath("studentId", "교직원의 교번"),
+                                stringFieldWithPath("email", "교직원의 이메일"),
+                                stringFieldWithPath("password", "교직원의 비밀번호"),
+                                stringFieldWithPath("memberType", "회원 유형 (STUDENT, STAFF)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 회원 유형이 STUDENT, STAFF가 아니면 400 에러를 반환한다.")
+    void 회원_유형이_STUDENT_STAFF가_아니면_에러를_반환한다() throws Exception {
+        final SignUpRequest request = new SignUpRequest(member.getName(), member.getStudentId(), member.getEmail(),
+                "qwer123!", "TEACHER");
+
+        mockMvc.perform(post("/sign-up")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(asJsonString(request)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("signup-invalid-type",
+                        requestFields(
+                                stringFieldWithPath("name", "회원 이름"),
+                                stringFieldWithPath("studentId", "회원의 학번"),
+                                stringFieldWithPath("email", "회원의 이메일"),
+                                stringFieldWithPath("password", "회원의 비밀번호"),
+                                stringFieldWithPath("memberType", "잘못된 회원 유형 (STUDENT, STAFF 외의 값)")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #148 

## 📜 작업 내용

- 기존 회원가입은 학생 기준 단일 흐름이었음                               
- 회원가입 시 memberType(STUDENT / STAFF)을 받아 유형별로 가입 로직을 분리
- 교직원은 사전 등록된 교직원 정보(StaffInfo)와 대조하여, 일치하는 정보의 권한으로 가입

1. 도메인 추가                                                            
- `StaffInfo` 엔티티 신규 생성 (id, name, email, role)                      
  - role은 `MemberRoleType` 재사용 (교수/직원 대상)                         
- `StaffInfoRepository` 추가 (findByEmailAndName)                           
                                                                          
2. 가입 요청 DTO                                                          
- `SignUpRequest`에 memberType 필드 추가 (String)                           
  - @NotNull + @Pattern("`STUDENT`|`STAFF`") → 두 값 외 입력 시 400 반환

3. 가입 로직 분리 (`MemberCommandService.signUp`)                           
- 공통: 이메일 인증 검증 → 비밀번호 인코딩 → 인증키 삭제                  
- `STUDENT`: 기존 흐름 유지 (가짜회원 전환 / 팀리더 정보 업데이트 / 신규가입
ROLE_학생)                                                                
- `STAFF`: StaffInfo를 이메일+이름으로 대조                                 
  - 일치하면 해당 role로 신규가입                                         
  - 일치하는 정보 없으면 예외 발생 (가짜회원/팀리더 전환 분기 없음)

## 💬 리뷰 요구사항

- 일단 데이터 넣는 거는 저희가 정보 받으면 한 번에 넣는 방향으로 생각하고 있습니다.
- 후속 작업으로 관리자가 교직원 정보를 저장할 수 있는 기능을 만들어 볼까 생각은 하고 있습니다.
  - 다만 파일 업로드 기능은 제공하지 않고 직접 입력하는 방향을 고려하고 있습니다.
- 또 후속 작업으로 소셜 로그인도 위 기획에 맞게 수정이 필요합니다!

## ✨ 기타

- 1시인데 배고파요
