### PR TITLE
fix: 마이페이지 403 버그 해결 (#162)

### DIFF
--- a/src/main/java/com/opus/opus/global/security/SecurityConfig.java
+++ b/src/main/java/com/opus/opus/global/security/SecurityConfig.java
@@ -54,7 +54,7 @@ public class SecurityConfig {
                         .requestMatchers("/sign-up/**", "/sign-in/**", "/oauth2/set-redirect").permitAll()
                         .requestMatchers(HttpMethod.GET, "/teams/**", "/contests/**", "/notices/**", "/statistics/**"
                                 , "/categories/**", "/sidebar").permitAll()
-                        .anyRequest().hasAnyRole("회원", "관리자", "팀장", "팀원")
+                        .anyRequest().hasAnyRole("학생", "관리자", "교수", "직원", "외부멘토")
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(authorization -> authorization


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #162

## 📜 작업 내용

- 로그인 후 마이페이지 GET 요청 시 403이 발생하는 버그를 해결했습니다.
- 원인은 PR #149(`회원`→`학생` role 일괄 변경)에서 `SecurityConfig`의 전역 인가 규칙이 누락된 것이었습니다.
  - `@Secured("ROLE_회원")` 패턴은 일괄 치환에 걸렸지만, `hasAnyRole("회원")`은 `ROLE_` 접두어가 없어 빠졌습니다.
- 전역 규칙의 role 이름을 현재 enum 기준으로 수정했습니다.

```
- .anyRequest().hasAnyRole("회원", "관리자", "팀장", "팀원")
+ .anyRequest().hasAnyRole("학생", "관리자", "교수", "직원", "외부멘토")
```

- `팀장`/`팀원`은 `TeamMemberRoleType`이라 JWT 권한에 포함되지 않아 제거했습니다.

## 💬 리뷰 요구사항

- 동일 유형(권한 문자열 불일치)으로 코드 전체를 확인했고, 해당 누락은 이 한 곳이 유일했습니다.

## ✨ 기타

- 감사합니다!