### PR TITLE
Feature/#160 제출물 제출 및 파일 첨부와 삭제 기능 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -34,3 +34,5 @@ link:./contest.html[대회 API]
 link:./contest-category.html[대회 카테고리 API]
 
 link:./contest-track.html[대회 분과 API]
+
+link:./submission.html[제출물 API]

--- a/src/main/java/com/opus/opus/docs/asciidoc/submission.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/submission.adoc
@@ -17,9 +17,9 @@ link:./opus.html[API 목록으로 돌아가기]
 == 제출물 상세 조회
 === `GET`: 제출물 상세 조회
 
-한 팀이 특정 제출물 종류로 낸 제출 한 건의 상세 정보를 조회합니다. +
-`ROLE_학생`은 해당 팀의 팀장/팀원만 조회할 수 있으며, 관리자/교수/직원/외부멘토는 제한이 없습니다. +
-`status`는 계산값으로, 단건 조회에서는 `SUBMITTED`(마감 내) / `LATE`(마감 후)만 반환됩니다. +
+한 팀이 특정 제출물 종류로 낸 제출 한 건의 상세 정보를 조회합니다.
+`ROLE_학생`은 해당 팀의 팀장/팀원만 조회할 수 있으며, 관리자/교수/직원/외부멘토는 제한이 없습니다.
+`status`는 계산값으로, 단건 조회에서는 `SUBMITTED`(마감 내) / `LATE`(마감 후)만 반환됩니다.
 `commentCount`는 제출물 코멘트 기능 추가 전까지 항상 0입니다.
 
 .HTTP Request
@@ -37,16 +37,19 @@ include::{snippets}/get-submission-detail/http-response.adoc[]
 .Response Fields
 include::{snippets}/get-submission-detail/response-fields.adoc[]
 
-=== `GET`: 제출물 상세 조회 실패 (존재하지 않는 제출)
+=== ⚠️ 실패 케이스
 
-.HTTP Request
+.❌ Case 1: 존재하지 않는 제출
+
+[%collapsible]
+
+====
+
 include::{snippets}/get-submission-detail-fail-not-found/http-request.adoc[]
 
-.Path Parameters
-include::{snippets}/get-submission-detail-fail-not-found/path-parameters.adoc[]
-
-.HTTP Response
 include::{snippets}/get-submission-detail-fail-not-found/http-response.adoc[]
+
+====
 
 == 제출물 제출
 === `POST`: 제출물 제출

