### PR TITLE
Feature/#155 ContestSubmission entity repository 추가

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmission.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmission.java
@@ -1,0 +1,53 @@
+package com.opus.opus.modules.contest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.opus.opus.global.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE contest_submission SET is_deleted = true WHERE id = ?")
+public class ContestSubmission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long teamId;
+
+    @Column(nullable = false)
+    private LocalDateTime firstSubmittedAt;
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "contest_submission_item_id", nullable = false)
+    private ContestSubmissionItem submissionItem;
+
+    @Builder
+    private ContestSubmission(final Long teamId, final LocalDateTime firstSubmittedAt,
+                              final ContestSubmissionItem submissionItem) {
+        this.teamId = teamId;
+        this.firstSubmittedAt = firstSubmittedAt;
+        this.submissionItem = submissionItem;
+        this.isDeleted = false;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -1,0 +1,100 @@
+package com.opus.opus.modules.contest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.opus.opus.global.base.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE contest_submission_item SET is_deleted = true WHERE id = ?")
+public class ContestSubmissionItem extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    private String description;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "contest_submission_item_file_formats",
+            joinColumns = @JoinColumn(name = "contest_submission_item_id"))
+    @Enumerated(EnumType.STRING)
+    @Column(name = "file_format", nullable = false)
+    private Set<SubmissionFileFormat> allowedFileFormats = new HashSet<>();
+
+    @Column(nullable = false)
+    private Integer maxFileSizeMb;
+
+    @Column(nullable = false)
+    private Integer maxFileCount;
+
+    @Column(nullable = false)
+    private LocalDateTime startAt;
+
+    @Column(nullable = false)
+    private LocalDateTime endAt;
+
+    @Column(nullable = false)
+    private Boolean allowLateSubmission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SubmissionVisibility visibility;
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    private Contest contest;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "contest_track_id")
+    private ContestTrack contestTrack;
+
+    @Builder
+    private ContestSubmissionItem(final String name, final String description,
+                                  final Set<SubmissionFileFormat> allowedFileFormats, final Integer maxFileSizeMb,
+                                  final Integer maxFileCount, final LocalDateTime startAt, final LocalDateTime endAt,
+                                  final Boolean allowLateSubmission, final SubmissionVisibility visibility,
+                                  final Contest contest, final ContestTrack contestTrack) {
+        this.name = name;
+        this.description = description;
+        this.allowedFileFormats = allowedFileFormats != null ? allowedFileFormats : new HashSet<>();
+        this.maxFileSizeMb = maxFileSizeMb;
+        this.maxFileCount = maxFileCount;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.allowLateSubmission = allowLateSubmission;
+        this.visibility = visibility;
+        this.contest = contest;
+        this.contestTrack = contestTrack;
+        this.isDeleted = false;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/SubmissionFileFormat.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/SubmissionFileFormat.java
@@ -1,0 +1,17 @@
+package com.opus.opus.modules.contest.domain;
+
+public enum SubmissionFileFormat {
+
+    PDF,
+    ZIP,
+    PNG,
+    JPG,
+    JPEG,
+    GIF,
+    MP4,
+    PPT,
+    PPTX,
+    DOC,
+    DOCX,
+    HWP
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/SubmissionVisibility.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/SubmissionVisibility.java
@@ -1,0 +1,7 @@
+package com.opus.opus.modules.contest.domain;
+
+public enum SubmissionVisibility {
+
+    PUBLIC,
+    PRIVATE
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionItemRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionItemRepository.java
@@ -1,0 +1,8 @@
+package com.opus.opus.modules.contest.domain.dao;
+
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestSubmissionItemRepository extends JpaRepository<ContestSubmissionItem, Long> {
+
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionRepository.java
@@ -1,0 +1,10 @@
+package com.opus.opus.modules.contest.domain.dao;
+
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestSubmissionRepository extends JpaRepository<ContestSubmission, Long> {
+
+    boolean existsByTeamIdAndSubmissionItem(final Long teamId, final ContestSubmissionItem submissionItem);
+}

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,6 @@
 USE opus;
 
+DROP TABLE IF EXISTS `contest_submission`;
 DROP TABLE IF EXISTS `contest_submission_item_file_formats`;
 DROP TABLE IF EXISTS `contest_submission_item`;
 DROP TABLE IF EXISTS `team_member_roles`;
@@ -109,6 +110,17 @@ CREATE TABLE `contest_submission_item_file_formats` (
   `contest_submission_item_id` bigint NOT NULL,
   `file_format` enum('PDF','ZIP','PNG','JPG','JPEG','GIF','MP4','PPT','PPTX','DOC','DOCX','HWP') NOT NULL,
   PRIMARY KEY (`contest_submission_item_id`,`file_format`)
+);
+
+CREATE TABLE `contest_submission` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `first_submitted_at` datetime(6) NOT NULL,
+  `is_deleted` bit(1) NOT NULL,
+  `team_id` bigint NOT NULL,
+  `contest_submission_item_id` bigint NOT NULL,
+  PRIMARY KEY (`id`)
 );
 
 CREATE TABLE `contest_sort` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,5 +1,7 @@
 USE opus;
 
+DROP TABLE IF EXISTS `contest_submission_item_file_formats`;
+DROP TABLE IF EXISTS `contest_submission_item`;
 DROP TABLE IF EXISTS `team_member_roles`;
 DROP TABLE IF EXISTS `team_vote`;
 DROP TABLE IF EXISTS `team_like`;
@@ -83,6 +85,30 @@ CREATE TABLE `contest_track` (
   `track_name` varchar(255) NOT NULL,
   `contest_id` bigint NOT NULL,
   PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `contest_submission_item` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `allow_late_submission` bit(1) NOT NULL,
+  `description` varchar(255) DEFAULT NULL,
+  `end_at` datetime(6) NOT NULL,
+  `is_deleted` bit(1) NOT NULL,
+  `max_file_count` int NOT NULL,
+  `max_file_size_mb` int NOT NULL,
+  `name` varchar(255) NOT NULL,
+  `start_at` datetime(6) NOT NULL,
+  `visibility` enum('PUBLIC','PRIVATE') NOT NULL,
+  `contest_id` bigint NOT NULL,
+  `contest_track_id` bigint DEFAULT NULL,
+  PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `contest_submission_item_file_formats` (
+  `contest_submission_item_id` bigint NOT NULL,
+  `file_format` enum('PDF','ZIP','PNG','JPG','JPEG','GIF','MP4','PPT','PPTX','DOC','DOCX','HWP') NOT NULL,
+  PRIMARY KEY (`contest_submission_item_id`,`file_format`)
 );
 
 CREATE TABLE `contest_sort` (


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #155

## 📜 작업 내용

- ContestSubmission 관련 entity와 repository를 구현했습니다.
- 관련해서 schema.sql도 추가했습니다.

### 설계 요약
-`teamId`: 교차 모듈(team)이라 `TeamContestAward` 관례를 따라 plain `Long`으로 두었습니다.
- `submissionItem`: 같은 contest 모듈이라 `@ManyToOne` 연관관계로 연결했습니다.
- `firstSubmittedAt`(최초 제출일시), `isDeleted`(소프트 삭제) 
- 의도적으로 제외한 것
    - `status`(조회 시점 계산값)
    - `files`(File이 `referenceId`로 느슨 연결)
    - `version`(현 명세상 불필요하여 보류) 
    - `contest`(`submissionItem` 경유 도달)
- repository는 중복 제출 검증용 `existsByTeamIdAndSubmissionItem`만 추가했습니다.

## 💬 리뷰 요구사항
- 감사합니다!


## ✨ 기타

- PR #154와 동일하게, 제출물 관련 기능들이 공통으로 사용할 수 있도록 entity/repository를 먼저 올립니다-!