--- a/src/main/java/com/opus/opus/docs/asciidoc/submission.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/submission.adoc
@@ -1,0 +1,114 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= SUBMISSION API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:./opus.html[API 목록으로 돌아가기]
+
+== 제출물 상세 조회
+=== `GET`: 제출물 상세 조회
+
+한 팀이 특정 제출물 종류로 낸 제출 한 건의 상세 정보를 조회합니다. +
+`ROLE_학생`은 해당 팀의 팀장/팀원만 조회할 수 있으며, 관리자/교수/직원/외부멘토는 제한이 없습니다. +
+`status`는 계산값으로, 단건 조회에서는 `SUBMITTED`(마감 내) / `LATE`(마감 후)만 반환됩니다. +
+`commentCount`는 제출물 코멘트 기능 추가 전까지 항상 0입니다.
+
+.HTTP Request
+include::{snippets}/get-submission-detail/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/get-submission-detail/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/get-submission-detail/request-headers.adoc[]
+
+.HTTP Response
+include::{snippets}/get-submission-detail/http-response.adoc[]
+
+.Response Fields
+include::{snippets}/get-submission-detail/response-fields.adoc[]
+
+=== `GET`: 제출물 상세 조회 실패 (존재하지 않는 제출)
+
+.HTTP Request
+include::{snippets}/get-submission-detail-fail-not-found/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/get-submission-detail-fail-not-found/path-parameters.adoc[]
+
+.HTTP Response
+include::{snippets}/get-submission-detail-fail-not-found/http-response.adoc[]
+
+== 제출물 제출
+=== `POST`: 제출물 제출
+
+팀이 특정 제출 항목에 파일을 제출합니다. (`multipart/form-data`, 여러 파일 가능) +
+한 팀이 동일한 제출 항목에 중복 제출할 수 없으며, 파일을 추가하려면 "제출 파일 추가" API를 사용합니다. +
+`teamId`는 요청 파라미터로 전달하며, `ROLE_학생`은 해당 팀의 팀장/팀원이어야 합니다.
+
+.HTTP Request
+include::{snippets}/create-submission/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/create-submission/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/create-submission/request-headers.adoc[]
+
+.Query Parameters
+include::{snippets}/create-submission/query-parameters.adoc[]
+
+.Request Parts
+include::{snippets}/create-submission/request-parts.adoc[]
+
+.HTTP Response
+include::{snippets}/create-submission/http-response.adoc[]
+
+.Response Fields
+include::{snippets}/create-submission/response-fields.adoc[]
+
+== 제출 파일 추가
+=== `POST`: 제출물에 파일 추가
+
+이미 제출된 제출물에 파일을 추가합니다. 기존 파일을 포함한 총 개수가 `maxFileCount`를 초과할 수 없습니다.
+
+.HTTP Request
+include::{snippets}/add-submission-files/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/add-submission-files/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/add-submission-files/request-headers.adoc[]
+
+.Request Parts
+include::{snippets}/add-submission-files/request-parts.adoc[]
+
+.HTTP Response
+include::{snippets}/add-submission-files/http-response.adoc[]
+
+== 제출 파일 삭제
+=== `DELETE`: 제출물의 파일 삭제
+
+제출물에 첨부된 파일 한 건을 삭제합니다. 마지막 남은 파일을 삭제하면 제출 자체가 취소됩니다.
+
+.HTTP Request
+include::{snippets}/delete-submission-file/http-request.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-submission-file/path-parameters.adoc[]
+
+.Request Headers
+include::{snippets}/delete-submission-file/request-headers.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-submission-file/http-response.adoc[]

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -254,7 +254,7 @@ public class ContestController {
                                                      @PathVariable final Long submissionId,
                                                      @PathVariable final Long fileId,
                                                      @LoginMember final Member member) {
-        contestSubmissionCommandService.deleteFile(contestId, submissionId, fileId, member);
+        contestSubmissionCommandService.deleteSubmissionFile(contestId, submissionId, fileId, member);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -236,6 +236,26 @@ public class ContestController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
+    @Secured({"ROLE_학생", "ROLE_관리자"})
+    @PostMapping("/{contestId}/submissions/{submissionId}/files")
+    public ResponseEntity<Void> addSubmissionFiles(@PathVariable final Long contestId,
+                                                   @PathVariable final Long submissionId,
+                                                   @RequestPart("files") final List<MultipartFile> files,
+                                                   @LoginMember final Member member) {
+        contestSubmissionCommandService.addFiles(contestId, submissionId, files, member);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Secured({"ROLE_학생", "ROLE_관리자"})
+    @DeleteMapping("/{contestId}/submissions/{submissionId}/files/{fileId}")
+    public ResponseEntity<Void> deleteSubmissionFile(@PathVariable final Long contestId,
+                                                     @PathVariable final Long submissionId,
+                                                     @PathVariable final Long fileId,
+                                                     @LoginMember final Member member) {
+        contestSubmissionCommandService.deleteFile(contestId, submissionId, fileId, member);
+        return ResponseEntity.noContent().build();
+    }
+
     @GetMapping("/{contestId}/template")
     public ResponseEntity<ContestTemplateResponse> getContestTemplate(@PathVariable final Long contestId) {
         final ContestTemplateResponse response = contestQueryService.getContestTemplate(contestId);

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.contest.api;
 import com.opus.opus.global.security.annotation.LoginMember;
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
 import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestSortCustomRequest;
@@ -21,6 +22,7 @@ import com.opus.opus.modules.contest.application.dto.response.ContestTemplateRes
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteStatisticsResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
+import com.opus.opus.modules.contest.application.dto.response.SubmissionCreateResponse;
 import com.opus.opus.modules.contest.application.dto.response.TeamBulkUploadResponse;
 import com.opus.opus.modules.contest.application.dto.response.TeamSummaryResponse;
 import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
@@ -58,6 +60,7 @@ public class ContestController {
 
     private final ContestCommandService contestCommandService;
     private final ContestQueryService contestQueryService;
+    private final ContestSubmissionCommandService contestSubmissionCommandService;
 
     @GetMapping("/{contestId}/image/banner")
     public ResponseEntity<Resource> getContestBanner(@PathVariable final Long contestId) {
@@ -219,6 +222,18 @@ public class ContestController {
         final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(contestId,
                 submissionId, member);
         return ResponseEntity.ok(response);
+    }
+
+    @Secured({"ROLE_학생", "ROLE_관리자"})
+    @PostMapping("/{contestId}/submission-items/{submissionItemId}/submissions")
+    public ResponseEntity<SubmissionCreateResponse> createSubmission(@PathVariable final Long contestId,
+                                                                     @PathVariable final Long submissionItemId,
+                                                                     @RequestParam final Long teamId,
+                                                                     @RequestPart("files") final List<MultipartFile> files,
+                                                                     @LoginMember final Member member) {
+        final SubmissionCreateResponse response = contestSubmissionCommandService.createSubmission(contestId,
+                submissionItemId, teamId, files, member);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
     @GetMapping("/{contestId}/template")

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -244,7 +244,7 @@ public class ContestController {
                                                    @PathVariable final Long submissionId,
                                                    @RequestPart("files") final List<MultipartFile> files,
                                                    @LoginMember final Member member) {
-        contestSubmissionCommandService.addFiles(contestId, submissionId, files, member);
+        contestSubmissionCommandService.addSubmissionFiles(contestId, submissionId, files, member);
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -15,13 +15,14 @@ import com.opus.opus.modules.contest.application.dto.response.ContestCurrentTogg
 import com.opus.opus.modules.contest.application.dto.response.ContestRankingResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSortResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestTemplateResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteStatisticsResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
-import com.opus.opus.modules.contest.application.dto.response.TeamSummaryResponse;
 import com.opus.opus.modules.contest.application.dto.response.TeamBulkUploadResponse;
+import com.opus.opus.modules.contest.application.dto.response.TeamSummaryResponse;
 import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.dto.ImageResponse;
@@ -208,6 +209,16 @@ public class ContestController {
     public ResponseEntity<List<ContestSubmissionResponse>> getTeamSubmissions(@PathVariable final Long contestId) {
         final List<ContestSubmissionResponse> responses = contestQueryService.getTeamSubmissions(contestId);
         return ResponseEntity.ok(responses);
+    }
+
+    @Secured({"ROLE_학생", "ROLE_관리자", "ROLE_교수", "ROLE_직원", "ROLE_외부멘토"})
+    @GetMapping("/{contestId}/submissions/{submissionId}")
+    public ResponseEntity<ContestSubmissionDetailResponse> getSubmissionDetail(@PathVariable final Long contestId,
+                                                                               @PathVariable final Long submissionId,
+                                                                               @LoginMember final Member member) {
+        final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(contestId,
+                submissionId, member);
+        return ResponseEntity.ok(response);
     }
 
     @GetMapping("/{contestId}/template")

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestController.java
@@ -4,6 +4,7 @@ import com.opus.opus.global.security.annotation.LoginMember;
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
+import com.opus.opus.modules.contest.application.ContestSubmissionQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestCurrentToggleRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestRequest;
 import com.opus.opus.modules.contest.application.dto.request.ContestSortCustomRequest;
@@ -61,6 +62,7 @@ public class ContestController {
     private final ContestCommandService contestCommandService;
     private final ContestQueryService contestQueryService;
     private final ContestSubmissionCommandService contestSubmissionCommandService;
+    private final ContestSubmissionQueryService contestSubmissionQueryService;
 
     @GetMapping("/{contestId}/image/banner")
     public ResponseEntity<Resource> getContestBanner(@PathVariable final Long contestId) {
@@ -219,7 +221,7 @@ public class ContestController {
     public ResponseEntity<ContestSubmissionDetailResponse> getSubmissionDetail(@PathVariable final Long contestId,
                                                                                @PathVariable final Long submissionId,
                                                                                @LoginMember final Member member) {
-        final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(contestId,
+        final ContestSubmissionDetailResponse response = contestSubmissionQueryService.getSubmissionDetail(contestId,
                 submissionId, member);
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -9,14 +9,12 @@ import static org.springframework.data.domain.Sort.Direction.DESC;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSortConvenience;
-import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTemplateConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestRankingResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSortResponse;
-import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestTemplateResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
@@ -27,18 +25,12 @@ import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.ContestSort;
-import com.opus.opus.modules.contest.domain.ContestSubmission;
-import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTemplate;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
-import com.opus.opus.modules.contest.exception.ContestException;
-import com.opus.opus.modules.contest.exception.ContestExceptionType;
 import com.opus.opus.modules.file.application.FileQueryService;
-import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
 import com.opus.opus.modules.file.application.convenience.FileImageConvenience;
 import com.opus.opus.modules.file.application.dto.FileResource;
-import com.opus.opus.modules.file.domain.FileDocument;
 import com.opus.opus.modules.file.domain.FileImage;
 import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
@@ -46,7 +38,6 @@ import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamContestAwardConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamLikeConvenience;
-import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamVoteConvenience;
 import com.opus.opus.modules.team.application.dto.ImageResponse;
 import com.opus.opus.modules.team.application.dto.response.MemberVoteCountResponse;
@@ -84,15 +75,12 @@ public class ContestQueryService {
     private final ContestSortConvenience contestSortConvenience;
     private final ContestTrackConvenience contestTrackConvenience;
     private final ContestTemplateConvenience contestTemplateConvenience;
-    private final ContestSubmissionConvenience contestSubmissionConvenience;
     private final TeamConvenience teamConvenience;
-    private final TeamMemberConvenience teamMemberConvenience;
     private final TeamVoteConvenience teamVoteConvenience;
     private final TeamLikeConvenience teamLikeConvenience;
     private final MemberConvenience memberConvenience;
     private final TeamContestAwardConvenience teamContestAwardConvenience;
     private final FileImageConvenience fileImageConvenience;
-    private final FileDocumentConvenience fileDocumentConvenience;
 
     private static List<ContestRankingResponse> applyRanking(List<TeamRankingResult> votesPerTeam) {
         List<ContestRankingResponse> responseList = new ArrayList<>();
@@ -234,38 +222,6 @@ public class ContestQueryService {
         return teamList.stream()
                 .map(team -> ContestSubmissionResponse.from(team, trackNameMap.get(team.getTrackId())))
                 .toList();
-    }
-
-    public ContestSubmissionDetailResponse getSubmissionDetail(final Long contestId, final Long submissionId,
-                                                               final Member member) {
-        contestConvenience.validateExistContest(contestId);
-
-        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
-        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
-        validateSubmissionInContest(submissionItem, contestId);
-
-        final Team team = teamConvenience.getValidateExistTeam(submission.getTeamId());
-        // 학생은 해당 팀의 팀장/팀원만 조회할 수 있다. (관리자/교수/직원/외부멘토는 제한 없음)
-        teamMemberConvenience.validateTeamMemberIfStudent(team.getId(), member);
-
-        final String trackName = submissionItem.getContestTrack() != null
-                ? submissionItem.getContestTrack().getTrackName()
-                : null;
-        final List<FileDocument> fileDocuments = fileDocumentConvenience.findAllBySubmissionId(submissionId);
-
-        /* TODO
-        제출물 코멘트 기능이 아직 없어서, 제출물 카운트를 0으로 고정하였습니다.
-        코멘트 기능 추가 시 실제 개수로 교체가 필요합니다.
-         */
-        final int commentCount = 0;
-
-        return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, commentCount);
-    }
-
-    private void validateSubmissionInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
-        if (!submissionItem.getContest().getId().equals(contestId)) {
-            throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
-        }
     }
 
     public List<TeamSummaryResponse> getContestTeamSummaries(final Long contestId, final Member member) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestQueryService.java
@@ -6,16 +6,17 @@ import static com.opus.opus.modules.file.domain.ReferenceDomainType.CONTEST;
 import static com.opus.opus.modules.file.exception.FileExceptionType.NOT_WEBP_CONVERTED;
 import static org.springframework.data.domain.Sort.Direction.DESC;
 
-import com.opus.opus.modules.file.application.FileQueryService;
 import com.opus.opus.modules.contest.application.convenience.ContestCategoryConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSortConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTemplateConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestCurrentResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestRankingResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSortResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestTemplateResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
@@ -26,10 +27,18 @@ import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestCategory;
 import com.opus.opus.modules.contest.domain.ContestSort;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTemplate;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestExceptionType;
+import com.opus.opus.modules.file.application.FileQueryService;
+import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
 import com.opus.opus.modules.file.application.convenience.FileImageConvenience;
+import com.opus.opus.modules.file.application.dto.FileResource;
+import com.opus.opus.modules.file.domain.FileDocument;
 import com.opus.opus.modules.file.domain.FileImage;
 import com.opus.opus.modules.file.exception.FileException;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
@@ -37,6 +46,7 @@ import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamContestAwardConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamLikeConvenience;
+import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamVoteConvenience;
 import com.opus.opus.modules.team.application.dto.ImageResponse;
 import com.opus.opus.modules.team.application.dto.response.MemberVoteCountResponse;
@@ -53,7 +63,6 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import com.opus.opus.modules.file.application.dto.FileResource;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -75,12 +84,15 @@ public class ContestQueryService {
     private final ContestSortConvenience contestSortConvenience;
     private final ContestTrackConvenience contestTrackConvenience;
     private final ContestTemplateConvenience contestTemplateConvenience;
+    private final ContestSubmissionConvenience contestSubmissionConvenience;
     private final TeamConvenience teamConvenience;
+    private final TeamMemberConvenience teamMemberConvenience;
     private final TeamVoteConvenience teamVoteConvenience;
     private final TeamLikeConvenience teamLikeConvenience;
     private final MemberConvenience memberConvenience;
     private final TeamContestAwardConvenience teamContestAwardConvenience;
     private final FileImageConvenience fileImageConvenience;
+    private final FileDocumentConvenience fileDocumentConvenience;
 
     private static List<ContestRankingResponse> applyRanking(List<TeamRankingResult> votesPerTeam) {
         List<ContestRankingResponse> responseList = new ArrayList<>();
@@ -222,6 +234,38 @@ public class ContestQueryService {
         return teamList.stream()
                 .map(team -> ContestSubmissionResponse.from(team, trackNameMap.get(team.getTrackId())))
                 .toList();
+    }
+
+    public ContestSubmissionDetailResponse getSubmissionDetail(final Long contestId, final Long submissionId,
+                                                               final Member member) {
+        contestConvenience.validateExistContest(contestId);
+
+        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
+        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
+        validateSubmissionInContest(submissionItem, contestId);
+
+        final Team team = teamConvenience.getValidateExistTeam(submission.getTeamId());
+        // 학생은 해당 팀의 팀장/팀원만 조회할 수 있다. (관리자/교수/직원/외부멘토는 제한 없음)
+        teamMemberConvenience.validateTeamMemberIfStudent(team.getId(), member);
+
+        final String trackName = submissionItem.getContestTrack() != null
+                ? submissionItem.getContestTrack().getTrackName()
+                : null;
+        final List<FileDocument> fileDocuments = fileDocumentConvenience.findAllBySubmissionId(submissionId);
+
+        /* TODO
+        제출물 코멘트 기능이 아직 없어서, 제출물 카운트를 0으로 고정하였습니다.
+        코멘트 기능 추가 시 실제 개수로 교체가 필요합니다.
+         */
+        final int commentCount = 0;
+
+        return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, commentCount);
+    }
+
+    private void validateSubmissionInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
+        if (!submissionItem.getContest().getId().equals(contestId)) {
+            throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
+        }
     }
 
     public List<TeamSummaryResponse> getContestTeamSummaries(final Long contestId, final Member member) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -19,13 +19,9 @@ import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.file.application.FileDocumentCommandService;
 import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
-import com.opus.opus.modules.file.domain.FileDocument;
-import com.opus.opus.modules.file.exception.FileException;
-import com.opus.opus.modules.file.exception.FileExceptionType;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,8 +32,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional
 public class ContestSubmissionCommandService {
-
-    private static final long MB_IN_BYTES = 1024L * 1024L;
 
     private final ContestConvenience contestConvenience;
     private final TeamConvenience teamConvenience;
@@ -60,7 +54,7 @@ public class ContestSubmissionCommandService {
 
         final ContestSubmission submission = contestSubmissionRepository.save(
                 ContestSubmission.create(teamId, submissionItem));
-        storeFiles(submission.getId(), files);
+        fileDocumentCommandService.storeDocumentFiles(submission.getId(), files);
 
         return new SubmissionCreateResponse(submission.getId());
     }
@@ -72,11 +66,11 @@ public class ContestSubmissionCommandService {
         final ContestSubmissionItem submissionItem = getValidatedSubmissionItem(submission, contestId);
         teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
 
-        final List<FileDocument> existingFiles = fileDocumentConvenience.findAllBySubmissionId(submissionId);
-        validateFiles(submissionItem, files, existingFiles.size() + files.size());
+        final long existingFileCount = fileDocumentConvenience.countBySubmissionId(submissionId);
+        validateFiles(submissionItem, files, (int) existingFileCount + files.size());
         validateSubmittable(submissionItem);
 
-        appendFiles(submissionId, existingFiles, files);
+        fileDocumentCommandService.storeDocumentFiles(submissionId, files);
     }
 
     public void deleteFile(final Long contestId, final Long submissionId, final Long fileId, final Member member) {
@@ -85,12 +79,12 @@ public class ContestSubmissionCommandService {
         final ContestSubmissionItem submissionItem = getValidatedSubmissionItem(submission, contestId);
         teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
 
-        final List<FileDocument> files = fileDocumentConvenience.findAllBySubmissionId(submissionId);
-        validateFileBelongsToSubmission(files, fileId);
+        fileDocumentConvenience.validateFileBelongsToSubmission(submissionId, fileId);
         validateSubmittable(submissionItem);
 
+        final boolean isLastFile = fileDocumentConvenience.countBySubmissionId(submissionId) == 1;
         fileDocumentCommandService.deleteDocumentFile(fileId);
-        if (files.size() == 1) {
+        if (isLastFile) {
             contestSubmissionRepository.delete(submission);
         }
     }
@@ -132,15 +126,8 @@ public class ContestSubmissionCommandService {
         }
     }
 
-    private void validateFileBelongsToSubmission(final List<FileDocument> files, final Long fileId) {
-        final boolean exists = files.stream().anyMatch(file -> file.getId().equals(fileId));
-        if (!exists) {
-            throw new FileException(FileExceptionType.NOT_FOUND);
-        }
-    }
-
     private void validateFileCount(final ContestSubmissionItem submissionItem, final int totalFileCount) {
-        if (totalFileCount > submissionItem.getMaxFileCount()) {
+        if (submissionItem.isFileCountExceeded(totalFileCount)) {
             throw new ContestException(SUBMISSION_FILE_COUNT_EXCEEDED);
         }
     }
@@ -152,59 +139,25 @@ public class ContestSubmissionCommandService {
     }
 
     private void validateFileSizes(final ContestSubmissionItem submissionItem, final List<MultipartFile> files) {
-        final long maxFileSizeBytes = submissionItem.getMaxFileSizeMb() * MB_IN_BYTES;
         for (final MultipartFile file : files) {
-            if (file.getSize() > maxFileSizeBytes) {
+            if (submissionItem.isFileSizeExceeded(file.getSize())) {
                 throw new ContestException(SUBMISSION_FILE_SIZE_EXCEEDED);
             }
         }
     }
 
     private void validateFileFormat(final ContestSubmissionItem submissionItem, final String filename) {
-        final String extension = extractExtension(filename);
-        final SubmissionFileFormat format;
-        try {
-            format = SubmissionFileFormat.valueOf(extension.toUpperCase());
-        } catch (final IllegalArgumentException e) {
-            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
-        }
-        if (!submissionItem.getAllowedFileFormats().contains(format)) {
+        final SubmissionFileFormat format = SubmissionFileFormat.from(filename)
+                .orElseThrow(() -> new ContestException(INVALID_SUBMISSION_FILE_FORMAT));
+        if (!submissionItem.supportsFormat(format)) {
             throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
         }
     }
 
     private void validateSubmittable(final ContestSubmissionItem submissionItem) {
-        final boolean afterDeadline = LocalDateTime.now().isAfter(submissionItem.getEndAt());
-        if (afterDeadline && !submissionItem.getAllowLateSubmission()) {
+        if (submissionItem.isSubmissionClosed()) {
             throw new ContestException(SUBMISSION_PERIOD_ENDED);
         }
     }
 
-    private void storeFiles(final Long submissionId, final List<MultipartFile> files) {
-        for (int i = 0; i < files.size(); i++) {
-            fileDocumentCommandService.storeDocumentFile(files.get(i), submissionId, i + 1);
-        }
-    }
-
-    private void appendFiles(final Long submissionId, final List<FileDocument> existingFiles,
-                             final List<MultipartFile> files) {
-        final int startOrder = existingFiles.stream()
-                .mapToInt(FileDocument::getFileOrder)
-                .max()
-                .orElse(0);
-        for (int i = 0; i < files.size(); i++) {
-            fileDocumentCommandService.storeDocumentFile(files.get(i), submissionId, startOrder + 1 + i);
-        }
-    }
-
-    private String extractExtension(final String filename) {
-        if (filename == null || filename.isBlank()) {
-            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
-        }
-        final int lastDot = filename.lastIndexOf('.');
-        if (lastDot <= 0 || lastDot >= filename.length() - 1) {
-            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
-        }
-        return filename.substring(lastDot + 1);
-    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -75,10 +75,12 @@ public class ContestSubmissionCommandService {
         teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
 
         validateSubmittable(submissionItem);
+        validateFilesNotEmpty(files);
         final long existingFileCount = fileDocumentConvenience.countBySubmissionId(submissionId);
         validateFiles(submissionItem, files, (int) existingFileCount + files.size());
 
         fileDocumentCommandService.storeDocumentFiles(submissionId, files);
+        contestSubmissionRepository.touchUpdatedAt(submissionId);
     }
 
     public void deleteSubmissionFile(final Long contestId, final Long submissionId, final Long fileId,
@@ -96,6 +98,8 @@ public class ContestSubmissionCommandService {
         fileDocumentCommandService.deleteDocumentFile(fileId);
         if (isLastFile) {
             contestSubmissionRepository.delete(submission);
+        } else {
+            contestSubmissionRepository.touchUpdatedAt(submissionId);
         }
     }
 
@@ -113,6 +117,11 @@ public class ContestSubmissionCommandService {
     private void validateFilesNotEmpty(final List<MultipartFile> files) {
         if (files.isEmpty()) {
             throw new ContestException(SUBMISSION_FILE_REQUIRED);
+        }
+        for (final MultipartFile file : files) {
+            if (file.isEmpty()) {
+                throw new ContestException(SUBMISSION_FILE_REQUIRED);
+            }
         }
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -7,6 +7,7 @@ import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMI
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_SIZE_EXCEEDED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
@@ -22,6 +23,8 @@ import com.opus.opus.modules.file.application.convenience.FileDocumentConvenienc
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.exception.TeamException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -46,7 +49,8 @@ public class ContestSubmissionCommandService {
                                                      final Long teamId, final List<MultipartFile> files,
                                                      final Member member) {
         contestConvenience.validateExistContest(contestId);
-        teamConvenience.validateExistTeam(teamId);
+        final Team team = teamConvenience.getValidateExistTeam(teamId);
+        validateTeamInContest(team, contestId);
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemConvenience.getValidateExistSubmissionItem(submissionItemId);
 
@@ -112,6 +116,12 @@ public class ContestSubmissionCommandService {
             throw new ContestException(NOT_FOUND_SUBMISSION);
         }
         return submissionItem;
+    }
+
+    private void validateTeamInContest(final Team team, final Long contestId) {
+        if (!team.isInContest(contestId)) {
+            throw new TeamException(NOT_FOUND_TEAM);
+        }
     }
 
     private void validateSubmissionItemInContest(final ContestSubmissionItem submissionItem, final Long contestId) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -111,16 +111,15 @@ public class ContestSubmissionCommandService {
     }
 
     private ContestSubmissionItem getValidatedSubmissionItem(final ContestSubmission submission, final Long contestId) {
-        final ContestSubmissionItem submissionItem = contestSubmissionItemConvenience
-                .getValidateExistSubmissionItem(submission.getSubmissionItem().getId());
-        if (!submissionItem.getContest().getId().equals(contestId)) {
+        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
+        if (!submissionItem.isInContest(contestId)) {
             throw new ContestException(NOT_FOUND_SUBMISSION);
         }
         return submissionItem;
     }
 
     private void validateSubmissionItemInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
-        if (!submissionItem.getContest().getId().equals(contestId)) {
+        if (!submissionItem.isInContest(contestId)) {
             throw new ContestException(NOT_FOUND_SUBMISSION_ITEM);
         }
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -15,6 +15,7 @@ import com.opus.opus.modules.contest.application.dto.response.SubmissionCreateRe
 import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.file.application.FileDocumentCommandService;
 import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
@@ -43,6 +44,7 @@ public class ContestSubmissionCommandService {
     private final TeamMemberConvenience teamMemberConvenience;
     private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
     private final ContestSubmissionConvenience contestSubmissionConvenience;
+    private final ContestSubmissionRepository contestSubmissionRepository;
     private final FileDocumentCommandService fileDocumentCommandService;
     private final FileDocumentConvenience fileDocumentConvenience;
 
@@ -56,7 +58,7 @@ public class ContestSubmissionCommandService {
 
         validateSubmission(contestId, teamId, submissionItem, files, member);
 
-        final ContestSubmission submission = contestSubmissionConvenience.save(
+        final ContestSubmission submission = contestSubmissionRepository.save(
                 ContestSubmission.create(teamId, submissionItem));
         storeFiles(submission.getId(), files);
 
@@ -89,7 +91,7 @@ public class ContestSubmissionCommandService {
 
         fileDocumentCommandService.deleteDocumentFile(fileId);
         if (files.size() == 1) {
-            contestSubmissionConvenience.delete(submission);
+            contestSubmissionRepository.delete(submission);
         }
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -1,10 +1,10 @@
 package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
-import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_REQUIRED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_SIZE_EXCEEDED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
@@ -20,11 +20,13 @@ import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.file.application.FileDocumentCommandService;
 import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
+import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.exception.TeamException;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,14 +38,16 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 public class ContestSubmissionCommandService {
 
+    private final ContestSubmissionRepository contestSubmissionRepository;
+
     private final ContestConvenience contestConvenience;
     private final TeamConvenience teamConvenience;
     private final TeamMemberConvenience teamMemberConvenience;
     private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
     private final ContestSubmissionConvenience contestSubmissionConvenience;
-    private final ContestSubmissionRepository contestSubmissionRepository;
-    private final FileDocumentCommandService fileDocumentCommandService;
     private final FileDocumentConvenience fileDocumentConvenience;
+
+    private final FileDocumentCommandService fileDocumentCommandService;
 
     public SubmissionCreateResponse createSubmission(final Long contestId, final Long submissionItemId,
                                                      final Long teamId, final List<MultipartFile> files,
@@ -56,31 +60,36 @@ public class ContestSubmissionCommandService {
 
         validateSubmission(contestId, teamId, submissionItem, files, member);
 
-        final ContestSubmission submission = contestSubmissionRepository.save(
-                ContestSubmission.create(teamId, submissionItem));
+        final ContestSubmission submission = contestSubmissionRepository.save(ContestSubmission.builder()
+                .teamId(teamId)
+                .firstSubmittedAt(LocalDateTime.now())
+                .submissionItem(submissionItem)
+                .build());
         fileDocumentCommandService.storeDocumentFiles(submission.getId(), files);
 
         return new SubmissionCreateResponse(submission.getId());
     }
 
-    public void addFiles(final Long contestId, final Long submissionId, final List<MultipartFile> files,
-                         final Member member) {
+    public void addSubmissionFiles(final Long contestId, final Long submissionId, final List<MultipartFile> files,
+                                   final Member member) {
         contestConvenience.validateExistContest(contestId);
-        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
-        final ContestSubmissionItem submissionItem = getValidatedSubmissionItem(submission, contestId);
+        final ContestSubmission submission =
+                contestSubmissionConvenience.getValidateSubmissionInContest(submissionId, contestId);
+        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
         teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
 
+        validateSubmittable(submissionItem);
         final long existingFileCount = fileDocumentConvenience.countBySubmissionId(submissionId);
         validateFiles(submissionItem, files, (int) existingFileCount + files.size());
-        validateSubmittable(submissionItem);
 
         fileDocumentCommandService.storeDocumentFiles(submissionId, files);
     }
 
     public void deleteFile(final Long contestId, final Long submissionId, final Long fileId, final Member member) {
         contestConvenience.validateExistContest(contestId);
-        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
-        final ContestSubmissionItem submissionItem = getValidatedSubmissionItem(submission, contestId);
+        final ContestSubmission submission =
+                contestSubmissionConvenience.getValidateSubmissionInContest(submissionId, contestId);
+        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
         teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
 
         fileDocumentConvenience.validateFileBelongsToSubmission(submissionId, fileId);
@@ -99,8 +108,15 @@ public class ContestSubmissionCommandService {
         validateSubmissionItemInContest(submissionItem, contestId);
         teamMemberConvenience.validateTeamMemberUnlessAdmin(teamId, member);
         validateNotAlreadySubmitted(teamId, submissionItem);
-        validateFiles(submissionItem, files, files.size());
         validateSubmittable(submissionItem);
+        validateFilesNotEmpty(files);
+        validateFiles(submissionItem, files, files.size());
+    }
+
+    private void validateFilesNotEmpty(final List<MultipartFile> files) {
+        if (files.isEmpty()) {
+            throw new ContestException(SUBMISSION_FILE_REQUIRED);
+        }
     }
 
     private void validateFiles(final ContestSubmissionItem submissionItem, final List<MultipartFile> files,
@@ -108,14 +124,6 @@ public class ContestSubmissionCommandService {
         validateFileCount(submissionItem, totalFileCount);
         validateFileFormats(submissionItem, files);
         validateFileSizes(submissionItem, files);
-    }
-
-    private ContestSubmissionItem getValidatedSubmissionItem(final ContestSubmission submission, final Long contestId) {
-        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
-        if (!submissionItem.isInContest(contestId)) {
-            throw new ContestException(NOT_FOUND_SUBMISSION);
-        }
-        return submissionItem;
     }
 
     private void validateTeamInContest(final Team team, final Long contestId) {
@@ -131,7 +139,7 @@ public class ContestSubmissionCommandService {
     }
 
     private void validateNotAlreadySubmitted(final Long teamId, final ContestSubmissionItem submissionItem) {
-        if (contestSubmissionConvenience.existsSubmission(teamId, submissionItem)) {
+        if (contestSubmissionConvenience.isSubmitted(teamId, submissionItem)) {
             throw new ContestException(SUBMISSION_ALREADY_EXISTS);
         }
     }
@@ -157,7 +165,8 @@ public class ContestSubmissionCommandService {
     }
 
     private void validateFileFormat(final ContestSubmissionItem submissionItem, final String filename) {
-        final SubmissionFileFormat format = SubmissionFileFormat.from(filename)
+        final String extension = File.extractExtension(filename);
+        final SubmissionFileFormat format = SubmissionFileFormat.fromExtension(extension)
                 .orElseThrow(() -> new ContestException(INVALID_SUBMISSION_FILE_FORMAT));
         if (!submissionItem.supportsFormat(format)) {
             throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -1,0 +1,131 @@
+package com.opus.opus.modules.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_SIZE_EXCEEDED;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestSubmissionItemConvenience;
+import com.opus.opus.modules.contest.application.dto.response.SubmissionCreateResponse;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.file.application.FileDocumentCommandService;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ContestSubmissionCommandService {
+
+    private static final long MB_IN_BYTES = 1024L * 1024L;
+
+    private final ContestConvenience contestConvenience;
+    private final TeamConvenience teamConvenience;
+    private final TeamMemberConvenience teamMemberConvenience;
+    private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
+    private final ContestSubmissionConvenience contestSubmissionConvenience;
+    private final FileDocumentCommandService fileDocumentCommandService;
+
+    public SubmissionCreateResponse createSubmission(final Long contestId, final Long submissionItemId,
+                                                     final Long teamId, final List<MultipartFile> files,
+                                                     final Member member) {
+        contestConvenience.validateExistContest(contestId);
+        teamConvenience.validateExistTeam(teamId);
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemConvenience.getValidateExistSubmissionItem(submissionItemId);
+
+        validateSubmission(contestId, teamId, submissionItem, files, member);
+
+        final ContestSubmission submission = contestSubmissionConvenience.save(
+                ContestSubmission.create(teamId, submissionItem));
+        storeFiles(submission.getId(), files);
+
+        return new SubmissionCreateResponse(submission.getId());
+    }
+
+    private void validateSubmission(final Long contestId, final Long teamId,
+                                    final ContestSubmissionItem submissionItem, final List<MultipartFile> files,
+                                    final Member member) {
+        validateSubmissionItemInContest(submissionItem, contestId);
+        teamMemberConvenience.validateTeamMemberUnlessAdmin(teamId, member);
+        validateNotAlreadySubmitted(teamId, submissionItem);
+        validateFiles(submissionItem, files);
+        validateSubmittable(submissionItem);
+    }
+
+    private void validateSubmissionItemInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
+        if (!submissionItem.getContest().getId().equals(contestId)) {
+            throw new ContestException(NOT_FOUND_SUBMISSION_ITEM);
+        }
+    }
+
+    private void validateNotAlreadySubmitted(final Long teamId, final ContestSubmissionItem submissionItem) {
+        if (contestSubmissionConvenience.existsSubmission(teamId, submissionItem)) {
+            throw new ContestException(SUBMISSION_ALREADY_EXISTS);
+        }
+    }
+
+    private void validateFiles(final ContestSubmissionItem submissionItem, final List<MultipartFile> files) {
+        if (files.size() > submissionItem.getMaxFileCount()) {
+            throw new ContestException(SUBMISSION_FILE_COUNT_EXCEEDED);
+        }
+        final long maxFileSizeBytes = submissionItem.getMaxFileSizeMb() * MB_IN_BYTES;
+        for (final MultipartFile file : files) {
+            validateFileFormat(submissionItem, file.getOriginalFilename());
+            if (file.getSize() > maxFileSizeBytes) {
+                throw new ContestException(SUBMISSION_FILE_SIZE_EXCEEDED);
+            }
+        }
+    }
+
+    private void validateFileFormat(final ContestSubmissionItem submissionItem, final String filename) {
+        final String extension = extractExtension(filename);
+        final SubmissionFileFormat format;
+        try {
+            format = SubmissionFileFormat.valueOf(extension.toUpperCase());
+        } catch (final IllegalArgumentException e) {
+            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
+        }
+        if (!submissionItem.getAllowedFileFormats().contains(format)) {
+            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
+        }
+    }
+
+    private void validateSubmittable(final ContestSubmissionItem submissionItem) {
+        final boolean afterDeadline = LocalDateTime.now().isAfter(submissionItem.getEndAt());
+        if (afterDeadline && !submissionItem.getAllowLateSubmission()) {
+            throw new ContestException(SUBMISSION_PERIOD_ENDED);
+        }
+    }
+
+    private void storeFiles(final Long submissionId, final List<MultipartFile> files) {
+        for (int i = 0; i < files.size(); i++) {
+            fileDocumentCommandService.storeDocumentFile(files.get(i), submissionId, i + 1);
+        }
+    }
+
+    private String extractExtension(final String filename) {
+        if (filename == null || filename.isBlank()) {
+            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
+        }
+        final int lastDot = filename.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot >= filename.length() - 1) {
+            throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
+        }
+        return filename.substring(lastDot + 1);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -7,7 +7,6 @@ import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMI
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_REQUIRED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_SIZE_EXCEEDED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
-import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
@@ -24,8 +23,6 @@ import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
-import com.opus.opus.modules.team.domain.Team;
-import com.opus.opus.modules.team.exception.TeamException;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -53,8 +50,7 @@ public class ContestSubmissionCommandService {
                                                      final Long teamId, final List<MultipartFile> files,
                                                      final Member member) {
         contestConvenience.validateExistContest(contestId);
-        final Team team = teamConvenience.getValidateExistTeam(teamId);
-        validateTeamInContest(team, contestId);
+        teamConvenience.getValidateTeamInContest(teamId, contestId);
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemConvenience.getValidateExistSubmissionItem(submissionItemId);
 
@@ -85,7 +81,8 @@ public class ContestSubmissionCommandService {
         fileDocumentCommandService.storeDocumentFiles(submissionId, files);
     }
 
-    public void deleteFile(final Long contestId, final Long submissionId, final Long fileId, final Member member) {
+    public void deleteSubmissionFile(final Long contestId, final Long submissionId, final Long fileId,
+                                     final Member member) {
         contestConvenience.validateExistContest(contestId);
         final ContestSubmission submission =
                 contestSubmissionConvenience.getValidateSubmissionInContest(submissionId, contestId);
@@ -124,12 +121,6 @@ public class ContestSubmissionCommandService {
         validateFileCount(submissionItem, totalFileCount);
         validateFileFormats(submissionItem, files);
         validateFileSizes(submissionItem, files);
-    }
-
-    private void validateTeamInContest(final Team team, final Long contestId) {
-        if (!team.isInContest(contestId)) {
-            throw new TeamException(NOT_FOUND_TEAM);
-        }
     }
 
     private void validateSubmissionItemInContest(final ContestSubmissionItem submissionItem, final Long contestId) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -159,7 +159,7 @@ public class ContestSubmissionCommandService {
         final String extension = File.extractExtension(filename);
         final SubmissionFileFormat format = SubmissionFileFormat.fromExtension(extension)
                 .orElseThrow(() -> new ContestException(INVALID_SUBMISSION_FILE_FORMAT));
-        if (!submissionItem.supportsFormat(format)) {
+        if (!submissionItem.isAllowedFormat(format)) {
             throw new ContestException(INVALID_SUBMISSION_FILE_FORMAT);
         }
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
@@ -16,6 +17,10 @@ import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.file.application.FileDocumentCommandService;
+import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.file.exception.FileException;
+import com.opus.opus.modules.file.exception.FileExceptionType;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
@@ -39,6 +44,7 @@ public class ContestSubmissionCommandService {
     private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
     private final ContestSubmissionConvenience contestSubmissionConvenience;
     private final FileDocumentCommandService fileDocumentCommandService;
+    private final FileDocumentConvenience fileDocumentConvenience;
 
     public SubmissionCreateResponse createSubmission(final Long contestId, final Long submissionItemId,
                                                      final Long teamId, final List<MultipartFile> files,
@@ -57,14 +63,60 @@ public class ContestSubmissionCommandService {
         return new SubmissionCreateResponse(submission.getId());
     }
 
+    public void addFiles(final Long contestId, final Long submissionId, final List<MultipartFile> files,
+                         final Member member) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
+        final ContestSubmissionItem submissionItem = getValidatedSubmissionItem(submission, contestId);
+        teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
+
+        final List<FileDocument> existingFiles = fileDocumentConvenience.findAllBySubmissionId(submissionId);
+        validateFiles(submissionItem, files, existingFiles.size() + files.size());
+        validateSubmittable(submissionItem);
+
+        appendFiles(submissionId, existingFiles, files);
+    }
+
+    public void deleteFile(final Long contestId, final Long submissionId, final Long fileId, final Member member) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
+        final ContestSubmissionItem submissionItem = getValidatedSubmissionItem(submission, contestId);
+        teamMemberConvenience.validateTeamMemberUnlessAdmin(submission.getTeamId(), member);
+
+        final List<FileDocument> files = fileDocumentConvenience.findAllBySubmissionId(submissionId);
+        validateFileBelongsToSubmission(files, fileId);
+        validateSubmittable(submissionItem);
+
+        fileDocumentCommandService.deleteDocumentFile(fileId);
+        if (files.size() == 1) {
+            contestSubmissionConvenience.delete(submission);
+        }
+    }
+
     private void validateSubmission(final Long contestId, final Long teamId,
                                     final ContestSubmissionItem submissionItem, final List<MultipartFile> files,
                                     final Member member) {
         validateSubmissionItemInContest(submissionItem, contestId);
         teamMemberConvenience.validateTeamMemberUnlessAdmin(teamId, member);
         validateNotAlreadySubmitted(teamId, submissionItem);
-        validateFiles(submissionItem, files);
+        validateFiles(submissionItem, files, files.size());
         validateSubmittable(submissionItem);
+    }
+
+    private void validateFiles(final ContestSubmissionItem submissionItem, final List<MultipartFile> files,
+                               final int totalFileCount) {
+        validateFileCount(submissionItem, totalFileCount);
+        validateFileFormats(submissionItem, files);
+        validateFileSizes(submissionItem, files);
+    }
+
+    private ContestSubmissionItem getValidatedSubmissionItem(final ContestSubmission submission, final Long contestId) {
+        final ContestSubmissionItem submissionItem = contestSubmissionItemConvenience
+                .getValidateExistSubmissionItem(submission.getSubmissionItem().getId());
+        if (!submissionItem.getContest().getId().equals(contestId)) {
+            throw new ContestException(NOT_FOUND_SUBMISSION);
+        }
+        return submissionItem;
     }
 
     private void validateSubmissionItemInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
@@ -79,13 +131,28 @@ public class ContestSubmissionCommandService {
         }
     }
 
-    private void validateFiles(final ContestSubmissionItem submissionItem, final List<MultipartFile> files) {
-        if (files.size() > submissionItem.getMaxFileCount()) {
+    private void validateFileBelongsToSubmission(final List<FileDocument> files, final Long fileId) {
+        final boolean exists = files.stream().anyMatch(file -> file.getId().equals(fileId));
+        if (!exists) {
+            throw new FileException(FileExceptionType.NOT_FOUND);
+        }
+    }
+
+    private void validateFileCount(final ContestSubmissionItem submissionItem, final int totalFileCount) {
+        if (totalFileCount > submissionItem.getMaxFileCount()) {
             throw new ContestException(SUBMISSION_FILE_COUNT_EXCEEDED);
         }
-        final long maxFileSizeBytes = submissionItem.getMaxFileSizeMb() * MB_IN_BYTES;
+    }
+
+    private void validateFileFormats(final ContestSubmissionItem submissionItem, final List<MultipartFile> files) {
         for (final MultipartFile file : files) {
             validateFileFormat(submissionItem, file.getOriginalFilename());
+        }
+    }
+
+    private void validateFileSizes(final ContestSubmissionItem submissionItem, final List<MultipartFile> files) {
+        final long maxFileSizeBytes = submissionItem.getMaxFileSizeMb() * MB_IN_BYTES;
+        for (final MultipartFile file : files) {
             if (file.getSize() > maxFileSizeBytes) {
                 throw new ContestException(SUBMISSION_FILE_SIZE_EXCEEDED);
             }
@@ -115,6 +182,17 @@ public class ContestSubmissionCommandService {
     private void storeFiles(final Long submissionId, final List<MultipartFile> files) {
         for (int i = 0; i < files.size(); i++) {
             fileDocumentCommandService.storeDocumentFile(files.get(i), submissionId, i + 1);
+        }
+    }
+
+    private void appendFiles(final Long submissionId, final List<FileDocument> existingFiles,
+                             final List<MultipartFile> files) {
+        final int startOrder = existingFiles.stream()
+                .mapToInt(FileDocument::getFileOrder)
+                .max()
+                .orElse(0);
+        for (int i = 0; i < files.size(); i++) {
+            fileDocumentCommandService.storeDocumentFile(files.get(i), submissionId, startOrder + 1 + i);
         }
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
@@ -5,8 +5,6 @@ import com.opus.opus.modules.contest.application.convenience.ContestSubmissionCo
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
-import com.opus.opus.modules.contest.exception.ContestException;
-import com.opus.opus.modules.contest.exception.ContestExceptionType;
 import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
 import com.opus.opus.modules.file.domain.FileDocument;
 import com.opus.opus.modules.member.domain.Member;
@@ -37,8 +35,7 @@ public class ContestSubmissionQueryService {
                 contestId);
         final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
 
-        final Team team = teamConvenience.getValidateExistTeam(submission.getTeamId());
-        validateTeamInContest(team, contestId);
+        final Team team = teamConvenience.getValidateTeamInContest(submission.getTeamId(), contestId);
         // 학생은 해당 팀의 팀장/팀원만 조회할 수 있다. (관리자/교수/직원/외부멘토는 제한 없음)
         teamMemberConvenience.validateTeamMemberIfStudent(team.getId(), member);
 
@@ -54,11 +51,5 @@ public class ContestSubmissionQueryService {
         final int commentCount = 0;
 
         return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, commentCount);
-    }
-
-    private void validateTeamInContest(final Team team, final Long contestId) {
-        if (!team.isInContest(contestId)) {
-            throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
-        }
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
@@ -33,9 +33,9 @@ public class ContestSubmissionQueryService {
                                                                final Member member) {
         contestConvenience.validateExistContest(contestId);
 
-        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
+        final ContestSubmission submission = contestSubmissionConvenience.getValidateSubmissionInContest(submissionId,
+                contestId);
         final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
-        validateSubmissionInContest(submissionItem, contestId);
 
         final Team team = teamConvenience.getValidateExistTeam(submission.getTeamId());
         validateTeamInContest(team, contestId);
@@ -54,12 +54,6 @@ public class ContestSubmissionQueryService {
         final int commentCount = 0;
 
         return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, commentCount);
-    }
-
-    private void validateSubmissionInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
-        if (!submissionItem.isInContest(contestId)) {
-            throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
-        }
     }
 
     private void validateTeamInContest(final Team team, final Long contestId) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
@@ -1,0 +1,63 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestExceptionType;
+import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
+import com.opus.opus.modules.team.domain.Team;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestSubmissionQueryService {
+
+    private final ContestConvenience contestConvenience;
+    private final ContestSubmissionConvenience contestSubmissionConvenience;
+    private final TeamConvenience teamConvenience;
+    private final TeamMemberConvenience teamMemberConvenience;
+    private final FileDocumentConvenience fileDocumentConvenience;
+
+    public ContestSubmissionDetailResponse getSubmissionDetail(final Long contestId, final Long submissionId,
+                                                               final Member member) {
+        contestConvenience.validateExistContest(contestId);
+
+        final ContestSubmission submission = contestSubmissionConvenience.getValidateExistSubmission(submissionId);
+        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
+        validateSubmissionInContest(submissionItem, contestId);
+
+        final Team team = teamConvenience.getValidateExistTeam(submission.getTeamId());
+        // 학생은 해당 팀의 팀장/팀원만 조회할 수 있다. (관리자/교수/직원/외부멘토는 제한 없음)
+        teamMemberConvenience.validateTeamMemberIfStudent(team.getId(), member);
+
+        final String trackName = submissionItem.getContestTrack() != null
+                ? submissionItem.getContestTrack().getTrackName()
+                : null;
+        final List<FileDocument> fileDocuments = fileDocumentConvenience.findAllBySubmissionId(submissionId);
+
+        /* TODO
+        제출물 코멘트 기능이 아직 없어서, 제출물 카운트를 0으로 고정하였습니다.
+        코멘트 기능 추가 시 실제 개수로 교체가 필요합니다.
+         */
+        final int commentCount = 0;
+
+        return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, commentCount);
+    }
+
+    private void validateSubmissionInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
+        if (!submissionItem.isInContest(contestId)) {
+            throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
@@ -38,6 +38,7 @@ public class ContestSubmissionQueryService {
         validateSubmissionInContest(submissionItem, contestId);
 
         final Team team = teamConvenience.getValidateExistTeam(submission.getTeamId());
+        validateTeamInContest(team, contestId);
         // 학생은 해당 팀의 팀장/팀원만 조회할 수 있다. (관리자/교수/직원/외부멘토는 제한 없음)
         teamMemberConvenience.validateTeamMemberIfStudent(team.getId(), member);
 
@@ -57,6 +58,12 @@ public class ContestSubmissionQueryService {
 
     private void validateSubmissionInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
         if (!submissionItem.isInContest(contestId)) {
+            throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
+        }
+    }
+
+    private void validateTeamInContest(final Team team, final Long contestId) {
+        if (!team.isInContest(contestId)) {
             throw new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION);
         }
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
@@ -4,6 +4,7 @@ package com.opus.opus.modules.contest.application.convenience;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
 
 import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import lombok.RequiredArgsConstructor;
@@ -20,5 +21,13 @@ public class ContestSubmissionConvenience {
     public ContestSubmission getValidateExistSubmission(final Long submissionId) {
         return contestSubmissionRepository.findById(submissionId)
                 .orElseThrow(() -> new ContestException(NOT_FOUND_SUBMISSION));
+    }
+
+    public boolean existsSubmission(final Long teamId, final ContestSubmissionItem submissionItem) {
+        return contestSubmissionRepository.existsByTeamIdAndSubmissionItem(teamId, submissionItem);
+    }
+
+    public ContestSubmission save(final ContestSubmission submission) {
+        return contestSubmissionRepository.save(submission);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
@@ -1,0 +1,24 @@
+package com.opus.opus.modules.contest.application.convenience;
+
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
+
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestSubmissionConvenience {
+
+    private final ContestSubmissionRepository contestSubmissionRepository;
+
+    public ContestSubmission getValidateExistSubmission(final Long submissionId) {
+        return contestSubmissionRepository.findById(submissionId)
+                .orElseThrow(() -> new ContestException(NOT_FOUND_SUBMISSION));
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
@@ -30,4 +30,8 @@ public class ContestSubmissionConvenience {
     public ContestSubmission save(final ContestSubmission submission) {
         return contestSubmissionRepository.save(submission);
     }
+
+    public void delete(final ContestSubmission submission) {
+        contestSubmissionRepository.delete(submission);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
@@ -23,7 +23,15 @@ public class ContestSubmissionConvenience {
                 .orElseThrow(() -> new ContestException(NOT_FOUND_SUBMISSION));
     }
 
-    public boolean existsSubmission(final Long teamId, final ContestSubmissionItem submissionItem) {
+    public ContestSubmission getValidateSubmissionInContest(final Long submissionId, final Long contestId) {
+        final ContestSubmission submission = getValidateExistSubmission(submissionId);
+        if (!submission.isInContest(contestId)) {
+            throw new ContestException(NOT_FOUND_SUBMISSION);
+        }
+        return submission;
+    }
+
+    public boolean isSubmitted(final Long teamId, final ContestSubmissionItem submissionItem) {
         return contestSubmissionRepository.existsByTeamIdAndSubmissionItem(teamId, submissionItem);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionConvenience.java
@@ -26,12 +26,4 @@ public class ContestSubmissionConvenience {
     public boolean existsSubmission(final Long teamId, final ContestSubmissionItem submissionItem) {
         return contestSubmissionRepository.existsByTeamIdAndSubmissionItem(teamId, submissionItem);
     }
-
-    public ContestSubmission save(final ContestSubmission submission) {
-        return contestSubmissionRepository.save(submission);
-    }
-
-    public void delete(final ContestSubmission submission) {
-        contestSubmissionRepository.delete(submission);
-    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionItemConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionItemConvenience.java
@@ -1,0 +1,24 @@
+package com.opus.opus.modules.contest.application.convenience;
+
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM;
+
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestSubmissionItemConvenience {
+
+    private final ContestSubmissionItemRepository contestSubmissionItemRepository;
+
+    public ContestSubmissionItem getValidateExistSubmissionItem(final Long submissionItemId) {
+        return contestSubmissionItemRepository.findById(submissionItemId)
+                .orElseThrow(() -> new ContestException(NOT_FOUND_SUBMISSION_ITEM));
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
@@ -3,7 +3,6 @@ package com.opus.opus.modules.contest.application.dto.response;
 import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.SubmissionStatus;
-import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.FileDocument;
 import com.opus.opus.modules.team.domain.Team;
 import java.time.LocalDateTime;
@@ -49,8 +48,7 @@ public record ContestSubmissionDetailResponse(
             Long fileSize
     ) {
         public static FileResponse from(final FileDocument fileDocument) {
-            final File file = fileDocument.getFile();
-            return new FileResponse(fileDocument.getId(), file.getName(), file.getFileSize());
+            return new FileResponse(fileDocument.getId(), fileDocument.getName(), fileDocument.getFileSize());
         }
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
@@ -1,0 +1,56 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.SubmissionStatus;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.team.domain.Team;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ContestSubmissionDetailResponse(
+        Long submissionId,
+        Long teamId,
+        String teamName,
+        String projectOverview,
+        String trackName,
+        String submissionTypeName,
+        SubmissionStatus status,
+        LocalDateTime deadlineAt,
+        LocalDateTime firstSubmittedAt,
+        LocalDateTime lastModifiedAt,
+        List<FileResponse> files,
+        Integer commentCount
+) {
+    public static ContestSubmissionDetailResponse of(final ContestSubmission submission, final Team team,
+                                                     final String trackName, final List<FileDocument> fileDocuments,
+                                                     final int commentCount) {
+        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
+        return new ContestSubmissionDetailResponse(
+                submission.getId(),
+                team.getId(),
+                team.getTeamName(),
+                team.getOverview(),
+                trackName,
+                submissionItem.getName(),
+                SubmissionStatus.from(submission.getFirstSubmittedAt(), submissionItem.getEndAt()),
+                submissionItem.getEndAt(),
+                submission.getFirstSubmittedAt(),
+                submission.getUpdatedAt(),
+                fileDocuments.stream().map(FileResponse::from).toList(),
+                commentCount
+        );
+    }
+
+    public record FileResponse(
+            Long fileId,
+            String fileName,
+            Long fileSize
+    ) {
+        public static FileResponse from(final FileDocument fileDocument) {
+            final File file = fileDocument.getFile();
+            return new FileResponse(fileDocument.getId(), file.getName(), file.getFileSize());
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
@@ -33,7 +33,7 @@ public record ContestSubmissionDetailResponse(
                 team.getOverview(),
                 trackName,
                 submissionItem.getName(),
-                SubmissionStatus.from(submission.getFirstSubmittedAt(), submissionItem.getEndAt()),
+                submission.isLate() ? SubmissionStatus.LATE : SubmissionStatus.SUBMITTED,
                 submissionItem.getEndAt(),
                 submission.getFirstSubmittedAt(),
                 submission.getUpdatedAt(),

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/SubmissionCreateResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/SubmissionCreateResponse.java
@@ -1,0 +1,6 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+public record SubmissionCreateResponse(
+        Long submissionId
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmission.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmission.java
@@ -51,11 +51,11 @@ public class ContestSubmission extends BaseEntity {
         this.isDeleted = false;
     }
 
-    public static ContestSubmission create(final Long teamId, final ContestSubmissionItem submissionItem) {
-        return ContestSubmission.builder()
-                .teamId(teamId)
-                .firstSubmittedAt(LocalDateTime.now())
-                .submissionItem(submissionItem)
-                .build();
+    public boolean isInContest(final Long contestId) {
+        return submissionItem.isInContest(contestId);
+    }
+
+    public boolean isLate() {
+        return firstSubmittedAt.isAfter(submissionItem.getEndAt());
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmission.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmission.java
@@ -50,4 +50,12 @@ public class ContestSubmission extends BaseEntity {
         this.submissionItem = submissionItem;
         this.isDeleted = false;
     }
+
+    public static ContestSubmission create(final Long teamId, final ContestSubmissionItem submissionItem) {
+        return ContestSubmission.builder()
+                .teamId(teamId)
+                .firstSubmittedAt(LocalDateTime.now())
+                .submissionItem(submissionItem)
+                .build();
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -31,6 +31,8 @@ import org.hibernate.annotations.SQLRestriction;
 @SQLDelete(sql = "UPDATE contest_submission_item SET is_deleted = true WHERE id = ?")
 public class ContestSubmissionItem extends BaseEntity {
 
+    private static final long MB_IN_BYTES = 1024L * 1024L;
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -100,5 +102,21 @@ public class ContestSubmissionItem extends BaseEntity {
 
     public boolean isInContest(final Long contestId) {
         return contest.getId().equals(contestId);
+    }
+
+    public boolean isSubmissionClosed() {
+        return LocalDateTime.now().isAfter(endAt) && !allowLateSubmission;
+    }
+
+    public boolean isFileCountExceeded(final int totalFileCount) {
+        return totalFileCount > maxFileCount;
+    }
+
+    public boolean supportsFormat(final SubmissionFileFormat format) {
+        return allowedFileFormats.contains(format);
+    }
+
+    public boolean isFileSizeExceeded(final long sizeBytes) {
+        return sizeBytes > maxFileSizeMb * MB_IN_BYTES;
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -112,7 +112,7 @@ public class ContestSubmissionItem extends BaseEntity {
         return totalFileCount > maxFileCount;
     }
 
-    public boolean supportsFormat(final SubmissionFileFormat format) {
+    public boolean isAllowedFormat(final SubmissionFileFormat format) {
         return allowedFileFormats.contains(format);
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -97,4 +97,8 @@ public class ContestSubmissionItem extends BaseEntity {
         this.contestTrack = contestTrack;
         this.isDeleted = false;
     }
+
+    public boolean isInContest(final Long contestId) {
+        return contest.getId().equals(contestId);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/SubmissionFileFormat.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/SubmissionFileFormat.java
@@ -17,9 +17,8 @@ public enum SubmissionFileFormat {
     DOCX,
     HWP;
 
-    public static Optional<SubmissionFileFormat> from(final String filename) {
-        final String extension = extractExtension(filename);
-        if (extension == null) {
+    public static Optional<SubmissionFileFormat> fromExtension(final String extension) {
+        if (extension == null || extension.isBlank()) {
             return Optional.empty();
         }
         try {
@@ -27,16 +26,5 @@ public enum SubmissionFileFormat {
         } catch (final IllegalArgumentException e) {
             return Optional.empty();
         }
-    }
-
-    private static String extractExtension(final String filename) {
-        if (filename == null || filename.isBlank()) {
-            return null;
-        }
-        final int lastDot = filename.lastIndexOf('.');
-        if (lastDot <= 0 || lastDot >= filename.length() - 1) {
-            return null;
-        }
-        return filename.substring(lastDot + 1);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/SubmissionFileFormat.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/SubmissionFileFormat.java
@@ -1,5 +1,7 @@
 package com.opus.opus.modules.contest.domain;
 
+import java.util.Optional;
+
 public enum SubmissionFileFormat {
 
     PDF,
@@ -13,5 +15,28 @@ public enum SubmissionFileFormat {
     PPTX,
     DOC,
     DOCX,
-    HWP
+    HWP;
+
+    public static Optional<SubmissionFileFormat> from(final String filename) {
+        final String extension = extractExtension(filename);
+        if (extension == null) {
+            return Optional.empty();
+        }
+        try {
+            return Optional.of(SubmissionFileFormat.valueOf(extension.toUpperCase()));
+        } catch (final IllegalArgumentException e) {
+            return Optional.empty();
+        }
+    }
+
+    private static String extractExtension(final String filename) {
+        if (filename == null || filename.isBlank()) {
+            return null;
+        }
+        final int lastDot = filename.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot >= filename.length() - 1) {
+            return null;
+        }
+        return filename.substring(lastDot + 1);
+    }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/SubmissionStatus.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/SubmissionStatus.java
@@ -1,0 +1,15 @@
+package com.opus.opus.modules.contest.domain;
+
+import java.time.LocalDateTime;
+
+public enum SubmissionStatus {
+
+    SUBMITTED,
+    LATE,
+    NOT_SUBMITTED,
+    NOT_SUBMITTED_AFTER_DEADLINE;
+
+    public static SubmissionStatus from(final LocalDateTime firstSubmittedAt, final LocalDateTime deadlineAt) {
+        return firstSubmittedAt.isAfter(deadlineAt) ? LATE : SUBMITTED;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/SubmissionStatus.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/SubmissionStatus.java
@@ -1,15 +1,9 @@
 package com.opus.opus.modules.contest.domain;
 
-import java.time.LocalDateTime;
-
 public enum SubmissionStatus {
 
     SUBMITTED,
     LATE,
     NOT_SUBMITTED,
-    NOT_SUBMITTED_AFTER_DEADLINE;
-
-    public static SubmissionStatus from(final LocalDateTime firstSubmittedAt, final LocalDateTime deadlineAt) {
-        return firstSubmittedAt.isAfter(deadlineAt) ? LATE : SUBMITTED;
-    }
+    NOT_SUBMITTED_AFTER_DEADLINE
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionRepository.java
@@ -3,8 +3,15 @@ package com.opus.opus.modules.contest.domain.dao;
 import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ContestSubmissionRepository extends JpaRepository<ContestSubmission, Long> {
 
     boolean existsByTeamIdAndSubmissionItem(final Long teamId, final ContestSubmissionItem submissionItem);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE ContestSubmission s SET s.updatedAt = CURRENT_TIMESTAMP WHERE s.id = :submissionId")
+    void touchUpdatedAt(@Param("submissionId") final Long submissionId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -6,6 +6,12 @@ import org.springframework.http.HttpStatus;
 public enum ContestExceptionType implements BaseExceptionType {
     NOT_FOUND_CONTEST(HttpStatus.NOT_FOUND, "존재하지 않는 대회입니다."),
     NOT_FOUND_SUBMISSION(HttpStatus.NOT_FOUND, "존재하지 않는 제출물입니다."),
+    NOT_FOUND_SUBMISSION_ITEM(HttpStatus.NOT_FOUND, "존재하지 않는 제출 항목입니다."),
+    SUBMISSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 제출한 제출 항목입니다."),
+    INVALID_SUBMISSION_FILE_FORMAT(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다."),
+    SUBMISSION_FILE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "제출 가능한 파일 수를 초과했습니다."),
+    SUBMISSION_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "제출 가능한 파일 크기를 초과했습니다."),
+    SUBMISSION_PERIOD_ENDED(HttpStatus.BAD_REQUEST, "제출 기간이 종료되었습니다."),
     CONTEST_HAS_TEAMS(HttpStatus.CONFLICT, "먼저 해당 대회의 모든 팀을 삭제해주세요."),
     CURRENT_CONTEST_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "현재 진행 중인 대회는 최대 2개까지 설정할 수 있습니다."),
     ALREADY_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회입니다."),

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -9,6 +9,7 @@ public enum ContestExceptionType implements BaseExceptionType {
     NOT_FOUND_SUBMISSION_ITEM(HttpStatus.NOT_FOUND, "존재하지 않는 제출 항목입니다."),
     SUBMISSION_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 제출한 제출 항목입니다."),
     INVALID_SUBMISSION_FILE_FORMAT(HttpStatus.BAD_REQUEST, "허용되지 않는 파일 형식입니다."),
+    SUBMISSION_FILE_REQUIRED(HttpStatus.BAD_REQUEST, "제출물은 최소 한 개의 파일을 포함해야 합니다."),
     SUBMISSION_FILE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "제출 가능한 파일 수를 초과했습니다."),
     SUBMISSION_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "제출 가능한 파일 크기를 초과했습니다."),
     SUBMISSION_PERIOD_ENDED(HttpStatus.BAD_REQUEST, "제출 기간이 종료되었습니다."),

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 
 public enum ContestExceptionType implements BaseExceptionType {
     NOT_FOUND_CONTEST(HttpStatus.NOT_FOUND, "존재하지 않는 대회입니다."),
+    NOT_FOUND_SUBMISSION(HttpStatus.NOT_FOUND, "존재하지 않는 제출물입니다."),
     CONTEST_HAS_TEAMS(HttpStatus.CONFLICT, "먼저 해당 대회의 모든 팀을 삭제해주세요."),
     CURRENT_CONTEST_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "현재 진행 중인 대회는 최대 2개까지 설정할 수 있습니다."),
     ALREADY_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회입니다."),

--- a/src/main/java/com/opus/opus/modules/file/application/FileDocumentCommandService.java
+++ b/src/main/java/com/opus/opus/modules/file/application/FileDocumentCommandService.java
@@ -57,11 +57,7 @@ public class FileDocumentCommandService {
     }
 
     public void storeDocumentFiles(final Long submissionId, final List<MultipartFile> files) {
-        final int startOrder = fileDocumentRepository.findAllBySubmissionIdOrderByFileOrder(submissionId)
-                .stream()
-                .mapToInt(FileDocument::getFileOrder)
-                .max()
-                .orElse(0);
+        final int startOrder = fileDocumentRepository.findMaxFileOrderBySubmissionId(submissionId);
         for (int i = 0; i < files.size(); i++) {
             storeDocumentFile(files.get(i), submissionId, startOrder + 1 + i);
         }

--- a/src/main/java/com/opus/opus/modules/file/application/FileDocumentCommandService.java
+++ b/src/main/java/com/opus/opus/modules/file/application/FileDocumentCommandService.java
@@ -33,7 +33,7 @@ public class FileDocumentCommandService {
 
         try {
             final byte[] fileBytes = multipartFile.getBytes();
-            final String extension = extractExtension(multipartFile.getOriginalFilename());
+            final String extension = File.extractExtension(multipartFile.getOriginalFilename());
             final String relativePath = filePathGenerator.generate(extension);
             final String mimeType = multipartFile.getContentType() != null
                     ? multipartFile.getContentType() : "application/octet-stream";
@@ -81,13 +81,5 @@ public class FileDocumentCommandService {
             fileDocumentRepository.delete(doc);
             eventPublisher.publishEvent(new PhysicalFileDeleteEvent(filePath));
         });
-    }
-
-    private String extractExtension(final String filename) {
-        if (filename == null || filename.isBlank()) {
-            return "bin";
-        }
-        final int lastDot = filename.lastIndexOf('.');
-        return (lastDot > 0 && lastDot < filename.length() - 1) ? filename.substring(lastDot + 1) : "bin";
     }
 }

--- a/src/main/java/com/opus/opus/modules/file/application/FileDocumentCommandService.java
+++ b/src/main/java/com/opus/opus/modules/file/application/FileDocumentCommandService.java
@@ -56,6 +56,17 @@ public class FileDocumentCommandService {
         }
     }
 
+    public void storeDocumentFiles(final Long submissionId, final List<MultipartFile> files) {
+        final int startOrder = fileDocumentRepository.findAllBySubmissionIdOrderByFileOrder(submissionId)
+                .stream()
+                .mapToInt(FileDocument::getFileOrder)
+                .max()
+                .orElse(0);
+        for (int i = 0; i < files.size(); i++) {
+            storeDocumentFile(files.get(i), submissionId, startOrder + 1 + i);
+        }
+    }
+
     public void deleteDocumentFile(final Long fileDocumentId) {
         final FileDocument fileDocument = fileDocumentRepository.findById(fileDocumentId)
                 .orElseThrow(() -> new FileException(FileExceptionType.NOT_FOUND,

--- a/src/main/java/com/opus/opus/modules/file/application/convenience/FileDocumentConvenience.java
+++ b/src/main/java/com/opus/opus/modules/file/application/convenience/FileDocumentConvenience.java
@@ -2,6 +2,8 @@ package com.opus.opus.modules.file.application.convenience;
 
 import com.opus.opus.modules.file.domain.FileDocument;
 import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
+import com.opus.opus.modules.file.exception.FileException;
+import com.opus.opus.modules.file.exception.FileExceptionType;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,5 +18,15 @@ public class FileDocumentConvenience {
 
     public List<FileDocument> findAllBySubmissionId(final Long submissionId) {
         return fileDocumentRepository.findAllBySubmissionIdOrderByFileOrder(submissionId);
+    }
+
+    public void validateFileBelongsToSubmission(final Long submissionId, final Long fileId) {
+        if (!fileDocumentRepository.existsByIdAndSubmissionId(fileId, submissionId)) {
+            throw new FileException(FileExceptionType.NOT_FOUND);
+        }
+    }
+
+    public long countBySubmissionId(final Long submissionId) {
+        return fileDocumentRepository.countBySubmissionId(submissionId);
     }
 }

--- a/src/main/java/com/opus/opus/modules/file/application/convenience/FileDocumentConvenience.java
+++ b/src/main/java/com/opus/opus/modules/file/application/convenience/FileDocumentConvenience.java
@@ -1,0 +1,20 @@
+package com.opus.opus.modules.file.application.convenience;
+
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FileDocumentConvenience {
+
+    private final FileDocumentRepository fileDocumentRepository;
+
+    public List<FileDocument> findAllBySubmissionId(final Long submissionId) {
+        return fileDocumentRepository.findAllBySubmissionIdOrderByFileOrder(submissionId);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/file/domain/File.java
+++ b/src/main/java/com/opus/opus/modules/file/domain/File.java
@@ -15,6 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class File extends BaseEntity {
 
+    private static final String DEFAULT_EXTENSION = "bin";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -42,6 +44,17 @@ public class File extends BaseEntity {
         file.mimeType = mimeType;
         file.fileSize = fileSize;
         return file;
+    }
+
+    public static String extractExtension(final String filename) {
+        if (filename == null || filename.isBlank()) {
+            return DEFAULT_EXTENSION;
+        }
+        final int lastDot = filename.lastIndexOf('.');
+        if (lastDot <= 0 || lastDot >= filename.length() - 1) {
+            return DEFAULT_EXTENSION;
+        }
+        return filename.substring(lastDot + 1);
     }
 
 }

--- a/src/main/java/com/opus/opus/modules/file/domain/FileDocument.java
+++ b/src/main/java/com/opus/opus/modules/file/domain/FileDocument.java
@@ -49,4 +49,12 @@ public class FileDocument extends BaseEntity {
         return file.getFilePath();
     }
 
+    public String getName() {
+        return file.getName();
+    }
+
+    public Long getFileSize() {
+        return file.getFileSize();
+    }
+
 }

--- a/src/main/java/com/opus/opus/modules/file/domain/dao/FileDocumentRepository.java
+++ b/src/main/java/com/opus/opus/modules/file/domain/dao/FileDocumentRepository.java
@@ -3,6 +3,8 @@ package com.opus.opus.modules.file.domain.dao;
 import com.opus.opus.modules.file.domain.FileDocument;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface FileDocumentRepository extends JpaRepository<FileDocument, Long> {
 
@@ -11,5 +13,12 @@ public interface FileDocumentRepository extends JpaRepository<FileDocument, Long
     boolean existsByIdAndSubmissionId(Long id, Long submissionId);
 
     long countBySubmissionId(Long submissionId);
+
+    @Query("""
+             SELECT COALESCE(MAX(fd.fileOrder), 0)
+             FROM FileDocument fd
+             WHERE fd.submissionId = :submissionId
+            """)
+    int findMaxFileOrderBySubmissionId(@Param("submissionId") Long submissionId);
 
 }

--- a/src/main/java/com/opus/opus/modules/file/domain/dao/FileDocumentRepository.java
+++ b/src/main/java/com/opus/opus/modules/file/domain/dao/FileDocumentRepository.java
@@ -8,4 +8,8 @@ public interface FileDocumentRepository extends JpaRepository<FileDocument, Long
 
     List<FileDocument> findAllBySubmissionIdOrderByFileOrder(Long submissionId);
 
+    boolean existsByIdAndSubmissionId(Long id, Long submissionId);
+
+    long countBySubmissionId(Long submissionId);
+
 }

--- a/src/main/java/com/opus/opus/modules/member/domain/Member.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/Member.java
@@ -119,6 +119,10 @@ public class Member extends BaseEntity {
         return roles.contains(MemberRoleType.ROLE_관리자);
     }
 
+    public boolean isStudent() {
+        return roles.contains(MemberRoleType.ROLE_학생);
+    }
+
     public void updateGithubUrl(final String githubUrl) {
         this.githubUrl = githubUrl;
     }

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -3,7 +3,6 @@ package com.opus.opus.modules.team.application.convenience;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST_SORT;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.CONTEST_HAS_TEAM;
-import static com.opus.opus.modules.team.exception.TeamExceptionType.INVALID_TEAM_FOR_CONTEST;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.TEAM_NOT_IN_CONTEST;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.TRACK_HAS_TEAM;
@@ -41,14 +40,6 @@ public class TeamConvenience {
         teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
     }
 
-    public Team getValidateTeamInContest(final Long teamId, final Long contestId) {
-        final Team team = getValidateExistTeam(teamId);
-        if (!team.isInContest(contestId)) {
-            throw new TeamException(INVALID_TEAM_FOR_CONTEST);
-        }
-        return team;
-    }
-
     public void validateAllTeamsDeletedInContest(final Long contestId) {
         if (teamRepository.existsByContestId(contestId)) {
             throw new TeamException(CONTEST_HAS_TEAM);
@@ -77,6 +68,15 @@ public class TeamConvenience {
     public void validateTeamsInContest(final Long contestId, final List<Long> teamIds) {
         final Map<Long, Team> teams = getTeamsByIds(teamIds);
         teamIds.forEach(teamId -> validateTeamInContest(contestId, teams.get(teamId)));
+    }
+
+
+    public Team getValidateTeamInContest(final Long teamId, final Long contestId) {
+        final Team team = getValidateExistTeam(teamId);
+        if (!team.getContestId().equals(contestId)) {
+            throw new TeamException(TEAM_NOT_IN_CONTEST);
+        }
+        return team;
     }
 
     private void validateTeamInContest(final Long contestId, final Team team) {

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.team.application.convenience;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST_SORT;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.CONTEST_HAS_TEAM;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.INVALID_TEAM_FOR_CONTEST;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.TRACK_HAS_TEAM;
 
@@ -34,6 +35,14 @@ public class TeamConvenience {
 
     public void validateExistTeam(final Long teamId) {
         teamRepository.findById(teamId).orElseThrow(() -> new TeamException(NOT_FOUND_TEAM));
+    }
+
+    public Team getValidateTeamInContest(final Long teamId, final Long contestId) {
+        final Team team = getValidateExistTeam(teamId);
+        if (!team.isInContest(contestId)) {
+            throw new TeamException(INVALID_TEAM_FOR_CONTEST);
+        }
+        return team;
     }
 
     public void validateAllTeamsDeletedInContest(final Long contestId) {

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
@@ -55,6 +55,12 @@ public class TeamMemberConvenience {
         }
     }
 
+    public void validateTeamMemberIfStudent(final Long teamId, final Member member) {
+        if (member.isStudent()) {
+            getValidateExistTeamMember(teamId, member.getId());
+        }
+    }
+
     /*
         [팀장/팀원 권한 검증 위치 변경]
         ROLE_팀장, ROLE_팀원을 JwtProvider roles에 추가해 @Secured로 검증하는 방식은

--- a/src/main/java/com/opus/opus/modules/team/domain/Team.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/Team.java
@@ -121,10 +121,6 @@ public class Team extends BaseEntity {
                 .build();
     }
 
-    public boolean isInContest(final Long contestId) {
-        return this.contestId.equals(contestId);
-    }
-
     public void updateItemOrder(final Integer newOrder) {
         this.itemOrder = newOrder;
     }

--- a/src/main/java/com/opus/opus/modules/team/domain/Team.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/Team.java
@@ -121,6 +121,10 @@ public class Team extends BaseEntity {
                 .build();
     }
 
+    public boolean isInContest(final Long contestId) {
+        return this.contestId.equals(contestId);
+    }
+
     public void updateItemOrder(final Integer newOrder) {
         this.itemOrder = newOrder;
     }

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
 
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀이 존재하지 않습니다."),
+    INVALID_TEAM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
     CONTEST_HAS_TEAM(HttpStatus.CONFLICT, "해당 대회에 속한 팀이 존재합니다."),
     TRACK_HAS_TEAM(HttpStatus.CONFLICT, "해당 분과에 속한 팀이 존재합니다."),
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "팀 상세보기의 필수 항목이 누락되었습니다."),

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
@@ -6,14 +6,12 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
 
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀이 존재하지 않습니다."),
-    INVALID_TEAM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
     TEAM_NOT_IN_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
     CONTEST_HAS_TEAM(HttpStatus.CONFLICT, "해당 대회에 속한 팀이 존재합니다."),
     TRACK_HAS_TEAM(HttpStatus.CONFLICT, "해당 분과에 속한 팀이 존재합니다."),
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "팀 상세보기의 필수 항목이 누락되었습니다."),
     FORBIDDEN_CONTEST_OR_TRACK_UPDATE(HttpStatus.FORBIDDEN, "대회 또는 분과는 변경할 수 없습니다."),
-    CANT_READ_EXCEL_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "엑셀 파일을 읽는 데 실패했습니다.")
-    ;
+    CANT_READ_EXCEL_FILE(HttpStatus.INTERNAL_SERVER_ERROR, "엑셀 파일을 읽는 데 실패했습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/test/java/com/opus/opus/contest/ContestSubmissionFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestSubmissionFixture.java
@@ -1,0 +1,26 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import java.time.LocalDateTime;
+
+public class ContestSubmissionFixture {
+
+    public static ContestSubmission createSubmission(final Long teamId, final ContestSubmissionItem submissionItem) {
+        return ContestSubmission.builder()
+                .teamId(teamId)
+                .firstSubmittedAt(LocalDateTime.now())
+                .submissionItem(submissionItem)
+                .build();
+    }
+
+    public static ContestSubmission createSubmissionWithFirstSubmittedAt(final Long teamId,
+                                                                         final ContestSubmissionItem submissionItem,
+                                                                         final LocalDateTime firstSubmittedAt) {
+        return ContestSubmission.builder()
+                .teamId(teamId)
+                .firstSubmittedAt(firstSubmittedAt)
+                .submissionItem(submissionItem)
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
@@ -1,0 +1,55 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
+import com.opus.opus.modules.contest.domain.SubmissionVisibility;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import java.util.Set;
+
+public class ContestSubmissionItemFixture {
+
+    public static ContestSubmissionItem createSubmissionItem(final Contest contest) {
+        return baseBuilder(contest).build();
+    }
+
+    public static ContestSubmissionItem createSubmissionItem(final Contest contest, final ContestTrack track) {
+        return baseBuilder(contest).contestTrack(track).build();
+    }
+
+    public static ContestSubmissionItem createSubmissionItemWithDeadline(final Contest contest,
+                                                                         final LocalDateTime endAt,
+                                                                         final boolean allowLateSubmission) {
+        return baseBuilder(contest)
+                .startAt(endAt.minusDays(7))
+                .endAt(endAt)
+                .allowLateSubmission(allowLateSubmission)
+                .build();
+    }
+
+    public static ContestSubmissionItem createSubmissionItemWithMaxFileCount(final Contest contest,
+                                                                             final int maxFileCount) {
+        return baseBuilder(contest).maxFileCount(maxFileCount).build();
+    }
+
+    public static ContestSubmissionItem createSubmissionItemWithMaxFileSizeMb(final Contest contest,
+                                                                              final int maxFileSizeMb) {
+        return baseBuilder(contest).maxFileSizeMb(maxFileSizeMb).build();
+    }
+
+    private static ContestSubmissionItem.ContestSubmissionItemBuilder baseBuilder(final Contest contest) {
+        return ContestSubmissionItem.builder()
+                .name("최종 발표 자료")
+                .description("발표 자료를 제출하세요")
+                .allowedFileFormats(new HashSet<>(Set.of(SubmissionFileFormat.PDF, SubmissionFileFormat.MP4)))
+                .maxFileSizeMb(50)
+                .maxFileCount(5)
+                .startAt(LocalDateTime.now().minusDays(1))
+                .endAt(LocalDateTime.now().plusDays(7))
+                .allowLateSubmission(false)
+                .visibility(SubmissionVisibility.PUBLIC)
+                .contest(contest);
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestQueryServiceTest.java
@@ -3,7 +3,6 @@ package com.opus.opus.contest.application;
 import static com.opus.opus.member.MemberFixture.createMemberWithUniqueNum;
 import static com.opus.opus.modules.contest.domain.SortType.CUSTOM;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
-import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
 import static com.opus.opus.modules.contest.exception.ContestTemplateExceptionType.NOT_FOUND_TEMPLATE;
 import static com.opus.opus.team.TeamFixture.createTeamWithContestId;
 import static com.opus.opus.team.TeamVoteFixture.createTeamVote;
@@ -13,15 +12,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.contest.ContestSortFixture;
-import com.opus.opus.contest.ContestSubmissionFixture;
-import com.opus.opus.contest.ContestSubmissionItemFixture;
 import com.opus.opus.contest.ContestTemplateFixture;
-import com.opus.opus.contest.ContestTrackFixture;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.dto.response.ContestRankingResponse;
-import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestTemplateResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
@@ -31,33 +26,18 @@ import com.opus.opus.modules.contest.application.dto.response.TeamSummaryRespons
 import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSort;
-import com.opus.opus.modules.contest.domain.ContestSubmission;
-import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
-import com.opus.opus.modules.contest.domain.ContestTrack;
-import com.opus.opus.modules.contest.domain.SubmissionStatus;
 import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSortRepository;
-import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
-import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTemplateRepository;
-import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.contest.exception.ContestTemplateException;
-import com.opus.opus.modules.file.domain.File;
-import com.opus.opus.modules.file.domain.FileDocument;
-import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
 import com.opus.opus.modules.team.application.dto.response.MemberVoteCountResponse;
 import com.opus.opus.modules.team.domain.Team;
-import com.opus.opus.modules.team.domain.TeamMember;
-import com.opus.opus.modules.team.domain.TeamMemberRoleType;
-import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.domain.dao.TeamVoteRepository;
-import com.opus.opus.modules.team.exception.TeamMemberException;
-import com.opus.opus.modules.team.exception.TeamMemberExceptionType;
 import com.opus.opus.team.TeamFixture;
 import com.opus.opus.team.TeamVoteFixture;
 import java.time.LocalDateTime;
@@ -87,16 +67,6 @@ public class ContestQueryServiceTest extends IntegrationTest {
     private ContestCategoryRepository contestCategoryRepository;
     @Autowired
     private ContestSortRepository contestSortRepository;
-    @Autowired
-    private ContestTrackRepository contestTrackRepository;
-    @Autowired
-    private ContestSubmissionItemRepository contestSubmissionItemRepository;
-    @Autowired
-    private ContestSubmissionRepository contestSubmissionRepository;
-    @Autowired
-    private FileDocumentRepository fileDocumentRepository;
-    @Autowired
-    private TeamMemberRepository teamMemberRepository;
 
     private Contest contest;
     private Team team;
@@ -395,77 +365,4 @@ public class ContestQueryServiceTest extends IntegrationTest {
                 .containsExactly(first.getId(), second.getId(), third.getId());
     }
 
-    private void joinTeam(final Member loginMember, final Team joinTeam) {
-        teamMemberRepository.save(TeamMember.builder()
-                .memberId(loginMember.getId())
-                .team(joinTeam)
-                .roles(java.util.Set.of(TeamMemberRoleType.ROLE_팀장))
-                .build());
-    }
-
-    @Test
-    @DisplayName("[성공] 팀원이 제출물 상세를 조회하면 기본 정보와 파일 목록을 반환한다.")
-    void 제출물_상세를_조회한다() {
-        joinTeam(member, team);
-        final ContestTrack track = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
-        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
-                ContestSubmissionItemFixture.createSubmissionItem(contest, track));
-        final ContestSubmission submission = contestSubmissionRepository.save(
-                ContestSubmissionFixture.createSubmission(team.getId(), item));
-        final File file = File.create("발표자료.pdf", "files/2026-06-24/a.pdf", "application/pdf", 1048576L);
-        fileDocumentRepository.save(FileDocument.builder()
-                .file(file).submissionId(submission.getId()).fileOrder(1).build());
-
-        final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(
-                contest.getId(), submission.getId(), member);
-
-        assertThat(response.submissionId()).isEqualTo(submission.getId());
-        assertThat(response.teamId()).isEqualTo(team.getId());
-        assertThat(response.teamName()).isEqualTo(team.getTeamName());
-        assertThat(response.trackName()).isEqualTo(track.getTrackName());
-        assertThat(response.submissionTypeName()).isEqualTo(item.getName());
-        assertThat(response.status()).isEqualTo(SubmissionStatus.SUBMITTED);
-        assertThat(response.commentCount()).isZero();
-        assertThat(response.files()).hasSize(1);
-        assertThat(response.files().get(0).fileName()).isEqualTo("발표자료.pdf");
-        assertThat(response.files().get(0).fileSize()).isEqualTo(1048576L);
-    }
-
-    @Test
-    @DisplayName("[성공] 마감 이후에 최초 제출된 제출물의 상태는 LATE이다.")
-    void 마감_이후_제출물의_상태는_LATE이다() {
-        joinTeam(member, team);
-        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
-                ContestSubmissionItemFixture.createSubmissionItemWithDeadline(
-                        contest, LocalDateTime.now().minusDays(2), true));
-        final ContestSubmission submission = contestSubmissionRepository.save(
-                ContestSubmissionFixture.createSubmissionWithFirstSubmittedAt(
-                        team.getId(), item, LocalDateTime.now().minusDays(1)));
-
-        final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(
-                contest.getId(), submission.getId(), member);
-
-        assertThat(response.status()).isEqualTo(SubmissionStatus.LATE);
-    }
-
-    @Test
-    @DisplayName("[실패] 존재하지 않는 제출물을 조회하면 예외가 발생한다.")
-    void 존재하지_않는_제출물_조회_예외() {
-        assertThatThrownBy(() -> contestQueryService.getSubmissionDetail(contest.getId(), 99999L, member))
-                .isInstanceOf(ContestException.class)
-                .hasMessage(NOT_FOUND_SUBMISSION.errorMessage());
-    }
-
-    @Test
-    @DisplayName("[실패] 해당 팀 소속이 아닌 학생은 제출물 상세를 조회할 수 없다.")
-    void 비소속_학생_상세_조회_예외() {
-        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
-                ContestSubmissionItemFixture.createSubmissionItem(contest));
-        final ContestSubmission submission = contestSubmissionRepository.save(
-                ContestSubmissionFixture.createSubmission(team.getId(), item));
-
-        assertThatThrownBy(() -> contestQueryService.getSubmissionDetail(contest.getId(), submission.getId(), member))
-                .isInstanceOf(TeamMemberException.class)
-                .hasMessage(TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
-    }
 }

--- a/src/test/java/com/opus/opus/contest/application/ContestQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestQueryServiceTest.java
@@ -3,6 +3,7 @@ package com.opus.opus.contest.application;
 import static com.opus.opus.member.MemberFixture.createMemberWithUniqueNum;
 import static com.opus.opus.modules.contest.domain.SortType.CUSTOM;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
 import static com.opus.opus.modules.contest.exception.ContestTemplateExceptionType.NOT_FOUND_TEMPLATE;
 import static com.opus.opus.team.TeamFixture.createTeamWithContestId;
 import static com.opus.opus.team.TeamVoteFixture.createTeamVote;
@@ -12,11 +13,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.contest.ContestSortFixture;
+import com.opus.opus.contest.ContestSubmissionFixture;
+import com.opus.opus.contest.ContestSubmissionItemFixture;
 import com.opus.opus.contest.ContestTemplateFixture;
+import com.opus.opus.contest.ContestTrackFixture;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.dto.response.ContestRankingResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestTemplateResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
@@ -26,18 +31,33 @@ import com.opus.opus.modules.contest.application.dto.response.TeamSummaryRespons
 import com.opus.opus.modules.contest.application.dto.response.VotePeriodResponse;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSort;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.SubmissionStatus;
 import com.opus.opus.modules.contest.domain.dao.ContestCategoryRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSortRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTemplateRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.contest.exception.ContestTemplateException;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
 import com.opus.opus.modules.team.application.dto.response.MemberVoteCountResponse;
 import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.domain.dao.TeamVoteRepository;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import com.opus.opus.modules.team.exception.TeamMemberExceptionType;
 import com.opus.opus.team.TeamFixture;
 import com.opus.opus.team.TeamVoteFixture;
 import java.time.LocalDateTime;
@@ -67,6 +87,16 @@ public class ContestQueryServiceTest extends IntegrationTest {
     private ContestCategoryRepository contestCategoryRepository;
     @Autowired
     private ContestSortRepository contestSortRepository;
+    @Autowired
+    private ContestTrackRepository contestTrackRepository;
+    @Autowired
+    private ContestSubmissionItemRepository contestSubmissionItemRepository;
+    @Autowired
+    private ContestSubmissionRepository contestSubmissionRepository;
+    @Autowired
+    private FileDocumentRepository fileDocumentRepository;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
 
     private Contest contest;
     private Team team;
@@ -363,5 +393,79 @@ public class ContestQueryServiceTest extends IntegrationTest {
         assertThat(responses)
                 .extracting(TeamSummaryResponse::teamId)
                 .containsExactly(first.getId(), second.getId(), third.getId());
+    }
+
+    private void joinTeam(final Member loginMember, final Team joinTeam) {
+        teamMemberRepository.save(TeamMember.builder()
+                .memberId(loginMember.getId())
+                .team(joinTeam)
+                .roles(java.util.Set.of(TeamMemberRoleType.ROLE_팀장))
+                .build());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀원이 제출물 상세를 조회하면 기본 정보와 파일 목록을 반환한다.")
+    void 제출물_상세를_조회한다() {
+        joinTeam(member, team);
+        final ContestTrack track = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest, track));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), item));
+        final File file = File.create("발표자료.pdf", "files/2026-06-24/a.pdf", "application/pdf", 1048576L);
+        fileDocumentRepository.save(FileDocument.builder()
+                .file(file).submissionId(submission.getId()).fileOrder(1).build());
+
+        final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(
+                contest.getId(), submission.getId(), member);
+
+        assertThat(response.submissionId()).isEqualTo(submission.getId());
+        assertThat(response.teamId()).isEqualTo(team.getId());
+        assertThat(response.teamName()).isEqualTo(team.getTeamName());
+        assertThat(response.trackName()).isEqualTo(track.getTrackName());
+        assertThat(response.submissionTypeName()).isEqualTo(item.getName());
+        assertThat(response.status()).isEqualTo(SubmissionStatus.SUBMITTED);
+        assertThat(response.commentCount()).isZero();
+        assertThat(response.files()).hasSize(1);
+        assertThat(response.files().get(0).fileName()).isEqualTo("발표자료.pdf");
+        assertThat(response.files().get(0).fileSize()).isEqualTo(1048576L);
+    }
+
+    @Test
+    @DisplayName("[성공] 마감 이후에 최초 제출된 제출물의 상태는 LATE이다.")
+    void 마감_이후_제출물의_상태는_LATE이다() {
+        joinTeam(member, team);
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItemWithDeadline(
+                        contest, LocalDateTime.now().minusDays(2), true));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmissionWithFirstSubmittedAt(
+                        team.getId(), item, LocalDateTime.now().minusDays(1)));
+
+        final ContestSubmissionDetailResponse response = contestQueryService.getSubmissionDetail(
+                contest.getId(), submission.getId(), member);
+
+        assertThat(response.status()).isEqualTo(SubmissionStatus.LATE);
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출물을 조회하면 예외가 발생한다.")
+    void 존재하지_않는_제출물_조회_예외() {
+        assertThatThrownBy(() -> contestQueryService.getSubmissionDetail(contest.getId(), 99999L, member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 해당 팀 소속이 아닌 학생은 제출물 상세를 조회할 수 없다.")
+    void 비소속_학생_상세_조회_예외() {
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), item));
+
+        assertThatThrownBy(() -> contestQueryService.getSubmissionDetail(contest.getId(), submission.getId(), member))
+                .isInstanceOf(TeamMemberException.class)
+                .hasMessage(TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
     }
 }

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
@@ -1,0 +1,259 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_SIZE_EXCEEDED;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.contest.ContestSubmissionFixture;
+import com.opus.opus.contest.ContestSubmissionItemFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
+import com.opus.opus.modules.contest.application.dto.response.SubmissionCreateResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
+import com.opus.opus.modules.file.exception.FileException;
+import com.opus.opus.modules.file.exception.FileExceptionType;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import com.opus.opus.modules.team.exception.TeamMemberExceptionType;
+import com.opus.opus.team.TeamFixture;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class ContestSubmissionCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestSubmissionCommandService contestSubmissionCommandService;
+
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+    @Autowired
+    private ContestSubmissionItemRepository contestSubmissionItemRepository;
+    @Autowired
+    private ContestSubmissionRepository contestSubmissionRepository;
+    @Autowired
+    private FileDocumentRepository fileDocumentRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private Contest contest;
+    private Team team;
+    private Member member;
+    private ContestSubmissionItem submissionItem;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContest());
+        team = teamRepository.save(TeamFixture.createTeamWithContestId(contest.getId()));
+        member = memberRepository.save(MemberFixture.createMember());
+        teamMemberRepository.save(TeamMember.builder()
+                .memberId(member.getId())
+                .team(team)
+                .roles(Set.of(TeamMemberRoleType.ROLE_팀장))
+                .build());
+        submissionItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest));
+    }
+
+    private MockMultipartFile pdf(final String filename) {
+        return new MockMultipartFile("files", filename, "application/pdf", "content".getBytes());
+    }
+
+    private FileDocument saveFileDocument(final Long submissionId, final int fileOrder, final String name) {
+        final File file = File.create(name, "files/2026-06-24/" + name, "application/pdf", 1024L);
+        return fileDocumentRepository.save(FileDocument.builder()
+                .file(file)
+                .submissionId(submissionId)
+                .fileOrder(fileOrder)
+                .build());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀원이 제출 항목에 파일을 제출하면 제출이 생성된다.")
+    void 제출을_생성한다() {
+        final List<MockMultipartFile> files = List.of(pdf("발표자료.pdf"), pdf("데모영상.pdf"));
+
+        final SubmissionCreateResponse response = contestSubmissionCommandService.createSubmission(
+                contest.getId(), submissionItem.getId(), team.getId(), List.copyOf(files), member);
+
+        assertThat(response.submissionId()).isNotNull();
+        assertThat(contestSubmissionRepository.findById(response.submissionId())).isPresent();
+        verify(fileDocumentCommandService, times(2))
+                .storeDocumentFile(any(), eq(response.submissionId()), any());
+    }
+
+    @Test
+    @DisplayName("[실패] 이미 제출한 항목에 다시 제출하면 예외가 발생한다.")
+    void 중복_제출_시_예외() {
+        contestSubmissionRepository.save(ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), submissionItem.getId(), team.getId(), List.of(pdf("발표자료.pdf")), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(SUBMISSION_ALREADY_EXISTS.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 허용되지 않는 확장자를 제출하면 예외가 발생한다.")
+    void 허용되지_않는_확장자_예외() {
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), submissionItem.getId(), team.getId(), List.of(pdf("악성코드.exe")), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(INVALID_SUBMISSION_FILE_FORMAT.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 최대 파일 수를 초과하면 예외가 발생한다.")
+    void 파일_수_초과_예외() {
+        final ContestSubmissionItem limitedItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItemWithMaxFileCount(contest, 1));
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), limitedItem.getId(), team.getId(),
+                List.of(pdf("a.pdf"), pdf("b.pdf")), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(SUBMISSION_FILE_COUNT_EXCEEDED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 최대 파일 크기를 초과하면 예외가 발생한다.")
+    void 파일_크기_초과_예외() {
+        final ContestSubmissionItem smallItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItemWithMaxFileSizeMb(contest, 1));
+        final MockMultipartFile bigFile = new MockMultipartFile(
+                "files", "big.pdf", "application/pdf", new byte[2 * 1024 * 1024]);
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), smallItem.getId(), team.getId(), List.of(bigFile), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(SUBMISSION_FILE_SIZE_EXCEEDED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 마감 후 지각 제출이 허용되지 않으면 예외가 발생한다.")
+    void 마감_후_지각_불가_예외() {
+        final ContestSubmissionItem closedItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItemWithDeadline(
+                        contest, LocalDateTime.now().minusDays(1), false));
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), closedItem.getId(), team.getId(), List.of(pdf("발표자료.pdf")), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(SUBMISSION_PERIOD_ENDED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 해당 팀 소속이 아닌 학생은 제출할 수 없다.")
+    void 비소속_학생_제출_예외() {
+        final Member other = memberRepository.save(MemberFixture.createMemberWithUniqueNum(2));
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), submissionItem.getId(), team.getId(), List.of(pdf("발표자료.pdf")), other))
+                .isInstanceOf(TeamMemberException.class)
+                .hasMessage(TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 기존 제출에 파일을 추가하면 기존 fileOrder 다음 번호로 저장된다.")
+    void 파일을_추가한다() {
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
+        saveFileDocument(submission.getId(), 1, "기존1.pdf");
+        saveFileDocument(submission.getId(), 2, "기존2.pdf");
+
+        contestSubmissionCommandService.addFiles(
+                contest.getId(), submission.getId(), List.of(pdf("추가.pdf")), member);
+
+        verify(fileDocumentCommandService).storeDocumentFile(any(), eq(submission.getId()), eq(3));
+    }
+
+    @Test
+    @DisplayName("[실패] 기존 파일을 포함해 최대 파일 수를 초과하면 파일 추가는 실패한다.")
+    void 파일_추가_시_총_개수_초과_예외() {
+        final ContestSubmissionItem limitedItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItemWithMaxFileCount(contest, 2));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), limitedItem));
+        saveFileDocument(submission.getId(), 1, "기존1.pdf");
+        saveFileDocument(submission.getId(), 2, "기존2.pdf");
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.addFiles(
+                contest.getId(), submission.getId(), List.of(pdf("추가.pdf")), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(SUBMISSION_FILE_COUNT_EXCEEDED.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 파일이 여러 개일 때 한 건을 삭제하면 제출은 유지된다.")
+    void 파일_한_건을_삭제한다() {
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
+        final FileDocument target = saveFileDocument(submission.getId(), 1, "삭제대상.pdf");
+        saveFileDocument(submission.getId(), 2, "유지.pdf");
+
+        contestSubmissionCommandService.deleteFile(contest.getId(), submission.getId(), target.getId(), member);
+
+        verify(fileDocumentCommandService).deleteDocumentFile(target.getId());
+        assertThat(contestSubmissionRepository.findById(submission.getId())).isPresent();
+    }
+
+    @Test
+    @DisplayName("[성공] 마지막 파일을 삭제하면 제출 자체가 취소된다.")
+    void 마지막_파일_삭제_시_제출_취소() {
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
+        final FileDocument target = saveFileDocument(submission.getId(), 1, "마지막.pdf");
+
+        contestSubmissionCommandService.deleteFile(contest.getId(), submission.getId(), target.getId(), member);
+
+        verify(fileDocumentCommandService).deleteDocumentFile(target.getId());
+        assertThat(contestSubmissionRepository.findById(submission.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] 제출에 속하지 않는 파일을 삭제하면 예외가 발생한다.")
+    void 존재하지_않는_파일_삭제_예외() {
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
+        saveFileDocument(submission.getId(), 1, "유일.pdf");
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.deleteFile(
+                contest.getId(), submission.getId(), 99999L, member))
+                .isInstanceOf(FileException.class)
+                .hasMessage(FileExceptionType.NOT_FOUND.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
@@ -7,9 +7,8 @@ import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMI
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.opus.opus.contest.ContestFixture;
@@ -112,8 +111,8 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
 
         assertThat(response.submissionId()).isNotNull();
         assertThat(contestSubmissionRepository.findById(response.submissionId())).isPresent();
-        verify(fileDocumentCommandService, times(2))
-                .storeDocumentFile(any(), eq(response.submissionId()), any());
+        verify(fileDocumentCommandService)
+                .storeDocumentFiles(eq(response.submissionId()), anyList());
     }
 
     @Test
@@ -188,7 +187,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[성공] 기존 제출에 파일을 추가하면 기존 fileOrder 다음 번호로 저장된다.")
+    @DisplayName("[성공] 기존 제출에 파일을 추가하면 파일 저장을 위임한다.")
     void 파일을_추가한다() {
         final ContestSubmission submission = contestSubmissionRepository.save(
                 ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
@@ -198,7 +197,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
         contestSubmissionCommandService.addFiles(
                 contest.getId(), submission.getId(), List.of(pdf("추가.pdf")), member);
 
-        verify(fileDocumentCommandService).storeDocumentFile(any(), eq(submission.getId()), eq(3));
+        verify(fileDocumentCommandService).storeDocumentFiles(eq(submission.getId()), anyList());
     }
 
     @Test

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
@@ -234,7 +234,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
         final FileDocument target = saveFileDocument(submission.getId(), 1, "삭제대상.pdf");
         saveFileDocument(submission.getId(), 2, "유지.pdf");
 
-        contestSubmissionCommandService.deleteFile(contest.getId(), submission.getId(), target.getId(), member);
+        contestSubmissionCommandService.deleteSubmissionFile(contest.getId(), submission.getId(), target.getId(), member);
 
         verify(fileDocumentCommandService).deleteDocumentFile(target.getId());
         assertThat(contestSubmissionRepository.findById(submission.getId())).isPresent();
@@ -247,7 +247,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
                 ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
         final FileDocument target = saveFileDocument(submission.getId(), 1, "마지막.pdf");
 
-        contestSubmissionCommandService.deleteFile(contest.getId(), submission.getId(), target.getId(), member);
+        contestSubmissionCommandService.deleteSubmissionFile(contest.getId(), submission.getId(), target.getId(), member);
 
         verify(fileDocumentCommandService).deleteDocumentFile(target.getId());
         assertThat(contestSubmissionRepository.findById(submission.getId())).isEmpty();
@@ -260,7 +260,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
                 ContestSubmissionFixture.createSubmission(team.getId(), submissionItem));
         saveFileDocument(submission.getId(), 1, "유일.pdf");
 
-        assertThatThrownBy(() -> contestSubmissionCommandService.deleteFile(
+        assertThatThrownBy(() -> contestSubmissionCommandService.deleteSubmissionFile(
                 contest.getId(), submission.getId(), 99999L, member))
                 .isInstanceOf(FileException.class)
                 .hasMessage(FileExceptionType.NOT_FOUND.errorMessage());

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
@@ -3,6 +3,7 @@ package com.opus.opus.contest.application;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_REQUIRED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_SIZE_EXCEEDED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_PERIOD_ENDED;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -103,7 +104,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
 
     @Test
     @DisplayName("[성공] 팀원이 제출 항목에 파일을 제출하면 제출이 생성된다.")
-    void 제출을_생성한다() {
+    void 팀원이_파일을_제출하면_제출이_생성된다() {
         final List<MockMultipartFile> files = List.of(pdf("발표자료.pdf"), pdf("데모영상.pdf"));
 
         final SubmissionCreateResponse response = contestSubmissionCommandService.createSubmission(
@@ -124,6 +125,15 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
                 contest.getId(), submissionItem.getId(), team.getId(), List.of(pdf("발표자료.pdf")), member))
                 .isInstanceOf(ContestException.class)
                 .hasMessage(SUBMISSION_ALREADY_EXISTS.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 파일 없이 제출하면 예외가 발생한다.")
+    void 파일_없이_제출하면_예외() {
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), submissionItem.getId(), team.getId(), List.of(), member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(SUBMISSION_FILE_REQUIRED.errorMessage());
     }
 
     @Test
@@ -194,7 +204,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
         saveFileDocument(submission.getId(), 1, "기존1.pdf");
         saveFileDocument(submission.getId(), 2, "기존2.pdf");
 
-        contestSubmissionCommandService.addFiles(
+        contestSubmissionCommandService.addSubmissionFiles(
                 contest.getId(), submission.getId(), List.of(pdf("추가.pdf")), member);
 
         verify(fileDocumentCommandService).storeDocumentFiles(eq(submission.getId()), anyList());
@@ -210,7 +220,7 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
         saveFileDocument(submission.getId(), 1, "기존1.pdf");
         saveFileDocument(submission.getId(), 2, "기존2.pdf");
 
-        assertThatThrownBy(() -> contestSubmissionCommandService.addFiles(
+        assertThatThrownBy(() -> contestSubmissionCommandService.addSubmissionFiles(
                 contest.getId(), submission.getId(), List.of(pdf("추가.pdf")), member))
                 .isInstanceOf(ContestException.class)
                 .hasMessage(SUBMISSION_FILE_COUNT_EXCEEDED.errorMessage());

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionQueryServiceTest.java
@@ -1,0 +1,152 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.contest.ContestSubmissionFixture;
+import com.opus.opus.contest.ContestSubmissionItemFixture;
+import com.opus.opus.contest.ContestTrackFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.contest.application.ContestSubmissionQueryService;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.SubmissionStatus;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.file.domain.File;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import com.opus.opus.modules.team.exception.TeamMemberExceptionType;
+import com.opus.opus.team.TeamFixture;
+import java.time.LocalDateTime;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContestSubmissionQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestSubmissionQueryService contestSubmissionQueryService;
+
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private ContestTrackRepository contestTrackRepository;
+    @Autowired
+    private ContestSubmissionItemRepository contestSubmissionItemRepository;
+    @Autowired
+    private ContestSubmissionRepository contestSubmissionRepository;
+    @Autowired
+    private FileDocumentRepository fileDocumentRepository;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
+
+    private Contest contest;
+    private Team team;
+    private Member member;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContest());
+        team = teamRepository.save(TeamFixture.createTeamWithContestId(contest.getId()));
+        member = memberRepository.save(MemberFixture.createMember());
+    }
+
+    private void joinTeam(final Member loginMember, final Team joinTeam) {
+        teamMemberRepository.save(TeamMember.builder()
+                .memberId(loginMember.getId())
+                .team(joinTeam)
+                .roles(Set.of(TeamMemberRoleType.ROLE_팀장))
+                .build());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀원이 제출물 상세를 조회하면 기본 정보와 파일 목록을 반환한다.")
+    void 제출물_상세를_조회한다() {
+        joinTeam(member, team);
+        final ContestTrack track = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest, track));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), item));
+        final File file = File.create("발표자료.pdf", "files/2026-06-24/a.pdf", "application/pdf", 1048576L);
+        fileDocumentRepository.save(FileDocument.builder()
+                .file(file).submissionId(submission.getId()).fileOrder(1).build());
+
+        final ContestSubmissionDetailResponse response = contestSubmissionQueryService.getSubmissionDetail(
+                contest.getId(), submission.getId(), member);
+
+        assertThat(response.submissionId()).isEqualTo(submission.getId());
+        assertThat(response.teamId()).isEqualTo(team.getId());
+        assertThat(response.teamName()).isEqualTo(team.getTeamName());
+        assertThat(response.trackName()).isEqualTo(track.getTrackName());
+        assertThat(response.submissionTypeName()).isEqualTo(item.getName());
+        assertThat(response.status()).isEqualTo(SubmissionStatus.SUBMITTED);
+        assertThat(response.commentCount()).isZero();
+        assertThat(response.files()).hasSize(1);
+        assertThat(response.files().get(0).fileName()).isEqualTo("발표자료.pdf");
+        assertThat(response.files().get(0).fileSize()).isEqualTo(1048576L);
+    }
+
+    @Test
+    @DisplayName("[성공] 마감 이후에 최초 제출된 제출물의 상태는 LATE이다.")
+    void 마감_이후_제출물의_상태는_LATE이다() {
+        joinTeam(member, team);
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItemWithDeadline(
+                        contest, LocalDateTime.now().minusDays(2), true));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmissionWithFirstSubmittedAt(
+                        team.getId(), item, LocalDateTime.now().minusDays(1)));
+
+        final ContestSubmissionDetailResponse response = contestSubmissionQueryService.getSubmissionDetail(
+                contest.getId(), submission.getId(), member);
+
+        assertThat(response.status()).isEqualTo(SubmissionStatus.LATE);
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출물을 조회하면 예외가 발생한다.")
+    void 존재하지_않는_제출물_조회_예외() {
+        assertThatThrownBy(() -> contestSubmissionQueryService.getSubmissionDetail(contest.getId(), 99999L, member))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 해당 팀 소속이 아닌 학생은 제출물 상세를 조회할 수 없다.")
+    void 비소속_학생_상세_조회_예외() {
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), item));
+
+        assertThatThrownBy(() -> contestSubmissionQueryService.getSubmissionDetail(
+                contest.getId(), submission.getId(), member))
+                .isInstanceOf(TeamMemberException.class)
+                .hasMessage(TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/file/application/FileDocumentCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/file/application/FileDocumentCommandServiceTest.java
@@ -1,0 +1,51 @@
+package com.opus.opus.file.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.opus.opus.helper.FileModuleIntegrationTest;
+import com.opus.opus.modules.file.application.FileDocumentCommandService;
+import com.opus.opus.modules.file.domain.FileDocument;
+import com.opus.opus.modules.file.domain.dao.FileDocumentRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.mock.web.MockMultipartFile;
+
+public class FileDocumentCommandServiceTest extends FileModuleIntegrationTest {
+
+    @Autowired
+    private FileDocumentCommandService fileDocumentCommandService;
+
+    @Autowired
+    private FileDocumentRepository fileDocumentRepository;
+
+    private MockMultipartFile pdf(final String name) {
+        return new MockMultipartFile("files", name, "application/pdf", "content".getBytes());
+    }
+
+    @Test
+    @DisplayName("[성공] 기존 파일이 없으면 fileOrder가 1부터 순서대로 저장된다.")
+    void 기존_파일이_없으면_1부터_저장된다() {
+        final Long submissionId = 100L;
+
+        fileDocumentCommandService.storeDocumentFiles(submissionId, List.of(pdf("a.pdf"), pdf("b.pdf")));
+
+        assertThat(fileDocumentRepository.findAllBySubmissionIdOrderByFileOrder(submissionId))
+                .extracting(FileDocument::getFileOrder)
+                .containsExactly(1, 2);
+    }
+
+    @Test
+    @DisplayName("[성공] 기존 파일이 있으면 마지막 fileOrder 다음 번호부터 저장된다.")
+    void 기존_파일_다음_번호부터_저장된다() {
+        final Long submissionId = 200L;
+        fileDocumentCommandService.storeDocumentFiles(submissionId, List.of(pdf("a.pdf"), pdf("b.pdf")));
+
+        fileDocumentCommandService.storeDocumentFiles(submissionId, List.of(pdf("c.pdf")));
+
+        assertThat(fileDocumentRepository.findAllBySubmissionIdOrderByFileOrder(submissionId))
+                .extracting(FileDocument::getFileOrder)
+                .containsExactly(1, 2, 3);
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -16,6 +16,7 @@ import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
+import com.opus.opus.modules.contest.application.ContestSubmissionQueryService;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackQueryService;
 import com.opus.opus.modules.member.api.MemberController;
@@ -111,6 +112,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected ContestSubmissionCommandService contestSubmissionCommandService;
+
+    @MockitoBean
+    protected ContestSubmissionQueryService contestSubmissionQueryService;
 
     @MockitoBean
     protected ContestCategoryCommandService contestCategoryCommandService;

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -15,6 +15,7 @@ import com.opus.opus.modules.contest.application.ContestCategoryCommandService;
 import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
 import com.opus.opus.modules.contest.application.ContestCommandService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
+import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackQueryService;
 import com.opus.opus.modules.member.api.MemberController;
@@ -107,6 +108,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected ContestQueryService contestQueryService;
+
+    @MockitoBean
+    protected ContestSubmissionCommandService contestSubmissionCommandService;
 
     @MockitoBean
     protected ContestCategoryCommandService contestCategoryCommandService;

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
@@ -938,7 +938,7 @@ public class ContestApiDocsTest extends RestDocsTest {
                 0
         );
 
-        when(contestQueryService.getSubmissionDetail(any(), any(), any())).thenReturn(response);
+        when(contestSubmissionQueryService.getSubmissionDetail(any(), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/contests/{contestId}/submissions/{submissionId}", 1L, 12L)
                         .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
@@ -978,7 +978,7 @@ public class ContestApiDocsTest extends RestDocsTest {
         loginMember();
 
         willThrow(new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION))
-                .given(contestQueryService)
+                .given(contestSubmissionQueryService)
                 .getSubmissionDetail(any(), any(), any());
 
         mockMvc.perform(get("/contests/{contestId}/submissions/{submissionId}", 1L, 999L)

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
@@ -34,6 +34,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.response
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.partWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParts;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -54,8 +55,11 @@ import com.opus.opus.modules.contest.application.dto.response.TeamBulkErrorRespo
 import com.opus.opus.modules.contest.application.dto.response.TeamBulkUploadResponse;
 import com.opus.opus.modules.contest.application.dto.response.TeamBulkUploadResponse.TeamBulkResult;
 import com.opus.opus.modules.contest.application.dto.response.ContestSortResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestTemplateResponse;
+import com.opus.opus.modules.contest.application.dto.response.SubmissionCreateResponse;
+import com.opus.opus.modules.contest.domain.SubmissionStatus;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteLogResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVoteStatisticsResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestVotesLimitResponse;
@@ -908,6 +912,175 @@ public class ContestApiDocsTest extends RestDocsTest {
                 .andDo(document("get-team-submissions-fail-not-found",
                         pathParameters(
                                 parameterWithName("contestId").description("존재하지 않는 대회 ID")
+                        )
+                ));
+    }
+
+    private void loginMember() {
+        when(memberArgumentResolver.supportsParameter(any())).thenReturn(true);
+        when(memberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(member);
+    }
+
+    @Test
+    @DisplayName("[성공] 제출물 상세를 조회한다.")
+    void 제출물_상세를_조회한다() throws Exception {
+        loginMember();
+        final ContestSubmissionDetailResponse response = new ContestSubmissionDetailResponse(
+                12L, 3L, "오퍼스", "교내 성과 관리 플랫폼", "AI/데이터", "최종 발표 자료",
+                SubmissionStatus.SUBMITTED,
+                LocalDateTime.of(2026, 6, 5, 23, 59, 59),
+                LocalDateTime.of(2026, 6, 1, 10, 12, 33),
+                LocalDateTime.of(2026, 6, 3, 22, 1, 0),
+                List.of(
+                        new ContestSubmissionDetailResponse.FileResponse(101L, "발표자료.pdf", 1048576L),
+                        new ContestSubmissionDetailResponse.FileResponse(102L, "데모영상.mp4", 20971520L)
+                ),
+                0
+        );
+
+        when(contestQueryService.getSubmissionDetail(any(), any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/contests/{contestId}/submissions/{submissionId}", 1L, 12L)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("get-submission-detail",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionId").description("제출 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "member"))
+                        ),
+                        responseFields(
+                                numberFieldWithPath("submissionId", "제출 ID"),
+                                numberFieldWithPath("teamId", "팀 ID"),
+                                stringFieldWithPath("teamName", "팀 이름"),
+                                stringFieldWithPath("projectOverview", "프로젝트 설명"),
+                                stringFieldWithPath("trackName", "분과명 (분과 미지정 시 null)"),
+                                stringFieldWithPath("submissionTypeName", "제출물 종류명"),
+                                stringFieldWithPath("status", "제출 상태(계산값) - 단건 조회에서는 SUBMITTED / LATE"),
+                                dateTimeFieldWithPath("deadlineAt", "제출 마감일시"),
+                                dateTimeFieldWithPath("firstSubmittedAt", "최초 제출일시"),
+                                dateTimeFieldWithPath("lastModifiedAt", "마지막 수정일시"),
+                                arrayFieldWithPath("files[]", "업로드된 파일 목록"),
+                                numberFieldWithPath("files[].fileId", "파일 ID"),
+                                stringFieldWithPath("files[].fileName", "파일명"),
+                                numberFieldWithPath("files[].fileSize", "파일 용량 (byte)"),
+                                numberFieldWithPath("commentCount", "코멘트 개수 (코멘트 기능 추가 전까지 항상 0)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출물 상세 조회 시 404 에러를 반환한다.")
+    void 존재하지_않는_제출물_상세_조회_시_에러를_반환한다() throws Exception {
+        loginMember();
+
+        willThrow(new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION))
+                .given(contestQueryService)
+                .getSubmissionDetail(any(), any(), any());
+
+        mockMvc.perform(get("/contests/{contestId}/submissions/{submissionId}", 1L, 999L)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("get-submission-detail-fail-not-found",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionId").description("존재하지 않는 제출 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "member"))
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 항목에 파일을 제출한다.")
+    void 제출_항목에_파일을_제출한다() throws Exception {
+        loginMember();
+        final MockMultipartFile file = new MockMultipartFile(
+                "files", "발표자료.pdf", "application/pdf", "file-content".getBytes());
+
+        when(contestSubmissionCommandService.createSubmission(any(), any(), any(), any(), any()))
+                .thenReturn(new SubmissionCreateResponse(12L));
+
+        mockMvc.perform(multipart("/contests/{contestId}/submission-items/{submissionItemId}/submissions", 1L, 10L)
+                        .file(file)
+                        .queryParam("teamId", "3")
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andDo(document("create-submission",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionItemId").description("제출 항목 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "member"))
+                        ),
+                        queryParameters(
+                                parameterWithName("teamId").description("제출하는 팀 ID")
+                        ),
+                        requestParts(
+                                partWithName("files").description("업로드할 파일 목록 (여러 개 가능)")
+                        ),
+                        responseFields(
+                                numberFieldWithPath("submissionId", "생성된 제출 ID")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 기존 제출물에 파일을 추가한다.")
+    void 기존_제출물에_파일을_추가한다() throws Exception {
+        loginMember();
+        final MockMultipartFile file = new MockMultipartFile(
+                "files", "추가자료.pdf", "application/pdf", "file-content".getBytes());
+
+        doNothing().when(contestSubmissionCommandService).addFiles(any(), any(), any(), any());
+
+        mockMvc.perform(multipart("/contests/{contestId}/submissions/{submissionId}/files", 1L, 12L)
+                        .file(file)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN)
+                        .contentType(MediaType.MULTIPART_FORM_DATA))
+                .andExpect(status().isCreated())
+                .andDo(document("add-submission-files",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionId").description("제출 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "member"))
+                        ),
+                        requestParts(
+                                partWithName("files").description("추가할 파일 목록 (기존 파일 포함 maxFileCount 이내)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 제출물의 파일 한 건을 삭제한다.")
+    void 제출물의_파일_한_건을_삭제한다() throws Exception {
+        loginMember();
+
+        doNothing().when(contestSubmissionCommandService).deleteFile(any(), any(), any(), any());
+
+        mockMvc.perform(delete("/contests/{contestId}/submissions/{submissionId}/files/{fileId}", 1L, 12L, 101L)
+                        .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-submission-file",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionId").description("제출 ID"),
+                                parameterWithName("fileId").description("삭제할 파일 ID (FileDocument ID)")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description(
+                                        String.format(authorizationHeaderDescription, "member"))
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
@@ -1040,7 +1040,7 @@ public class ContestApiDocsTest extends RestDocsTest {
         final MockMultipartFile file = new MockMultipartFile(
                 "files", "추가자료.pdf", "application/pdf", "file-content".getBytes());
 
-        doNothing().when(contestSubmissionCommandService).addFiles(any(), any(), any(), any());
+        doNothing().when(contestSubmissionCommandService).addSubmissionFiles(any(), any(), any(), any());
 
         mockMvc.perform(multipart("/contests/{contestId}/submissions/{submissionId}/files", 1L, 12L)
                         .file(file)

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
@@ -1067,7 +1067,7 @@ public class ContestApiDocsTest extends RestDocsTest {
     void 제출물의_파일_한_건을_삭제한다() throws Exception {
         loginMember();
 
-        doNothing().when(contestSubmissionCommandService).deleteFile(any(), any(), any(), any());
+        doNothing().when(contestSubmissionCommandService).deleteSubmissionFile(any(), any(), any(), any());
 
         mockMvc.perform(delete("/contests/{contestId}/submissions/{submissionId}/files/{fileId}", 1L, 12L, 101L)
                         .header(HttpHeaders.AUTHORIZATION, MEMBER_TOKEN))


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #160 

## 📜 작업 내용

- 제출물 상세 조회 / 제출 / 파일 추가·삭제 기능을 개발했습니다.
- **제출물 상세 조회** : 특정 제출물 한 건의 상세 정보를 조회합니다.
  - 응답 : 기본 정보(id, 팀 id, 팀 이름, 프로젝트 설명, 분과명, 제출물 종류명, 제출 상태, 제출 마감 일시, 최초 제출과 마지막 수정 일시, 코멘트 개수)와 업로드된 파일 목록(id, 파일명, 용량)
  - 권한: `ROLE_학생`은 해당 팀 소속만, 그 외 역할(관리자/교수/직원/외부멘토)은 제한 없음
- **제출물 제출** : 특정 제출 항목에 대해 `multipart/form-data`로 여러 파일을 한 번에 제출하여 제출물을 생성합니다.
  - 한 팀이 동일한 제출 항목에 대해 중복 제출할 수 없습니다.
  - 파일을 추가하려면 “제출 파일 추가” API 사용해야 합니다.
  - 파일 수 제한(maxFileCount)을 초과할 수 없습니다.
  - 추가할 파일의 확장자는 submissionItem.allowedFileFormats 목록에 포함되어야 합니다.
  - 현재 시각이 endAt 이후이고 allowLateSubmission = false이면 제출이 거부됩니다.
  - 현재 시각이 endAt 이후이고 allowLateSubmission = true이면 제출이 허용됩니다.
- **제출 파일 첨부** : 이미 제출된 제출물에 파일을 추가합니다.
  - 파일 수 제한(`maxFileCount`)을 초과할 수 없습니다.
  - 추가할 파일의 확장자는 `submissionItem.allowedFileFormats` 목록에 포함되어야 합니다.
  - 현재 시각이 `endAt` 이후이고 `allowLateSubmission = false`이면 파일 추가가 거부됩니다.
  - 현재 시각이 `endAt` 이후이고 `allowLateSubmission = true`이면 파일 추가가 허용됩니다.
- **제출 파일 삭제** : 제출물에 첨부된 파일 한 건을 삭제합니다.
  - 마지막 남은 파일을 삭제하면 제출 자체가 취소됩니다.
  - 현재 시각이 `endAt` 이후이고 `allowLateSubmission = false`이면 파일 삭제가 거부됩니다.
  - 현재 시각이 `endAt` 이후이고 `allowLateSubmission = true`이면 파일 삭제가 허용됩니다.

## 💬 리뷰 요구사항

- `status` 계산값: 제출한 제출물만 조회되기 때문에, `SUBMITTED`/`LATE`만 반환됩니다. enum에는 `NOT_SUBMITTED`/`NOT_SUBMITTED_AFTER_DEADLINE`도 정의해 뒀습니다.
- 제출물 제출의 `teamId` 전달 방식
  - `teamId`는 `@RequestParam Long teamId` 로 받습니다. REST Docs는 query parameter로 문서화했습니다.
  - `POST .../submission-items/{submissionItemId}/submissions?teamId=3` + `files`는 multipart


## ✨ 기타

- `commentCount` 0 고정: 제출물 단위 코멘트 기능이 없어 0으로 고정시켜두었습니다. 추후 제출물 코멘트 기능이 개발되면 수정이 필요합니다.
