### PR TITLE
Feature/#174 제출 항목 관련 api 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
@@ -48,3 +48,22 @@ include::{snippets}/create-submission-item-fail/http-response.adoc[]
 include::{snippets}/create-submission-item-fail/request-fields.adoc[]
 
 ====
+
+== `PATCH`: 제출 항목 수정
+
+저장된 제출 항목 설정을 수정하는 API입니다. (권한: 관리자)
+
+.HTTP Request Headers
+include::{snippets}/update-submission-item/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/update-submission-item/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/update-submission-item/http-request.adoc[]
+
+.Request Fields
+include::{snippets}/update-submission-item/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/update-submission-item/http-response.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
@@ -84,6 +84,28 @@ include::{snippets}/delete-submission-item/http-request.adoc[]
 .HTTP Response
 include::{snippets}/delete-submission-item/http-response.adoc[]
 
+== `GET`: 제출 항목 목록 조회
+
+제출 항목 목록을 조회하는 API입니다. 제출물이 설정된(수정) 기준 최신 순서대로 정렬합니다.
+
+.HTTP Request Headers
+include::{snippets}/get-submission-items/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/get-submission-items/path-parameters.adoc[]
+
+.Query Parameters
+include::{snippets}/get-submission-items/query-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/get-submission-items/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-submission-items/http-response.adoc[]
+
+.Response Fields
+include::{snippets}/get-submission-items/response-fields.adoc[]
+
 == `GET`: 제출 항목 설정값 조회
 
 제출 항목 수정을 위해 저장된 설정값을 조회하는 API입니다.

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
@@ -1,0 +1,50 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= CONTEST SUBMISSION ITEM API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:./opus.html[API 목록으로 돌아가기]
+
+== `POST`: 제출 항목 추가
+
+제출물을 낼 수 있는 설정을 추가하는 API입니다. (권한: 관리자)
+
+.HTTP Request Headers
+include::{snippets}/create-submission-item/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/create-submission-item/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/create-submission-item/http-request.adoc[]
+
+.Request Fields
+include::{snippets}/create-submission-item/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/create-submission-item/http-response.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 시작일시가 마감일시보다 이후
+
+[%collapsible]
+
+====
+
+include::{snippets}/create-submission-item-fail/http-request.adoc[]
+
+include::{snippets}/create-submission-item-fail/http-response.adoc[]
+
+include::{snippets}/create-submission-item-fail/request-fields.adoc[]
+
+====

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
@@ -16,7 +16,7 @@ link:./opus.html[API 목록으로 돌아가기]
 
 == `POST`: 제출 항목 추가
 
-제출물을 낼 수 있는 설정을 추가하는 API입니다. (권한: 관리자)
+제출물을 낼 수 있는 설정을 추가하는 API입니다.
 
 .HTTP Request Headers
 include::{snippets}/create-submission-item/request-headers.adoc[]
@@ -51,7 +51,7 @@ include::{snippets}/create-submission-item-fail/request-fields.adoc[]
 
 == `PATCH`: 제출 항목 수정
 
-저장된 제출 항목 설정을 수정하는 API입니다. (권한: 관리자)
+저장된 제출 항목 설정을 수정하는 API입니다.
 
 .HTTP Request Headers
 include::{snippets}/update-submission-item/request-headers.adoc[]
@@ -67,3 +67,19 @@ include::{snippets}/update-submission-item/request-fields.adoc[]
 
 .HTTP Response
 include::{snippets}/update-submission-item/http-response.adoc[]
+
+== `DELETE`: 제출 항목 삭제
+
+저장된 제출 항목을 삭제하는 API입니다.
+
+.HTTP Request Headers
+include::{snippets}/delete-submission-item/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-submission-item/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/delete-submission-item/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-submission-item/http-response.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-submission-item.adoc
@@ -83,3 +83,22 @@ include::{snippets}/delete-submission-item/http-request.adoc[]
 
 .HTTP Response
 include::{snippets}/delete-submission-item/http-response.adoc[]
+
+== `GET`: 제출 항목 설정값 조회
+
+제출 항목 수정을 위해 저장된 설정값을 조회하는 API입니다.
+
+.HTTP Request Headers
+include::{snippets}/get-submission-item/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/get-submission-item/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/get-submission-item/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-submission-item/http-response.adoc[]
+
+.Response Fields
+include::{snippets}/get-submission-item/response-fields.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -39,3 +39,5 @@ link:./contest-member.html[대회 배정(교수/외부멘토) API]
 
 link:./submission-feedback.html[제출물 피드백 API]
 link:./submission.html[제출물 API]
+
+link:./contest-submission-item.html[대회 제출 항목 API]

--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -38,6 +38,7 @@ link:./contest-track.html[대회 분과 API]
 link:./contest-member.html[대회 배정(교수/외부멘토) API]
 
 link:./submission-feedback.html[제출물 피드백 API]
+
 link:./submission.html[제출물 API]
 
 link:./contest-submission-item.html[대회 제출 항목 API]

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
@@ -1,7 +1,9 @@
 package com.opus.opus.modules.contest.api;
 
 import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
+import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -9,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -23,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContestSubmissionItemController {
 
     private final ContestSubmissionItemCommandService contestSubmissionItemCommandService;
+    private final ContestSubmissionItemQueryService contestSubmissionItemQueryService;
 
     @Secured("ROLE_관리자")
     @PostMapping
@@ -47,5 +51,12 @@ public class ContestSubmissionItemController {
                                                      @PathVariable final Long submissionItemId) {
         contestSubmissionItemCommandService.deleteSubmissionItem(contestId, submissionItemId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @GetMapping("/{submissionItemId}")
+    public ResponseEntity<ContestSubmissionItemResponse> getSubmissionItem(@PathVariable final Long contestId,
+                                                                           @PathVariable final Long submissionItemId) {
+        return ResponseEntity.ok(contestSubmissionItemQueryService.getSubmissionItem(contestId, submissionItemId));
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
@@ -1,0 +1,32 @@
+package com.opus.opus.modules.contest.api;
+
+import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
+import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/contests/{contestId}/submission-items")
+public class ContestSubmissionItemController {
+
+    private final ContestSubmissionItemCommandService contestSubmissionItemCommandService;
+
+    @Secured("ROLE_관리자")
+    @PostMapping
+    public ResponseEntity<Void> createSubmissionItem(@Valid @RequestBody final ContestSubmissionItemRequest request,
+                                                     @PathVariable final Long contestId) {
+        contestSubmissionItemCommandService.createSubmissionItem(contestId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
@@ -1,9 +1,11 @@
 package com.opus.opus.modules.contest.api;
 
+import com.opus.opus.global.security.annotation.LoginMember;
 import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
 import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.member.domain.Member;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -53,10 +55,12 @@ public class ContestSubmissionItemController {
         return ResponseEntity.noContent().build();
     }
 
-    @Secured("ROLE_관리자")
+    @Secured({"ROLE_관리자", "ROLE_학생"})
     @GetMapping("/{submissionItemId}")
     public ResponseEntity<ContestSubmissionItemResponse> getSubmissionItem(@PathVariable final Long contestId,
-                                                                           @PathVariable final Long submissionItemId) {
-        return ResponseEntity.ok(contestSubmissionItemQueryService.getSubmissionItem(contestId, submissionItemId));
+                                                                           @PathVariable final Long submissionItemId,
+                                                                           @LoginMember final Member member) {
+        return ResponseEntity.ok(
+                contestSubmissionItemQueryService.getSubmissionItem(contestId, submissionItemId, member));
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,5 +29,14 @@ public class ContestSubmissionItemController {
                                                      @PathVariable final Long contestId) {
         contestSubmissionItemCommandService.createSubmissionItem(contestId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Secured("ROLE_관리자")
+    @PatchMapping("/{submissionItemId}")
+    public ResponseEntity<Void> updateSubmissionItem(@Valid @RequestBody final ContestSubmissionItemRequest request,
+                                                     @PathVariable final Long contestId,
+                                                     @PathVariable final Long submissionItemId) {
+        contestSubmissionItemCommandService.updateSubmissionItem(contestId, submissionItemId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -37,6 +38,14 @@ public class ContestSubmissionItemController {
                                                      @PathVariable final Long contestId,
                                                      @PathVariable final Long submissionItemId) {
         contestSubmissionItemCommandService.updateSubmissionItem(contestId, submissionItemId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @DeleteMapping("/{submissionItemId}")
+    public ResponseEntity<Void> deleteSubmissionItem(@PathVariable final Long contestId,
+                                                     @PathVariable final Long submissionItemId) {
+        contestSubmissionItemCommandService.deleteSubmissionItem(contestId, submissionItemId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionItemController.java
@@ -5,8 +5,10 @@ import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandSer
 import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemSummaryResponse;
 import com.opus.opus.modules.member.domain.Member;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Validated
@@ -53,6 +56,13 @@ public class ContestSubmissionItemController {
                                                      @PathVariable final Long submissionItemId) {
         contestSubmissionItemCommandService.deleteSubmissionItem(contestId, submissionItemId);
         return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @GetMapping
+    public ResponseEntity<List<ContestSubmissionItemSummaryResponse>> getSubmissionItems(
+            @PathVariable final Long contestId, @RequestParam(required = false) final String status) {
+        return ResponseEntity.ok(contestSubmissionItemQueryService.getSubmissionItems(contestId, status));
     }
 
     @Secured({"ROLE_관리자", "ROLE_학생"})

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
@@ -10,6 +10,7 @@ import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
 import java.time.LocalDateTime;
 import java.util.HashSet;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ContestSubmissionItemCommandService {
 
     private final ContestSubmissionItemRepository contestSubmissionItemRepository;
+    private final ContestSubmissionRepository contestSubmissionRepository;
 
     private final ContestConvenience contestConvenience;
     private final ContestTrackConvenience contestTrackConvenience;
@@ -46,6 +48,14 @@ public class ContestSubmissionItemCommandService {
                 request.name(), request.description(), new HashSet<>(request.allowedFileFormats()),
                 request.maxFileSizeMb(), request.maxFileCount(), request.startAt(), request.endAt(),
                 request.allowLateSubmission(), request.visibility(), contestTrack);
+    }
+
+    public void deleteSubmissionItem(final Long contestId, final Long submissionItemId) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemConvenience.getValidateExistSubmissionItem(contestId, submissionItemId);
+        contestSubmissionRepository.deleteAllBySubmissionItemId(submissionItemId);
+        contestSubmissionItemRepository.delete(submissionItem);
     }
 
     private ContestTrack resolveContestTrack(final Long contestId, final Long contestTrackId) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
@@ -66,7 +66,7 @@ public class ContestSubmissionItemCommandService {
     }
 
     private void validateSubmissionPeriod(final LocalDateTime startAt, final LocalDateTime endAt) {
-        if (startAt.isAfter(endAt)) {
+        if (!endAt.isAfter(startAt)) {
             throw new ContestSubmissionItemException(INVALID_SUBMISSION_PERIOD);
         }
     }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
@@ -1,0 +1,65 @@
+package com.opus.opus.modules.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
+import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
+import java.time.LocalDateTime;
+import java.util.HashSet;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ContestSubmissionItemCommandService {
+
+    private final ContestSubmissionItemRepository contestSubmissionItemRepository;
+
+    private final ContestConvenience contestConvenience;
+    private final ContestTrackConvenience contestTrackConvenience;
+
+    public void createSubmissionItem(final Long contestId, final ContestSubmissionItemRequest request) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        final ContestTrack contestTrack = resolveContestTrack(contestId, request.contestTrackId());
+        validateSubmissionPeriod(request.startAt(), request.endAt());
+        contestSubmissionItemRepository.save(buildSubmissionItem(request, contest, contestTrack));
+    }
+
+    private ContestTrack resolveContestTrack(final Long contestId, final Long contestTrackId) {
+        if (contestTrackId == null) {
+            return null;
+        }
+        return contestTrackConvenience.getValidateExistTrack(contestId, contestTrackId);
+    }
+
+    private void validateSubmissionPeriod(final LocalDateTime startAt, final LocalDateTime endAt) {
+        if (startAt.isAfter(endAt)) {
+            throw new ContestSubmissionItemException(INVALID_SUBMISSION_PERIOD);
+        }
+    }
+
+    private ContestSubmissionItem buildSubmissionItem(final ContestSubmissionItemRequest request,
+                                                      final Contest contest, final ContestTrack contestTrack) {
+        return ContestSubmissionItem.builder()
+                .name(request.name())
+                .description(request.description())
+                .allowedFileFormats(new HashSet<>(request.allowedFileFormats()))
+                .maxFileSizeMb(request.maxFileSizeMb())
+                .maxFileCount(request.maxFileCount())
+                .startAt(request.startAt())
+                .endAt(request.endAt())
+                .allowLateSubmission(request.allowLateSubmission())
+                .visibility(request.visibility())
+                .contest(contest)
+                .contestTrack(contestTrack)
+                .build();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
@@ -9,11 +9,14 @@ import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionIt
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,7 +48,7 @@ public class ContestSubmissionItemCommandService {
         final ContestTrack contestTrack = resolveContestTrack(contestId, request.contestTrackId());
         validateSubmissionPeriod(request.startAt(), request.endAt());
         submissionItem.updateContestSubmissionItem(
-                request.name(), request.description(), new HashSet<>(request.allowedFileFormats()),
+                request.name(), request.description(), toAllowedFileFormats(request.allowedFileFormats()),
                 request.maxFileSizeMb(), request.maxFileCount(), request.startAt(), request.endAt(),
                 request.allowLateSubmission(), request.visibility(), contestTrack);
     }
@@ -76,7 +79,7 @@ public class ContestSubmissionItemCommandService {
         return ContestSubmissionItem.builder()
                 .name(request.name())
                 .description(request.description())
-                .allowedFileFormats(new HashSet<>(request.allowedFileFormats()))
+                .allowedFileFormats(toAllowedFileFormats(request.allowedFileFormats()))
                 .maxFileSizeMb(request.maxFileSizeMb())
                 .maxFileCount(request.maxFileCount())
                 .startAt(request.startAt())
@@ -86,5 +89,12 @@ public class ContestSubmissionItemCommandService {
                 .contest(contest)
                 .contestTrack(contestTrack)
                 .build();
+    }
+
+    private Set<SubmissionFileFormat> toAllowedFileFormats(final List<SubmissionFileFormat> allowedFileFormats) {
+        if (allowedFileFormats == null) {
+            return new HashSet<>();
+        }
+        return new HashSet<>(allowedFileFormats);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemCommandService.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.contest.application;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestSubmissionItemConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.domain.Contest;
@@ -25,12 +26,26 @@ public class ContestSubmissionItemCommandService {
 
     private final ContestConvenience contestConvenience;
     private final ContestTrackConvenience contestTrackConvenience;
+    private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
 
     public void createSubmissionItem(final Long contestId, final ContestSubmissionItemRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         final ContestTrack contestTrack = resolveContestTrack(contestId, request.contestTrackId());
         validateSubmissionPeriod(request.startAt(), request.endAt());
         contestSubmissionItemRepository.save(buildSubmissionItem(request, contest, contestTrack));
+    }
+
+    public void updateSubmissionItem(final Long contestId, final Long submissionItemId,
+                                     final ContestSubmissionItemRequest request) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemConvenience.getValidateExistSubmissionItem(contestId, submissionItemId);
+        final ContestTrack contestTrack = resolveContestTrack(contestId, request.contestTrackId());
+        validateSubmissionPeriod(request.startAt(), request.endAt());
+        submissionItem.updateContestSubmissionItem(
+                request.name(), request.description(), new HashSet<>(request.allowedFileFormats()),
+                request.maxFileSizeMb(), request.maxFileCount(), request.startAt(), request.endAt(),
+                request.allowLateSubmission(), request.visibility(), contestTrack);
     }
 
     private ContestTrack resolveContestTrack(final Long contestId, final Long contestTrackId) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemQueryService.java
@@ -1,0 +1,25 @@
+package com.opus.opus.modules.contest.application;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestSubmissionItemConvenience;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestSubmissionItemQueryService {
+
+    private final ContestConvenience contestConvenience;
+    private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
+
+    public ContestSubmissionItemResponse getSubmissionItem(final Long contestId, final Long submissionItemId) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemConvenience.getValidateExistSubmissionItem(contestId, submissionItemId);
+        return ContestSubmissionItemResponse.from(submissionItem);
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemQueryService.java
@@ -4,6 +4,8 @@ import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSubmissionItemConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,9 +17,12 @@ public class ContestSubmissionItemQueryService {
 
     private final ContestConvenience contestConvenience;
     private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
+    private final TeamMemberConvenience teamMemberConvenience;
 
-    public ContestSubmissionItemResponse getSubmissionItem(final Long contestId, final Long submissionItemId) {
+    public ContestSubmissionItemResponse getSubmissionItem(final Long contestId, final Long submissionItemId,
+                                                           final Member member) {
         contestConvenience.validateExistContest(contestId);
+        teamMemberConvenience.validateTeamMemberInContestUnlessAdmin(contestId, member);
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemConvenience.getValidateExistSubmissionItem(contestId, submissionItemId);
         return ContestSubmissionItemResponse.from(submissionItem);

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionItemQueryService.java
@@ -3,9 +3,13 @@ package com.opus.opus.modules.contest.application;
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSubmissionItemConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemSummaryResponse;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,9 +19,24 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class ContestSubmissionItemQueryService {
 
+    private static final String SCHEDULED = "SCHEDULED";
+    private static final String IN_PROGRESS = "IN_PROGRESS";
+    private static final String CLOSED = "CLOSED";
+
+    private final ContestSubmissionItemRepository contestSubmissionItemRepository;
+
     private final ContestConvenience contestConvenience;
     private final ContestSubmissionItemConvenience contestSubmissionItemConvenience;
     private final TeamMemberConvenience teamMemberConvenience;
+
+    public List<ContestSubmissionItemSummaryResponse> getSubmissionItems(final Long contestId, final String status) {
+        contestConvenience.validateExistContest(contestId);
+        final List<ContestSubmissionItem> submissionItems =
+                contestSubmissionItemRepository.findAllByContestIdOrderByUpdatedAtDesc(contestId);
+        return toSummaryResponses(submissionItems).stream()
+                .filter(response -> matchesStatus(response, status))
+                .toList();
+    }
 
     public ContestSubmissionItemResponse getSubmissionItem(final Long contestId, final Long submissionItemId,
                                                            final Member member) {
@@ -26,5 +45,28 @@ public class ContestSubmissionItemQueryService {
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemConvenience.getValidateExistSubmissionItem(contestId, submissionItemId);
         return ContestSubmissionItemResponse.from(submissionItem);
+    }
+
+    private List<ContestSubmissionItemSummaryResponse> toSummaryResponses(
+            final List<ContestSubmissionItem> submissionItems) {
+        final LocalDateTime now = LocalDateTime.now();
+        return submissionItems.stream()
+                .map(submissionItem -> ContestSubmissionItemSummaryResponse.of(
+                        submissionItem, resolveOperationStatus(submissionItem, now)))
+                .toList();
+    }
+
+    private String resolveOperationStatus(final ContestSubmissionItem submissionItem, final LocalDateTime now) {
+        if (now.isBefore(submissionItem.getStartAt())) {
+            return SCHEDULED;
+        }
+        if (now.isAfter(submissionItem.getEndAt())) {
+            return CLOSED;
+        }
+        return IN_PROGRESS;
+    }
+
+    private boolean matchesStatus(final ContestSubmissionItemSummaryResponse response, final String status) {
+        return status == null || status.isBlank() || status.equals(response.operationStatus());
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionItemConvenience.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/convenience/ContestSubmissionItemConvenience.java
@@ -1,11 +1,11 @@
 package com.opus.opus.modules.contest.application.convenience;
 
-
-import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM;
-
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestExceptionType;
+import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
+import com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +19,16 @@ public class ContestSubmissionItemConvenience {
 
     public ContestSubmissionItem getValidateExistSubmissionItem(final Long submissionItemId) {
         return contestSubmissionItemRepository.findById(submissionItemId)
-                .orElseThrow(() -> new ContestException(NOT_FOUND_SUBMISSION_ITEM));
+                .orElseThrow(() -> new ContestException(ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM));
+    }
+
+    public ContestSubmissionItem getValidateExistSubmissionItem(final Long contestId, final Long submissionItemId) {
+        final ContestSubmissionItem submissionItem = contestSubmissionItemRepository.findById(submissionItemId)
+                .orElseThrow(() -> new ContestSubmissionItemException(ContestSubmissionItemExceptionType.NOT_FOUND_SUBMISSION_ITEM));
+
+        if (!submissionItem.getContest().getId().equals(contestId)) {
+            throw new ContestSubmissionItemException(ContestSubmissionItemExceptionType.INVALID_SUBMISSION_ITEM_FOR_CONTEST);
+        }
+        return submissionItem;
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestSubmissionItemRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestSubmissionItemRequest.java
@@ -3,7 +3,6 @@ package com.opus.opus.modules.contest.application.dto.request;
 import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
 import com.opus.opus.modules.contest.domain.SubmissionVisibility;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDateTime;
@@ -18,7 +17,6 @@ public record ContestSubmissionItemRequest(
 
         String description,
 
-        @NotEmpty(message = "허용 파일 형식은 최소 1개 이상이어야 합니다.")
         List<SubmissionFileFormat> allowedFileFormats,
 
         @NotNull(message = "파일 크기 제한은 필수입니다.")

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestSubmissionItemRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/ContestSubmissionItemRequest.java
@@ -1,0 +1,44 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
+import com.opus.opus.modules.contest.domain.SubmissionVisibility;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ContestSubmissionItemRequest(
+
+        @NotBlank(message = "제출물 종류 이름은 비어 있을 수 없습니다.")
+        String name,
+
+        Long contestTrackId,
+
+        String description,
+
+        @NotEmpty(message = "허용 파일 형식은 최소 1개 이상이어야 합니다.")
+        List<SubmissionFileFormat> allowedFileFormats,
+
+        @NotNull(message = "파일 크기 제한은 필수입니다.")
+        @Positive(message = "파일 크기 제한은 0보다 커야 합니다.")
+        Integer maxFileSizeMb,
+
+        @NotNull(message = "파일 수 제한은 필수입니다.")
+        @Positive(message = "파일 수 제한은 0보다 커야 합니다.")
+        Integer maxFileCount,
+
+        @NotNull(message = "시작일시는 필수입니다.")
+        LocalDateTime startAt,
+
+        @NotNull(message = "마감일시는 필수입니다.")
+        LocalDateTime endAt,
+
+        @NotNull(message = "지각 제출 허용 여부는 필수입니다.")
+        Boolean allowLateSubmission,
+
+        @NotNull(message = "공개 범위는 필수입니다.")
+        SubmissionVisibility visibility
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionItemResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionItemResponse.java
@@ -1,0 +1,37 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ContestSubmissionItemResponse(
+
+        String name,
+        Long contestTrackId,
+        String description,
+        List<String> allowedFileFormats,
+        Integer maxFileSizeMb,
+        Integer maxFileCount,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Boolean allowLateSubmission,
+        String visibility
+) {
+
+    public static ContestSubmissionItemResponse from(final ContestSubmissionItem submissionItem) {
+        final ContestTrack contestTrack = submissionItem.getContestTrack();
+        return new ContestSubmissionItemResponse(
+                submissionItem.getName(),
+                contestTrack != null ? contestTrack.getId() : null,
+                submissionItem.getDescription(),
+                submissionItem.getAllowedFileFormats().stream().map(Enum::name).toList(),
+                submissionItem.getMaxFileSizeMb(),
+                submissionItem.getMaxFileCount(),
+                submissionItem.getStartAt(),
+                submissionItem.getEndAt(),
+                submissionItem.getAllowLateSubmission(),
+                submissionItem.getVisibility().name()
+        );
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionItemSummaryResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionItemSummaryResponse.java
@@ -1,0 +1,33 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import java.time.LocalDateTime;
+
+public record ContestSubmissionItemSummaryResponse(
+
+        Long contestSubmissionItemId,
+        String name,
+        String trackName,
+        LocalDateTime startAt,
+        LocalDateTime endAt,
+        Boolean allowLateSubmission,
+        String visibility,
+        String operationStatus
+) {
+
+    public static ContestSubmissionItemSummaryResponse of(final ContestSubmissionItem submissionItem,
+                                                          final String operationStatus) {
+        final ContestTrack contestTrack = submissionItem.getContestTrack();
+        return new ContestSubmissionItemSummaryResponse(
+                submissionItem.getId(),
+                submissionItem.getName(),
+                contestTrack != null ? contestTrack.getTrackName() : null,
+                submissionItem.getStartAt(),
+                submissionItem.getEndAt(),
+                submissionItem.getAllowLateSubmission(),
+                submissionItem.getVisibility().name(),
+                operationStatus
+        );
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -88,7 +88,7 @@ public class ContestSubmissionItem extends BaseEntity {
                                   final Contest contest, final ContestTrack contestTrack) {
         this.name = name;
         this.description = description;
-        this.allowedFileFormats = allowedFileFormats != null ? allowedFileFormats : new HashSet<>();
+        this.allowedFileFormats = allowedFileFormats != null ? new HashSet<>(allowedFileFormats) : new HashSet<>();
         this.maxFileSizeMb = maxFileSizeMb;
         this.maxFileCount = maxFileCount;
         this.startAt = startAt;
@@ -118,5 +118,29 @@ public class ContestSubmissionItem extends BaseEntity {
 
     public boolean isFileSizeExceeded(final long sizeBytes) {
         return sizeBytes > maxFileSizeMb * MB_IN_BYTES;
+    }
+
+    public void updateContestSubmissionItem(final String name, final String description,
+                                            final Set<SubmissionFileFormat> allowedFileFormats,
+                                            final Integer maxFileSizeMb,
+                                            final Integer maxFileCount, final LocalDateTime startAt,
+                                            final LocalDateTime endAt,
+                                            final Boolean allowLateSubmission, final SubmissionVisibility visibility,
+                                            final ContestTrack contestTrack) {
+        this.name = name;
+        this.description = description;
+        this.maxFileSizeMb = maxFileSizeMb;
+        this.maxFileCount = maxFileCount;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.allowLateSubmission = allowLateSubmission;
+        this.visibility = visibility;
+        this.contestTrack = contestTrack;
+        replaceAllowedFileFormats(allowedFileFormats);
+    }
+
+    private void replaceAllowedFileFormats(final Set<SubmissionFileFormat> allowedFileFormats) {
+        this.allowedFileFormats.clear();
+        this.allowedFileFormats.addAll(allowedFileFormats);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -141,6 +141,8 @@ public class ContestSubmissionItem extends BaseEntity {
 
     private void replaceAllowedFileFormats(final Set<SubmissionFileFormat> allowedFileFormats) {
         this.allowedFileFormats.clear();
-        this.allowedFileFormats.addAll(allowedFileFormats);
+        if (allowedFileFormats != null) {
+            this.allowedFileFormats.addAll(allowedFileFormats);
+        }
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionItemRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionItemRepository.java
@@ -1,8 +1,10 @@
 package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestSubmissionItemRepository extends JpaRepository<ContestSubmissionItem, Long> {
 
+    List<ContestSubmissionItem> findAllByContestIdOrderByUpdatedAtDesc(final Long contestId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionRepository.java
@@ -14,4 +14,6 @@ public interface ContestSubmissionRepository extends JpaRepository<ContestSubmis
     @Modifying(clearAutomatically = true)
     @Query("UPDATE ContestSubmission s SET s.updatedAt = CURRENT_TIMESTAMP WHERE s.id = :submissionId")
     void touchUpdatedAt(@Param("submissionId") final Long submissionId);
+
+    void deleteAllBySubmissionItemId(final Long submissionItemId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -27,6 +27,7 @@ public enum ContestExceptionType implements BaseExceptionType {
     DUPLICATE_TEAM_ID_IN_SORT_REQUEST(HttpStatus.BAD_REQUEST, "중복된 팀ID가 있습니다."),
     DUPLICATE_ITEM_ORDER_IN_SORT_REQUEST(HttpStatus.BAD_REQUEST, "중복된 itemOrder가 있습니다."),
     NOT_EXIST_TEAM_IN_CONTEST(HttpStatus.NOT_FOUND, "현재 대회에 소속된 팀이 아닙니다"),
+    NOT_CONTEST_MEMBER(HttpStatus.FORBIDDEN, "현재 대회에 소속된 회원이 아닙니다."),
     INVALID_CONTEST_SORT_CUSTOM_REQUEST(HttpStatus.BAD_REQUEST, "저장된 팀 개수와 request의 팀 개수가 다릅니다"),
     NOT_ALLOWED_DURING_VOTING_PERIOD(HttpStatus.BAD_REQUEST, "현재 투표 기간이므로 해당 작업을 수행할 수 없습니다."),
     NOT_VOTE_PERIOD_NOW(HttpStatus.BAD_REQUEST, "지금은 투표 기간이 아닙니다."),

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestSubmissionItemException.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestSubmissionItemException.java
@@ -1,0 +1,23 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class ContestSubmissionItemException extends BaseException {
+    private final ContestSubmissionItemExceptionType exceptionType;
+
+    public ContestSubmissionItemException(final ContestSubmissionItemExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public ContestSubmissionItemException(final ContestSubmissionItemExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestSubmissionItemExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestSubmissionItemExceptionType.java
@@ -1,0 +1,27 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ContestSubmissionItemExceptionType implements BaseExceptionType {
+
+    INVALID_SUBMISSION_PERIOD(HttpStatus.BAD_REQUEST, "마감일시는 시작일시보다 이후여야 합니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    ContestSubmissionItemExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestSubmissionItemExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestSubmissionItemExceptionType.java
@@ -5,6 +5,8 @@ import org.springframework.http.HttpStatus;
 
 public enum ContestSubmissionItemExceptionType implements BaseExceptionType {
 
+    NOT_FOUND_SUBMISSION_ITEM(HttpStatus.NOT_FOUND, "존재하지 않는 제출 항목입니다."),
+    INVALID_SUBMISSION_ITEM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 제출 항목입니다."),
     INVALID_SUBMISSION_PERIOD(HttpStatus.BAD_REQUEST, "마감일시는 시작일시보다 이후여야 합니다.");
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
@@ -76,6 +76,14 @@ public class TeamMemberConvenience {
         }
     }
 
+    public void validateTeamMemberInContestUnlessAdmin(final Long contestId, final Member member) {
+        if (!member.isAdmin()) {
+            if (!findMemberIdsByContestId(contestId).contains(member.getId())) {
+                throw new TeamMemberException(TEAM_MEMBER_NOT_FOUND_IN_TEAM);
+            }
+        }
+    }
+
     public Set<Long> findMemberIdsByContestId(final Long contestId) {
         return teamMemberRepository.findMemberIdsByContestId(contestId);
     }

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamMemberConvenience.java
@@ -1,10 +1,12 @@
 package com.opus.opus.modules.team.application.convenience;
 
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_CONTEST_MEMBER;
 import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀장;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.NOT_TEAM_LEADER;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_ALREADY_EXISTS;
 import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
 
+import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.domain.TeamMember;
@@ -78,8 +80,8 @@ public class TeamMemberConvenience {
 
     public void validateTeamMemberInContestUnlessAdmin(final Long contestId, final Member member) {
         if (!member.isAdmin()) {
-            if (!findMemberIdsByContestId(contestId).contains(member.getId())) {
-                throw new TeamMemberException(TEAM_MEMBER_NOT_FOUND_IN_TEAM);
+            if (!teamMemberRepository.existsByContestIdAndMemberId(contestId, member.getId())) {
+                throw new ContestException(NOT_CONTEST_MEMBER);
             }
         }
     }

--- a/src/main/java/com/opus/opus/modules/team/domain/dao/TeamMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/team/domain/dao/TeamMemberRepository.java
@@ -31,6 +31,13 @@ public interface TeamMemberRepository extends JpaRepository<TeamMember, Long> {
     @Query("SELECT tm.memberId FROM TeamMember tm JOIN Team t ON tm.team.id = t.id WHERE t.contestId = :contestId")
     Set<Long> findMemberIdsByContestId(Long contestId);
 
+    @Query("""
+            SELECT CASE WHEN COUNT(tm) > 0 THEN true ELSE false END
+            FROM TeamMember tm JOIN Team t ON tm.team.id = t.id
+            WHERE t.contestId = :contestId AND tm.memberId = :memberId
+            """)
+    boolean existsByContestIdAndMemberId(Long contestId, Long memberId);
+
     @Query("SELECT DISTINCT tm.memberId FROM TeamMember tm JOIN Member m ON m.id = tm.memberId WHERE tm.team.id = :teamId AND m.isFake = false AND m.isDeleted = false")
     List<Long> findRealMemberIdsByTeamId(final Long teamId);
 }

--- a/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
@@ -1,5 +1,6 @@
 package com.opus.opus.contest;
 
+import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTrack;
@@ -7,6 +8,7 @@ import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
 import com.opus.opus.modules.contest.domain.SubmissionVisibility;
 import java.time.LocalDateTime;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class ContestSubmissionItemFixture {
@@ -51,5 +53,36 @@ public class ContestSubmissionItemFixture {
                 .allowLateSubmission(false)
                 .visibility(SubmissionVisibility.PUBLIC)
                 .contest(contest);
+    }
+
+    public static ContestSubmissionItemRequest createRequest(final Long contestTrackId) {
+        return new ContestSubmissionItemRequest(
+                "발표자료",
+                contestTrackId,
+                "PDF 형식의 발표자료를 제출하세요.",
+                List.of(SubmissionFileFormat.PDF, SubmissionFileFormat.ZIP),
+                50,
+                3,
+                LocalDateTime.of(2026, 7, 1, 0, 0),
+                LocalDateTime.of(2026, 7, 31, 23, 59),
+                true,
+                SubmissionVisibility.PUBLIC
+        );
+    }
+
+    public static ContestSubmissionItemRequest createRequestWithPeriod(final LocalDateTime startAt,
+                                                                       final LocalDateTime endAt) {
+        return new ContestSubmissionItemRequest(
+                "발표자료",
+                null,
+                "PDF 형식의 발표자료를 제출하세요.",
+                List.of(SubmissionFileFormat.PDF),
+                50,
+                3,
+                startAt,
+                endAt,
+                true,
+                SubmissionVisibility.PUBLIC
+        );
     }
 }

--- a/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
@@ -1,5 +1,9 @@
 package com.opus.opus.contest;
 
+import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.PDF;
+import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.ZIP;
+import static com.opus.opus.modules.contest.domain.SubmissionVisibility.PUBLIC;
+
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
@@ -60,13 +64,13 @@ public class ContestSubmissionItemFixture {
                 "발표자료",
                 contestTrackId,
                 "PDF 형식의 발표자료를 제출하세요.",
-                List.of(SubmissionFileFormat.PDF, SubmissionFileFormat.ZIP),
+                List.of(PDF, ZIP),
                 50,
                 3,
                 LocalDateTime.of(2026, 7, 1, 0, 0),
                 LocalDateTime.of(2026, 7, 31, 23, 59),
                 true,
-                SubmissionVisibility.PUBLIC
+                PUBLIC
         );
     }
 
@@ -76,13 +80,13 @@ public class ContestSubmissionItemFixture {
                 "발표자료",
                 null,
                 "PDF 형식의 발표자료를 제출하세요.",
-                List.of(SubmissionFileFormat.PDF),
+                List.of(PDF),
                 50,
                 3,
                 startAt,
                 endAt,
                 true,
-                SubmissionVisibility.PUBLIC
+                PUBLIC
         );
     }
 }

--- a/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestSubmissionItemFixture.java
@@ -21,8 +21,27 @@ public class ContestSubmissionItemFixture {
         return baseBuilder(contest).build();
     }
 
-    public static ContestSubmissionItem createSubmissionItem(final Contest contest, final ContestTrack track) {
-        return baseBuilder(contest).contestTrack(track).build();
+    public static ContestSubmissionItem createSubmissionItem(final Contest contest, final ContestTrack contestTrack) {
+        return createSubmissionItem(contest, contestTrack, "발표자료",
+                LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59));
+    }
+
+    public static ContestSubmissionItem createSubmissionItem(final Contest contest, final ContestTrack contestTrack,
+                                                             final String name, final LocalDateTime startAt,
+                                                             final LocalDateTime endAt) {
+        return ContestSubmissionItem.builder()
+                .name(name)
+                .description("PDF 형식의 발표자료를 제출하세요.")
+                .allowedFileFormats(Set.of(PDF, ZIP))
+                .maxFileSizeMb(50)
+                .maxFileCount(3)
+                .startAt(startAt)
+                .endAt(endAt)
+                .allowLateSubmission(true)
+                .visibility(PUBLIC)
+                .contest(contest)
+                .contestTrack(contestTrack)
+                .build();
     }
 
     public static ContestSubmissionItem createSubmissionItemWithDeadline(final Contest contest,

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -125,6 +125,19 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[실패] 시작일시와 마감일시가 같으면 제출 항목 생성에 실패한다.")
+    void 시작일시와_마감일시가_같으면_제출_항목_생성에_실패한다() {
+        final LocalDateTime sameTime = LocalDateTime.of(2026, 7, 1, 0, 0);
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "발표자료", null, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, sameTime, sameTime, true, PUBLIC);
+
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
+    }
+
+    @Test
     @DisplayName("[성공] 제출 항목의 설정값이 수정된다.")
     void 제출_항목의_설정값이_수정된다() {
         final ContestSubmissionItem submissionItem =
@@ -195,6 +208,22 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
                 100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0), false, PRIVATE);
+
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(
+                contest.getId(), submissionItem.getId(), request))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 시작일시와 마감일시가 같으면 수정에 실패한다.")
+    void 시작일시와_마감일시가_같으면_수정에_실패한다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+        final LocalDateTime sameTime = LocalDateTime.of(2026, 8, 1, 0, 0);
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
+                100, 5, sameTime, sameTime, false, PRIVATE);
 
         assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(
                 contest.getId(), submissionItem.getId(), request))

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -62,10 +62,8 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 분과가 지정된 제출 항목이 생성된다.")
     void 분과가_지정된_제출_항목이_생성된다() {
-        // when
         contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
 
-        // then
         final List<ContestSubmissionItem> submissionItems = contestSubmissionItemRepository.findAll();
         assertThat(submissionItems).hasSize(1);
         final ContestSubmissionItem submissionItem = submissionItems.get(0);
@@ -79,15 +77,12 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 분과 ID가 없으면 전체 분과 대상 제출 항목이 생성된다.")
     void 분과_ID가_없으면_전체_분과_대상_제출_항목이_생성된다() {
-        // given
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "발표자료", null, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
                 50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
 
-        // when
         contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
 
-        // then
         final List<ContestSubmissionItem> submissionItems = contestSubmissionItemRepository.findAll();
         assertThat(submissionItems).hasSize(1);
         assertThat(submissionItems.get(0).getContestTrack()).isNull();
@@ -96,7 +91,6 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 존재하지 않는 대회면 제출 항목 생성에 실패한다.")
     void 존재하지_않는_대회면_제출_항목_생성에_실패한다() {
-        // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(999L, request))
                 .isInstanceOf(ContestException.class)
                 .hasMessage(NOT_FOUND_CONTEST.errorMessage());
@@ -105,12 +99,10 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 존재하지 않는 분과면 제출 항목 생성에 실패한다.")
     void 존재하지_않는_분과면_제출_항목_생성에_실패한다() {
-        // given
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "발표자료", 999L, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
                 50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
 
-        // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
                 .isInstanceOf(ContestTrackException.class)
                 .hasMessage(NOT_FOUND_TRACK.errorMessage());
@@ -119,12 +111,10 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 시작일시가 마감일시보다 이후면 제출 항목 생성에 실패한다.")
     void 시작일시가_마감일시보다_이후면_제출_항목_생성에_실패한다() {
-        // given
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "발표자료", null, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
                 50, 3, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0), true, PUBLIC);
 
-        // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
@@ -133,17 +123,14 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 제출 항목의 설정값이 수정된다.")
     void 제출_항목의_설정값이_수정된다() {
-        // given
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
                 100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
 
-        // when
         contestSubmissionItemCommandService.updateSubmissionItem(contest.getId(), submissionItem.getId(), request);
 
-        // then
         final ContestSubmissionItem updated =
                 contestSubmissionItemRepository.findById(submissionItem.getId()).orElseThrow();
         assertThat(updated.getName()).isEqualTo("수정된 발표자료");
@@ -155,17 +142,14 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 분과 ID가 없으면 전체 분과 대상으로 수정된다.")
     void 분과_ID가_없으면_전체_분과_대상으로_수정된다() {
-        // given
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "수정된 발표자료", null, "수정된 설명", List.of(PDF),
                 100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
 
-        // when
         contestSubmissionItemCommandService.updateSubmissionItem(contest.getId(), submissionItem.getId(), request);
 
-        // then
         final ContestSubmissionItem updated =
                 contestSubmissionItemRepository.findById(submissionItem.getId()).orElseThrow();
         assertThat(updated.getContestTrack()).isNull();
@@ -174,12 +158,10 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 존재하지 않는 제출 항목이면 수정에 실패한다.")
     void 존재하지_않는_제출_항목이면_수정에_실패한다() {
-        // given
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
                 100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
 
-        // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(contest.getId(), 999L, request))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(NOT_FOUND_SUBMISSION_ITEM.errorMessage());
@@ -188,7 +170,6 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 다른 대회의 제출 항목이면 수정에 실패한다.")
     void 다른_대회의_제출_항목이면_수정에_실패한다() {
-        // given
         final Contest otherContest = contestRepository.save(createContest());
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemRepository.save(createSubmissionItem(otherContest, null));
@@ -196,7 +177,6 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
                 "수정된 발표자료", null, "수정된 설명", List.of(PDF),
                 100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
 
-        // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(
                 contest.getId(), submissionItem.getId(), request))
                 .isInstanceOf(ContestSubmissionItemException.class)
@@ -206,14 +186,12 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 시작일시가 마감일시보다 이후면 수정에 실패한다.")
     void 시작일시가_마감일시보다_이후면_수정에_실패한다() {
-        // given
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
         final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
                 "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
                 100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0), false, PRIVATE);
 
-        // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(
                 contest.getId(), submissionItem.getId(), request))
                 .isInstanceOf(ContestSubmissionItemException.class)

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -125,6 +125,20 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[성공] 허용 파일 형식이 없어도 제출 항목이 생성된다.")
+    void 허용_파일_형식이_없어도_제출_항목이_생성된다() {
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "발표자료", null, "파일 제출이 없는 항목입니다.", null,
+                50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
+
+        contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
+
+        final List<ContestSubmissionItem> submissionItems = contestSubmissionItemRepository.findAll();
+        assertThat(submissionItems).hasSize(1);
+        assertThat(submissionItems.get(0).getAllowedFileFormats()).isEmpty();
+    }
+
+    @Test
     @DisplayName("[실패] 시작일시와 마감일시가 같으면 제출 항목 생성에 실패한다.")
     void 시작일시와_마감일시가_같으면_제출_항목_생성에_실패한다() {
         final LocalDateTime sameTime = LocalDateTime.of(2026, 7, 1, 0, 0);

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -1,6 +1,7 @@
 package com.opus.opus.contest.application;
 
 import static com.opus.opus.contest.ContestFixture.createContest;
+import static com.opus.opus.contest.ContestSubmissionFixture.createSubmission;
 import static com.opus.opus.contest.ContestSubmissionItemFixture.createSubmissionItem;
 import static com.opus.opus.contest.ContestTrackFixture.createTrack;
 import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.PDF;
@@ -23,6 +24,7 @@ import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
@@ -41,6 +43,8 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
 
     @Autowired
     private ContestSubmissionItemRepository contestSubmissionItemRepository;
+    @Autowired
+    private ContestSubmissionRepository contestSubmissionRepository;
     @Autowired
     private ContestRepository contestRepository;
     @Autowired
@@ -196,5 +200,40 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
                 contest.getId(), submissionItem.getId(), request))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 항목과 해당 항목의 제출물이 함께 삭제된다.")
+    void 제출_항목과_해당_항목의_제출물이_함께_삭제된다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+        contestSubmissionRepository.save(createSubmission(1L, submissionItem));
+        contestSubmissionRepository.save(createSubmission(2L, submissionItem));
+
+        contestSubmissionItemCommandService.deleteSubmissionItem(contest.getId(), submissionItem.getId());
+
+        assertThat(contestSubmissionItemRepository.findAll()).isEmpty();
+        assertThat(contestSubmissionRepository.findAll()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출 항목이면 삭제에 실패한다.")
+    void 존재하지_않는_제출_항목이면_삭제에_실패한다() {
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.deleteSubmissionItem(contest.getId(), 999L))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION_ITEM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 대회의 제출 항목이면 삭제에 실패한다.")
+    void 다른_대회의_제출_항목이면_삭제에_실패한다() {
+        final Contest otherContest = contestRepository.save(createContest());
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(otherContest, null));
+
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.deleteSubmissionItem(
+                contest.getId(), submissionItem.getId()))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_ITEM_FOR_CONTEST.errorMessage());
     }
 }

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -1,0 +1,128 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
+import static com.opus.opus.modules.contest.exception.ContestTrackExceptionType.NOT_FOUND_TRACK;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.contest.ContestSubmissionItemFixture;
+import com.opus.opus.contest.ContestTrackFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
+import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
+import com.opus.opus.modules.contest.domain.SubmissionVisibility;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
+import com.opus.opus.modules.contest.exception.ContestTrackException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestSubmissionItemCommandService contestSubmissionItemCommandService;
+
+    @Autowired
+    private ContestSubmissionItemRepository contestSubmissionItemRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private ContestTrackRepository contestTrackRepository;
+
+    private Contest contest;
+    private ContestTrack track;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContest());
+        track = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+    }
+
+    @Test
+    @DisplayName("[성공] 분과가 지정된 제출 항목이 생성된다.")
+    void 분과가_지정된_제출_항목이_생성된다() {
+        // given
+        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(track.getId());
+
+        // when
+        contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
+
+        // then
+        final List<ContestSubmissionItem> submissionItems = contestSubmissionItemRepository.findAll();
+        assertThat(submissionItems).hasSize(1);
+        final ContestSubmissionItem submissionItem = submissionItems.get(0);
+        assertThat(submissionItem.getName()).isEqualTo("발표자료");
+        assertThat(submissionItem.getContest().getId()).isEqualTo(contest.getId());
+        assertThat(submissionItem.getContestTrack().getId()).isEqualTo(track.getId());
+        assertThat(submissionItem.getAllowedFileFormats())
+                .containsExactlyInAnyOrder(SubmissionFileFormat.PDF, SubmissionFileFormat.ZIP);
+        assertThat(submissionItem.getVisibility()).isEqualTo(SubmissionVisibility.PUBLIC);
+    }
+
+    @Test
+    @DisplayName("[성공] 분과 ID가 없으면 전체 분과 대상 제출 항목이 생성된다.")
+    void 분과_ID가_없으면_전체_분과_대상_제출_항목이_생성된다() {
+        // given
+        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(null);
+
+        // when
+        contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
+
+        // then
+        final List<ContestSubmissionItem> submissionItems = contestSubmissionItemRepository.findAll();
+        assertThat(submissionItems).hasSize(1);
+        assertThat(submissionItems.get(0).getContestTrack()).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회면 제출 항목 생성에 실패한다.")
+    void 존재하지_않는_대회면_제출_항목_생성에_실패한다() {
+        // given
+        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(null);
+
+        // when & then
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(999L, request))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 분과면 제출 항목 생성에 실패한다.")
+    void 존재하지_않는_분과면_제출_항목_생성에_실패한다() {
+        // given
+        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(999L);
+
+        // when & then
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
+                .isInstanceOf(ContestTrackException.class)
+                .hasMessage(NOT_FOUND_TRACK.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 시작일시가 마감일시보다 이후면 제출 항목 생성에 실패한다.")
+    void 시작일시가_마감일시보다_이후면_제출_항목_생성에_실패한다() {
+        // given
+        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequestWithPeriod(
+                LocalDateTime.of(2026, 8, 1, 0, 0),
+                LocalDateTime.of(2026, 7, 1, 0, 0)
+        );
+
+        // when & then
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -1,14 +1,16 @@
 package com.opus.opus.contest.application;
 
 import static com.opus.opus.contest.ContestFixture.createContest;
-import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequest;
-import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequestWithPeriod;
+import static com.opus.opus.contest.ContestSubmissionItemFixture.createSubmissionItem;
 import static com.opus.opus.contest.ContestTrackFixture.createTrack;
 import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.PDF;
 import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.ZIP;
+import static com.opus.opus.modules.contest.domain.SubmissionVisibility.PRIVATE;
 import static com.opus.opus.modules.contest.domain.SubmissionVisibility.PUBLIC;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_ITEM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.NOT_FOUND_SUBMISSION_ITEM;
 import static com.opus.opus.modules.contest.exception.ContestTrackExceptionType.NOT_FOUND_TRACK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -46,19 +48,20 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
 
     private Contest contest;
     private ContestTrack track;
+    private ContestSubmissionItemRequest request;
 
     @BeforeEach
     void setUp() {
         contest = contestRepository.save(createContest());
         track = contestTrackRepository.save(createTrack(contest));
+        request = new ContestSubmissionItemRequest(
+                "발표자료", track.getId(), "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
     }
 
     @Test
     @DisplayName("[성공] 분과가 지정된 제출 항목이 생성된다.")
     void 분과가_지정된_제출_항목이_생성된다() {
-        // given
-        final ContestSubmissionItemRequest request = createRequest(track.getId());
-
         // when
         contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
 
@@ -77,7 +80,9 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @DisplayName("[성공] 분과 ID가 없으면 전체 분과 대상 제출 항목이 생성된다.")
     void 분과_ID가_없으면_전체_분과_대상_제출_항목이_생성된다() {
         // given
-        final ContestSubmissionItemRequest request = createRequest(null);
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "발표자료", null, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
 
         // when
         contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
@@ -91,9 +96,6 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 존재하지 않는 대회면 제출 항목 생성에 실패한다.")
     void 존재하지_않는_대회면_제출_항목_생성에_실패한다() {
-        // given
-        final ContestSubmissionItemRequest request = createRequest(null);
-
         // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(999L, request))
                 .isInstanceOf(ContestException.class)
@@ -104,7 +106,9 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] 존재하지 않는 분과면 제출 항목 생성에 실패한다.")
     void 존재하지_않는_분과면_제출_항목_생성에_실패한다() {
         // given
-        final ContestSubmissionItemRequest request = createRequest(999L);
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "발표자료", 999L, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
 
         // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
@@ -116,13 +120,102 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] 시작일시가 마감일시보다 이후면 제출 항목 생성에 실패한다.")
     void 시작일시가_마감일시보다_이후면_제출_항목_생성에_실패한다() {
         // given
-        final ContestSubmissionItemRequest request = createRequestWithPeriod(
-                LocalDateTime.of(2026, 8, 1, 0, 0),
-                LocalDateTime.of(2026, 7, 1, 0, 0)
-        );
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "발표자료", null, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0), true, PUBLIC);
 
         // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 항목의 설정값이 수정된다.")
+    void 제출_항목의_설정값이_수정된다() {
+        // given
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
+                100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
+
+        // when
+        contestSubmissionItemCommandService.updateSubmissionItem(contest.getId(), submissionItem.getId(), request);
+
+        // then
+        final ContestSubmissionItem updated =
+                contestSubmissionItemRepository.findById(submissionItem.getId()).orElseThrow();
+        assertThat(updated.getName()).isEqualTo("수정된 발표자료");
+        assertThat(updated.getMaxFileCount()).isEqualTo(5);
+        assertThat(updated.getAllowedFileFormats()).containsExactly(PDF);
+        assertThat(updated.getVisibility()).isEqualTo(PRIVATE);
+    }
+
+    @Test
+    @DisplayName("[성공] 분과 ID가 없으면 전체 분과 대상으로 수정된다.")
+    void 분과_ID가_없으면_전체_분과_대상으로_수정된다() {
+        // given
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "수정된 발표자료", null, "수정된 설명", List.of(PDF),
+                100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
+
+        // when
+        contestSubmissionItemCommandService.updateSubmissionItem(contest.getId(), submissionItem.getId(), request);
+
+        // then
+        final ContestSubmissionItem updated =
+                contestSubmissionItemRepository.findById(submissionItem.getId()).orElseThrow();
+        assertThat(updated.getContestTrack()).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출 항목이면 수정에 실패한다.")
+    void 존재하지_않는_제출_항목이면_수정에_실패한다() {
+        // given
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
+                100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
+
+        // when & then
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(contest.getId(), 999L, request))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION_ITEM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 대회의 제출 항목이면 수정에 실패한다.")
+    void 다른_대회의_제출_항목이면_수정에_실패한다() {
+        // given
+        final Contest otherContest = contestRepository.save(createContest());
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(otherContest, null));
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "수정된 발표자료", null, "수정된 설명", List.of(PDF),
+                100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59), false, PRIVATE);
+
+        // when & then
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(
+                contest.getId(), submissionItem.getId(), request))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_ITEM_FOR_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 시작일시가 마감일시보다 이후면 수정에 실패한다.")
+    void 시작일시가_마감일시보다_이후면_수정에_실패한다() {
+        // given
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+        final ContestSubmissionItemRequest request = new ContestSubmissionItemRequest(
+                "수정된 발표자료", track.getId(), "수정된 설명", List.of(PDF),
+                100, 5, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0), false, PRIVATE);
+
+        // when & then
+        assertThatThrownBy(() -> contestSubmissionItemCommandService.updateSubmissionItem(
+                contest.getId(), submissionItem.getId(), request))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(INVALID_SUBMISSION_PERIOD.errorMessage());
     }

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemCommandServiceTest.java
@@ -1,22 +1,24 @@
 package com.opus.opus.contest.application;
 
+import static com.opus.opus.contest.ContestFixture.createContest;
+import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequest;
+import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequestWithPeriod;
+import static com.opus.opus.contest.ContestTrackFixture.createTrack;
+import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.PDF;
+import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.ZIP;
+import static com.opus.opus.modules.contest.domain.SubmissionVisibility.PUBLIC;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
 import static com.opus.opus.modules.contest.exception.ContestTrackExceptionType.NOT_FOUND_TRACK;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.opus.opus.contest.ContestFixture;
-import com.opus.opus.contest.ContestSubmissionItemFixture;
-import com.opus.opus.contest.ContestTrackFixture;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTrack;
-import com.opus.opus.modules.contest.domain.SubmissionFileFormat;
-import com.opus.opus.modules.contest.domain.SubmissionVisibility;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
@@ -47,15 +49,15 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
 
     @BeforeEach
     void setUp() {
-        contest = contestRepository.save(ContestFixture.createContest());
-        track = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+        contest = contestRepository.save(createContest());
+        track = contestTrackRepository.save(createTrack(contest));
     }
 
     @Test
     @DisplayName("[성공] 분과가 지정된 제출 항목이 생성된다.")
     void 분과가_지정된_제출_항목이_생성된다() {
         // given
-        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(track.getId());
+        final ContestSubmissionItemRequest request = createRequest(track.getId());
 
         // when
         contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
@@ -67,16 +69,15 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
         assertThat(submissionItem.getName()).isEqualTo("발표자료");
         assertThat(submissionItem.getContest().getId()).isEqualTo(contest.getId());
         assertThat(submissionItem.getContestTrack().getId()).isEqualTo(track.getId());
-        assertThat(submissionItem.getAllowedFileFormats())
-                .containsExactlyInAnyOrder(SubmissionFileFormat.PDF, SubmissionFileFormat.ZIP);
-        assertThat(submissionItem.getVisibility()).isEqualTo(SubmissionVisibility.PUBLIC);
+        assertThat(submissionItem.getAllowedFileFormats()).containsExactlyInAnyOrder(PDF, ZIP);
+        assertThat(submissionItem.getVisibility()).isEqualTo(PUBLIC);
     }
 
     @Test
     @DisplayName("[성공] 분과 ID가 없으면 전체 분과 대상 제출 항목이 생성된다.")
     void 분과_ID가_없으면_전체_분과_대상_제출_항목이_생성된다() {
         // given
-        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(null);
+        final ContestSubmissionItemRequest request = createRequest(null);
 
         // when
         contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request);
@@ -91,7 +92,7 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] 존재하지 않는 대회면 제출 항목 생성에 실패한다.")
     void 존재하지_않는_대회면_제출_항목_생성에_실패한다() {
         // given
-        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(null);
+        final ContestSubmissionItemRequest request = createRequest(null);
 
         // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(999L, request))
@@ -103,7 +104,7 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] 존재하지 않는 분과면 제출 항목 생성에 실패한다.")
     void 존재하지_않는_분과면_제출_항목_생성에_실패한다() {
         // given
-        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequest(999L);
+        final ContestSubmissionItemRequest request = createRequest(999L);
 
         // when & then
         assertThatThrownBy(() -> contestSubmissionItemCommandService.createSubmissionItem(contest.getId(), request))
@@ -115,7 +116,7 @@ class ContestSubmissionItemCommandServiceTest extends IntegrationTest {
     @DisplayName("[실패] 시작일시가 마감일시보다 이후면 제출 항목 생성에 실패한다.")
     void 시작일시가_마감일시보다_이후면_제출_항목_생성에_실패한다() {
         // given
-        final ContestSubmissionItemRequest request = ContestSubmissionItemFixture.createRequestWithPeriod(
+        final ContestSubmissionItemRequest request = createRequestWithPeriod(
                 LocalDateTime.of(2026, 8, 1, 0, 0),
                 LocalDateTime.of(2026, 7, 1, 0, 0)
         );

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
@@ -3,12 +3,12 @@ package com.opus.opus.contest.application;
 import static com.opus.opus.contest.ContestFixture.createContest;
 import static com.opus.opus.contest.ContestSubmissionItemFixture.createSubmissionItem;
 import static com.opus.opus.contest.ContestTrackFixture.createTrack;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_CONTEST_MEMBER;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_ITEM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.NOT_FOUND_SUBMISSION_ITEM;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_관리자;
 import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀원;
 import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀장;
-import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -23,6 +23,7 @@ import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.domain.dao.MemberRepository;
@@ -31,7 +32,6 @@ import com.opus.opus.modules.team.domain.TeamMember;
 import com.opus.opus.modules.team.domain.TeamMemberRoleType;
 import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
-import com.opus.opus.modules.team.exception.TeamMemberException;
 import com.opus.opus.team.TeamFixture;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -143,8 +143,8 @@ class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
 
         assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(
                 contest.getId(), submissionItem.getId(), outsider))
-                .isInstanceOf(TeamMemberException.class)
-                .hasMessage(TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_CONTEST_MEMBER.errorMessage());
     }
 
     @Test

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
@@ -1,0 +1,97 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.contest.ContestFixture.createContest;
+import static com.opus.opus.contest.ContestSubmissionItemFixture.createSubmissionItem;
+import static com.opus.opus.contest.ContestTrackFixture.createTrack;
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_ITEM_FOR_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.NOT_FOUND_SUBMISSION_ITEM;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
+import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestSubmissionItemQueryService contestSubmissionItemQueryService;
+
+    @Autowired
+    private ContestSubmissionItemRepository contestSubmissionItemRepository;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private ContestTrackRepository contestTrackRepository;
+
+    private Contest contest;
+    private ContestTrack track;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(createContest());
+        track = contestTrackRepository.save(createTrack(contest));
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 항목의 설정값을 조회한다.")
+    void 제출_항목의_설정값을_조회한다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+
+        final ContestSubmissionItemResponse response =
+                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId());
+
+        assertThat(response.name()).isEqualTo("발표자료");
+        assertThat(response.contestTrackId()).isEqualTo(track.getId());
+        assertThat(response.allowedFileFormats()).containsExactlyInAnyOrder("PDF", "ZIP");
+        assertThat(response.maxFileSizeMb()).isEqualTo(50);
+        assertThat(response.maxFileCount()).isEqualTo(3);
+        assertThat(response.allowLateSubmission()).isTrue();
+        assertThat(response.visibility()).isEqualTo("PUBLIC");
+    }
+
+    @Test
+    @DisplayName("[성공] 전체 분과 제출 항목은 분과 ID가 null로 조회된다.")
+    void 전체_분과_제출_항목은_분과_ID가_null로_조회된다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, null));
+
+        final ContestSubmissionItemResponse response =
+                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId());
+
+        assertThat(response.contestTrackId()).isNull();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출 항목이면 조회에 실패한다.")
+    void 존재하지_않는_제출_항목이면_조회에_실패한다() {
+        assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), 999L))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION_ITEM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 대회의 제출 항목이면 조회에 실패한다.")
+    void 다른_대회의_제출_항목이면_조회에_실패한다() {
+        final Contest otherContest = contestRepository.save(createContest());
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(otherContest, null));
+
+        assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(
+                contest.getId(), submissionItem.getId()))
+                .isInstanceOf(ContestSubmissionItemException.class)
+                .hasMessage(INVALID_SUBMISSION_ITEM_FOR_CONTEST.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
@@ -5,10 +5,15 @@ import static com.opus.opus.contest.ContestSubmissionItemFixture.createSubmissio
 import static com.opus.opus.contest.ContestTrackFixture.createTrack;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_ITEM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.NOT_FOUND_SUBMISSION_ITEM;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_관리자;
+import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀원;
+import static com.opus.opus.modules.team.domain.TeamMemberRoleType.ROLE_팀장;
+import static com.opus.opus.modules.team.exception.TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
 import com.opus.opus.modules.contest.domain.Contest;
@@ -18,6 +23,16 @@ import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.TeamMember;
+import com.opus.opus.modules.team.domain.TeamMemberRoleType;
+import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamMemberException;
+import com.opus.opus.team.TeamFixture;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,24 +49,54 @@ class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
     private ContestRepository contestRepository;
     @Autowired
     private ContestTrackRepository contestTrackRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private TeamMemberRepository teamMemberRepository;
 
     private Contest contest;
     private ContestTrack track;
+    private Member teamLeader;
+    private Member teamMember;
+    private Member admin;
 
     @BeforeEach
     void setUp() {
         contest = contestRepository.save(createContest());
         track = contestTrackRepository.save(createTrack(contest));
+
+        final Team team = teamRepository.save(TeamFixture.createTeamWithContestId(contest.getId()));
+        teamLeader = saveTeamMember(team, MemberFixture.createMemberWithUniqueNum(1), ROLE_팀장);
+        teamMember = saveTeamMember(team, MemberFixture.createMemberWithUniqueNum(2), ROLE_팀원);
+        admin = memberRepository.save(Member.generalMember()
+                .name("관리자")
+                .email("admin@pusan.ac.kr")
+                .password("{noop}12345678")
+                .studentId("000000000")
+                .roles(Set.of(ROLE_관리자))
+                .build());
+    }
+
+    private Member saveTeamMember(final Team team, final Member member, final TeamMemberRoleType roleType) {
+        final Member savedMember = memberRepository.save(member);
+        teamMemberRepository.save(TeamMember.builder()
+                .memberId(savedMember.getId())
+                .team(team)
+                .roles(Set.of(roleType))
+                .build());
+        return savedMember;
     }
 
     @Test
-    @DisplayName("[성공] 제출 항목의 설정값을 조회한다.")
-    void 제출_항목의_설정값을_조회한다() {
+    @DisplayName("[성공] 팀장이 제출 항목의 설정값을 조회한다.")
+    void 팀장이_제출_항목의_설정값을_조회한다() {
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
 
         final ContestSubmissionItemResponse response =
-                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId());
+                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId(), teamLeader);
 
         assertThat(response.name()).isEqualTo("발표자료");
         assertThat(response.contestTrackId()).isEqualTo(track.getId());
@@ -63,13 +108,50 @@ class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[성공] 팀원이 제출 항목의 설정값을 조회한다.")
+    void 팀원이_제출_항목의_설정값을_조회한다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+
+        final ContestSubmissionItemResponse response =
+                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId(), teamMember);
+
+        assertThat(response.name()).isEqualTo("발표자료");
+    }
+
+    @Test
+    @DisplayName("[성공] 관리자는 팀에 속하지 않아도 제출 항목을 조회한다.")
+    void 관리자는_팀에_속하지_않아도_제출_항목을_조회한다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+
+        final ContestSubmissionItemResponse response =
+                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId(), admin);
+
+        assertThat(response.name()).isEqualTo("발표자료");
+    }
+
+    @Test
+    @DisplayName("[실패] 해당 대회의 팀에 속하지 않은 회원이면 조회에 실패한다.")
+    void 해당_대회의_팀에_속하지_않은_회원이면_조회에_실패한다() {
+        final ContestSubmissionItem submissionItem =
+                contestSubmissionItemRepository.save(createSubmissionItem(contest, track));
+        final Member outsider = memberRepository.save(MemberFixture.createMemberWithUniqueNum(3));
+
+        assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(
+                contest.getId(), submissionItem.getId(), outsider))
+                .isInstanceOf(TeamMemberException.class)
+                .hasMessage(TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
+    }
+
+    @Test
     @DisplayName("[성공] 전체 분과 제출 항목은 분과 ID가 null로 조회된다.")
     void 전체_분과_제출_항목은_분과_ID가_null로_조회된다() {
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemRepository.save(createSubmissionItem(contest, null));
 
         final ContestSubmissionItemResponse response =
-                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId());
+                contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), submissionItem.getId(), teamLeader);
 
         assertThat(response.contestTrackId()).isNull();
     }
@@ -77,7 +159,7 @@ class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[실패] 존재하지 않는 제출 항목이면 조회에 실패한다.")
     void 존재하지_않는_제출_항목이면_조회에_실패한다() {
-        assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), 999L))
+        assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(contest.getId(), 999L, teamLeader))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(NOT_FOUND_SUBMISSION_ITEM.errorMessage());
     }
@@ -90,7 +172,7 @@ class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
                 contestSubmissionItemRepository.save(createSubmissionItem(otherContest, null));
 
         assertThatThrownBy(() -> contestSubmissionItemQueryService.getSubmissionItem(
-                contest.getId(), submissionItem.getId()))
+                contest.getId(), submissionItem.getId(), teamLeader))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(INVALID_SUBMISSION_ITEM_FOR_CONTEST.errorMessage());
     }

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionItemQueryServiceTest.java
@@ -16,6 +16,7 @@ import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemSummaryResponse;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
 import com.opus.opus.modules.contest.domain.ContestTrack;
@@ -32,6 +33,8 @@ import com.opus.opus.modules.team.domain.dao.TeamMemberRepository;
 import com.opus.opus.modules.team.domain.dao.TeamRepository;
 import com.opus.opus.modules.team.exception.TeamMemberException;
 import com.opus.opus.team.TeamFixture;
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -175,5 +178,90 @@ class ContestSubmissionItemQueryServiceTest extends IntegrationTest {
                 contest.getId(), submissionItem.getId(), teamLeader))
                 .isInstanceOf(ContestSubmissionItemException.class)
                 .hasMessage(INVALID_SUBMISSION_ITEM_FOR_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 항목 목록을 최신 수정 순으로 조회한다.")
+    void 제출_항목_목록을_최신_수정_순으로_조회한다() {
+        final LocalDateTime now = LocalDateTime.now();
+        final ContestSubmissionItem first = contestSubmissionItemRepository.saveAndFlush(
+                createSubmissionItem(contest, track, "발표자료", now.minusDays(1), now.plusDays(1)));
+        final ContestSubmissionItem second = contestSubmissionItemRepository.saveAndFlush(
+                createSubmissionItem(contest, track, "포스터", now.minusDays(1), now.plusDays(1)));
+
+        final List<ContestSubmissionItemSummaryResponse> responses =
+                contestSubmissionItemQueryService.getSubmissionItems(contest.getId(), null);
+
+        assertThat(responses).extracting(ContestSubmissionItemSummaryResponse::contestSubmissionItemId)
+                .containsExactly(second.getId(), first.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 시작 전 제출 항목은 운영 상태가 SCHEDULED로 조회된다.")
+    void 시작_전_제출_항목은_운영_상태가_SCHEDULED로_조회된다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contestSubmissionItemRepository.save(
+                createSubmissionItem(contest, track, "발표자료", now.plusDays(1), now.plusDays(2)));
+
+        final List<ContestSubmissionItemSummaryResponse> responses =
+                contestSubmissionItemQueryService.getSubmissionItems(contest.getId(), null);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).operationStatus()).isEqualTo("SCHEDULED");
+    }
+
+    @Test
+    @DisplayName("[성공] 진행 중인 제출 항목은 운영 상태가 IN_PROGRESS로 조회된다.")
+    void 진행_중인_제출_항목은_운영_상태가_IN_PROGRESS로_조회된다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contestSubmissionItemRepository.save(
+                createSubmissionItem(contest, track, "발표자료", now.minusDays(1), now.plusDays(1)));
+
+        final List<ContestSubmissionItemSummaryResponse> responses =
+                contestSubmissionItemQueryService.getSubmissionItems(contest.getId(), null);
+
+        assertThat(responses.get(0).operationStatus()).isEqualTo("IN_PROGRESS");
+    }
+
+    @Test
+    @DisplayName("[성공] 마감된 제출 항목은 운영 상태가 CLOSED로 조회된다.")
+    void 마감된_제출_항목은_운영_상태가_CLOSED로_조회된다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contestSubmissionItemRepository.save(
+                createSubmissionItem(contest, track, "발표자료", now.minusDays(2), now.minusDays(1)));
+
+        final List<ContestSubmissionItemSummaryResponse> responses =
+                contestSubmissionItemQueryService.getSubmissionItems(contest.getId(), null);
+
+        assertThat(responses.get(0).operationStatus()).isEqualTo("CLOSED");
+    }
+
+    @Test
+    @DisplayName("[성공] 운영 상태로 필터링하여 제출 항목 목록을 조회한다.")
+    void 운영_상태로_필터링하여_제출_항목_목록을_조회한다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contestSubmissionItemRepository.save(
+                createSubmissionItem(contest, track, "진행중", now.minusDays(1), now.plusDays(1)));
+        contestSubmissionItemRepository.save(
+                createSubmissionItem(contest, track, "마감", now.minusDays(2), now.minusDays(1)));
+
+        final List<ContestSubmissionItemSummaryResponse> responses =
+                contestSubmissionItemQueryService.getSubmissionItems(contest.getId(), "IN_PROGRESS");
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).name()).isEqualTo("진행중");
+    }
+
+    @Test
+    @DisplayName("[성공] 전체 분과 제출 항목은 분과명이 null로 조회된다.")
+    void 전체_분과_제출_항목은_분과명이_null로_조회된다() {
+        final LocalDateTime now = LocalDateTime.now();
+        contestSubmissionItemRepository.save(
+                createSubmissionItem(contest, null, "발표자료", now.minusDays(1), now.plusDays(1)));
+
+        final List<ContestSubmissionItemSummaryResponse> responses =
+                contestSubmissionItemQueryService.getSubmissionItems(contest.getId(), null);
+
+        assertThat(responses.get(0).trackName()).isNull();
     }
 }

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -25,6 +25,7 @@ import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
 import com.opus.opus.modules.contest.application.ContestSubmissionQueryService;
 import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
+import com.opus.opus.modules.contest.application.ContestSubmissionItemQueryService;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackQueryService;
 import com.opus.opus.modules.member.api.MemberController;
@@ -153,6 +154,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected ContestSubmissionItemCommandService contestSubmissionItemCommandService;
+
+    @MockitoBean
+    protected ContestSubmissionItemQueryService contestSubmissionItemQueryService;
 
     // Setting
     @Autowired

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -12,6 +12,7 @@ import com.opus.opus.modules.contest.api.ContestCategoryController;
 import com.opus.opus.modules.contest.api.ContestController;
 import com.opus.opus.modules.contest.api.ContestMemberController;
 import com.opus.opus.modules.contest.api.ContestSubmissionFeedbackController;
+import com.opus.opus.modules.contest.api.ContestSubmissionItemController;
 import com.opus.opus.modules.contest.api.ContestTrackController;
 import com.opus.opus.modules.contest.application.ContestCategoryCommandService;
 import com.opus.opus.modules.contest.application.ContestSubmissionFeedbackCommandService;
@@ -23,6 +24,7 @@ import com.opus.opus.modules.contest.application.ContestMemberQueryService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
 import com.opus.opus.modules.contest.application.ContestSubmissionQueryService;
+import com.opus.opus.modules.contest.application.ContestSubmissionItemCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackQueryService;
 import com.opus.opus.modules.member.api.MemberController;
@@ -70,6 +72,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
         ContestTrackController.class,
         ContestMemberController.class,
         ContestSubmissionFeedbackController.class,
+        ContestSubmissionItemController.class,
 })
 @Import(RestDocsConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -147,6 +150,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected ContestSubmissionFeedbackQueryService contestSubmissionFeedbackQueryService;
+
+    @MockitoBean
+    protected ContestSubmissionItemCommandService contestSubmissionItemCommandService;
 
     // Setting
     @Autowired

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -5,6 +5,7 @@ import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.ZIP;
 import static com.opus.opus.modules.contest.domain.SubmissionVisibility.PUBLIC;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
@@ -22,6 +23,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.opus.opus.global.security.annotation.LoginMember;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
@@ -47,6 +49,11 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
     void setUp() {
         this.admin = MemberFixture.createMember();
         setField(admin, "id", 1L);
+
+        when(memberArgumentResolver.supportsParameter(
+                argThat(param -> param != null && param.hasParameterAnnotation(LoginMember.class))))
+                .thenReturn(true);
+        when(memberArgumentResolver.resolveArgument(any(), any(), any(), any())).thenReturn(admin);
 
         request = new ContestSubmissionItemRequest(
                 "발표자료", 1L, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
@@ -144,7 +151,7 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
                 "발표자료", 1L, "PDF 형식의 발표자료를 제출하세요.", List.of("PDF", "ZIP"),
                 50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, "PUBLIC");
 
-        when(contestSubmissionItemQueryService.getSubmissionItem(any(), any())).thenReturn(response);
+        when(contestSubmissionItemQueryService.getSubmissionItem(any(), any(), any())).thenReturn(response);
 
         mockMvc.perform(get("/contests/{contestId}/submission-items/{submissionItemId}", 1, 1)
                         .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
@@ -155,7 +162,8 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
                                 parameterWithName("submissionItemId").description("제출 항목 ID")
                         ),
                         requestHeaders(
-                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                                headerWithName(HttpHeaders.AUTHORIZATION)
+                                        .description("Bearer {accessToken} (관리자 또는 해당 대회의 팀장/팀원)")
                         ),
                         responseFields(
                                 stringFieldWithPath("name", "제출물 종류 이름"),

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -1,5 +1,7 @@
 package com.opus.opus.restdocs.docs;
 
+import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequest;
+import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequestWithPeriod;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
@@ -14,7 +16,6 @@ import static org.springframework.restdocs.request.RequestDocumentation.pathPara
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.opus.opus.contest.ContestSubmissionItemFixture;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
@@ -39,7 +40,7 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
         this.admin = MemberFixture.createMember();
         setField(admin, "id", 1L);
 
-        request = ContestSubmissionItemFixture.createRequest(1L);
+        request = createRequest(1L);
     }
 
     @Test
@@ -77,7 +78,7 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
     @Test
     @DisplayName("[실패] 시작일시가 마감일시보다 이후면 에러를 반환한다.")
     void 시작일시가_마감일시보다_이후면_에러를_반환한다() throws Exception {
-        final ContestSubmissionItemRequest invalidRequest = ContestSubmissionItemFixture.createRequestWithPeriod(
+        final ContestSubmissionItemRequest invalidRequest = createRequestWithPeriod(
                 LocalDateTime.of(2026, 8, 1, 0, 0),
                 LocalDateTime.of(2026, 7, 1, 0, 0)
         );

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
@@ -109,6 +110,25 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
                                 dateTimeFieldWithPath("endAt", "마감일시"),
                                 booleanFieldWithPath("allowLateSubmission", "지각 제출 허용 여부"),
                                 stringFieldWithPath("visibility", "공개 범위 (SubmissionVisibility)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 제출 항목 삭제는 성공한다.")
+    void 유효한_요청이면_제출_항목_삭제는_성공한다() throws Exception {
+        doNothing().when(contestSubmissionItemCommandService).deleteSubmissionItem(any(), any());
+
+        mockMvc.perform(delete("/contests/{contestId}/submission-items/{submissionItemId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-submission-item",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionItemId").description("제출 항목 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -7,13 +7,16 @@ import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExcep
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -21,6 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.restdocs.RestDocsTest;
@@ -129,6 +133,41 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
                         ),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 제출 항목 설정값 조회는 성공한다.")
+    void 유효한_요청이면_제출_항목_설정값_조회는_성공한다() throws Exception {
+        final ContestSubmissionItemResponse response = new ContestSubmissionItemResponse(
+                "발표자료", 1L, "PDF 형식의 발표자료를 제출하세요.", List.of("PDF", "ZIP"),
+                50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, "PUBLIC");
+
+        when(contestSubmissionItemQueryService.getSubmissionItem(any(), any())).thenReturn(response);
+
+        mockMvc.perform(get("/contests/{contestId}/submission-items/{submissionItemId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("get-submission-item",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionItemId").description("제출 항목 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        responseFields(
+                                stringFieldWithPath("name", "제출물 종류 이름"),
+                                numberFieldWithPath("contestTrackId", "대상 분과 ID (전체 분과면 null)").optional(),
+                                stringFieldWithPath("description", "설명").optional(),
+                                arrayFieldWithPath("allowedFileFormats", "허용 파일 형식 목록 (SubmissionFileFormat)"),
+                                numberFieldWithPath("maxFileSizeMb", "파일 크기 제한 (MB)"),
+                                numberFieldWithPath("maxFileCount", "파일 수 제한"),
+                                dateTimeFieldWithPath("startAt", "시작일시"),
+                                dateTimeFieldWithPath("endAt", "마감일시"),
+                                booleanFieldWithPath("allowLateSubmission", "지각 제출 허용 여부"),
+                                stringFieldWithPath("visibility", "공개 범위 (SubmissionVisibility)")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -1,7 +1,8 @@
 package com.opus.opus.restdocs.docs;
 
-import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequest;
-import static com.opus.opus.contest.ContestSubmissionItemFixture.createRequestWithPeriod;
+import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.PDF;
+import static com.opus.opus.modules.contest.domain.SubmissionFileFormat.ZIP;
+import static com.opus.opus.modules.contest.domain.SubmissionVisibility.PUBLIC;
 import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.willThrow;
@@ -9,6 +10,7 @@ import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
@@ -22,6 +24,7 @@ import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.restdocs.RestDocsTest;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -40,7 +43,9 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
         this.admin = MemberFixture.createMember();
         setField(admin, "id", 1L);
 
-        request = createRequest(1L);
+        request = new ContestSubmissionItemRequest(
+                "발표자료", 1L, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59), true, PUBLIC);
     }
 
     @Test
@@ -76,12 +81,44 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("[성공] 유효한 요청이면 제출 항목 수정은 성공한다.")
+    void 유효한_요청이면_제출_항목_수정은_성공한다() throws Exception {
+        doNothing().when(contestSubmissionItemCommandService).updateSubmissionItem(any(), any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/submission-items/{submissionItemId}", 1, 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-submission-item",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionItemId").description("제출 항목 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("name", "제출물 종류 이름"),
+                                numberFieldWithPath("contestTrackId", "대상 분과 ID (생략 시 전체 분과)").optional(),
+                                stringFieldWithPath("description", "설명").optional(),
+                                arrayFieldWithPath("allowedFileFormats", "허용 파일 형식 목록 (SubmissionFileFormat)"),
+                                numberFieldWithPath("maxFileSizeMb", "파일 크기 제한 (MB)"),
+                                numberFieldWithPath("maxFileCount", "파일 수 제한"),
+                                dateTimeFieldWithPath("startAt", "시작일시"),
+                                dateTimeFieldWithPath("endAt", "마감일시"),
+                                booleanFieldWithPath("allowLateSubmission", "지각 제출 허용 여부"),
+                                stringFieldWithPath("visibility", "공개 범위 (SubmissionVisibility)")
+                        )
+                ));
+    }
+
+    @Test
     @DisplayName("[실패] 시작일시가 마감일시보다 이후면 에러를 반환한다.")
     void 시작일시가_마감일시보다_이후면_에러를_반환한다() throws Exception {
-        final ContestSubmissionItemRequest invalidRequest = createRequestWithPeriod(
-                LocalDateTime.of(2026, 8, 1, 0, 0),
-                LocalDateTime.of(2026, 7, 1, 0, 0)
-        );
+        final ContestSubmissionItemRequest invalidRequest = new ContestSubmissionItemRequest(
+                "발표자료", null, "PDF 형식의 발표자료를 제출하세요.", List.of(PDF, ZIP),
+                50, 3, LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 7, 1, 0, 0), true, PUBLIC);
 
         willThrow(new ContestSubmissionItemException(INVALID_SUBMISSION_PERIOD))
                 .given(contestSubmissionItemCommandService).createSubmissionItem(any(), any());

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -1,0 +1,114 @@
+package com.opus.opus.restdocs.docs;
+
+import static com.opus.opus.modules.contest.exception.ContestSubmissionItemExceptionType.INVALID_SUBMISSION_PERIOD;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.contest.ContestSubmissionItemFixture;
+import com.opus.opus.member.MemberFixture;
+import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
+import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.restdocs.RestDocsTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
+
+    private static final String ADMIN_TOKEN = "Bearer admin.access.token";
+
+    private Member admin;
+    private ContestSubmissionItemRequest request;
+
+    @BeforeEach
+    void setUp() {
+        this.admin = MemberFixture.createMember();
+        setField(admin, "id", 1L);
+
+        request = ContestSubmissionItemFixture.createRequest(1L);
+    }
+
+    @Test
+    @DisplayName("[성공] 유효한 요청이면 제출 항목 생성은 성공한다.")
+    void 유효한_요청이면_제출_항목_생성은_성공한다() throws Exception {
+        doNothing().when(contestSubmissionItemCommandService).createSubmissionItem(any(), any());
+
+        mockMvc.perform(post("/contests/{contestId}/submission-items", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("create-submission-item",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("name", "제출물 종류 이름"),
+                                numberFieldWithPath("contestTrackId", "대상 분과 ID (생략 시 전체 분과)").optional(),
+                                stringFieldWithPath("description", "설명").optional(),
+                                arrayFieldWithPath("allowedFileFormats", "허용 파일 형식 목록 (SubmissionFileFormat)"),
+                                numberFieldWithPath("maxFileSizeMb", "파일 크기 제한 (MB)"),
+                                numberFieldWithPath("maxFileCount", "파일 수 제한"),
+                                dateTimeFieldWithPath("startAt", "시작일시"),
+                                dateTimeFieldWithPath("endAt", "마감일시"),
+                                booleanFieldWithPath("allowLateSubmission", "지각 제출 허용 여부"),
+                                stringFieldWithPath("visibility", "공개 범위 (SubmissionVisibility)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 시작일시가 마감일시보다 이후면 에러를 반환한다.")
+    void 시작일시가_마감일시보다_이후면_에러를_반환한다() throws Exception {
+        final ContestSubmissionItemRequest invalidRequest = ContestSubmissionItemFixture.createRequestWithPeriod(
+                LocalDateTime.of(2026, 8, 1, 0, 0),
+                LocalDateTime.of(2026, 7, 1, 0, 0)
+        );
+
+        willThrow(new ContestSubmissionItemException(INVALID_SUBMISSION_PERIOD))
+                .given(contestSubmissionItemCommandService).createSubmissionItem(any(), any());
+
+        mockMvc.perform(post("/contests/{contestId}/submission-items", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest)))
+                .andExpect(status().isBadRequest())
+                .andDo(document("create-submission-item-fail",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                stringFieldWithPath("name", "제출물 종류 이름"),
+                                numberFieldWithPath("contestTrackId", "대상 분과 ID (생략 시 전체 분과)").optional(),
+                                stringFieldWithPath("description", "설명").optional(),
+                                arrayFieldWithPath("allowedFileFormats", "허용 파일 형식 목록 (SubmissionFileFormat)"),
+                                numberFieldWithPath("maxFileSizeMb", "파일 크기 제한 (MB)"),
+                                numberFieldWithPath("maxFileCount", "파일 수 제한"),
+                                dateTimeFieldWithPath("startAt", "시작일시 (마감일시보다 이후)"),
+                                dateTimeFieldWithPath("endAt", "마감일시"),
+                                booleanFieldWithPath("allowLateSubmission", "지각 제출 허용 여부"),
+                                stringFieldWithPath("visibility", "공개 범위 (SubmissionVisibility)")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionItemApiDocsTest.java
@@ -20,6 +20,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.requestF
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -27,6 +28,7 @@ import com.opus.opus.global.security.annotation.LoginMember;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.dto.request.ContestSubmissionItemRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionItemSummaryResponse;
 import com.opus.opus.modules.contest.exception.ContestSubmissionItemException;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.restdocs.RestDocsTest;
@@ -140,6 +142,48 @@ public class ContestSubmissionItemApiDocsTest extends RestDocsTest {
                         ),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 항목 목록 조회는 성공한다.")
+    void 제출_항목_목록_조회는_성공한다() throws Exception {
+        final List<ContestSubmissionItemSummaryResponse> responses = List.of(
+                new ContestSubmissionItemSummaryResponse(1L, "발표자료", "AI 분과",
+                        LocalDateTime.of(2026, 7, 1, 0, 0), LocalDateTime.of(2026, 7, 31, 23, 59),
+                        true, "PUBLIC", "IN_PROGRESS"),
+                new ContestSubmissionItemSummaryResponse(2L, "포스터", null,
+                        LocalDateTime.of(2026, 8, 1, 0, 0), LocalDateTime.of(2026, 8, 31, 23, 59),
+                        false, "PRIVATE", "SCHEDULED"));
+
+        when(contestSubmissionItemQueryService.getSubmissionItems(any(), any())).thenReturn(responses);
+
+        mockMvc.perform(get("/contests/{contestId}/submission-items", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .param("status", "IN_PROGRESS"))
+                .andExpect(status().isOk())
+                .andDo(document("get-submission-items",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("status").optional()
+                                        .description("운영 상태 필터 (SCHEDULED, IN_PROGRESS, CLOSED)")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        responseFields(
+                                arrayFieldWithPath("[]", "제출 항목 목록"),
+                                numberFieldWithPath("[].contestSubmissionItemId", "제출물 ID"),
+                                stringFieldWithPath("[].name", "제출물 종류 이름"),
+                                stringFieldWithPath("[].trackName", "대상 분과명 (전체 분과면 null)").optional(),
+                                dateTimeFieldWithPath("[].startAt", "시작일시"),
+                                dateTimeFieldWithPath("[].endAt", "마감일시"),
+                                booleanFieldWithPath("[].allowLateSubmission", "지각 제출 허용 여부"),
+                                stringFieldWithPath("[].visibility", "공개 범위 (SubmissionVisibility)"),
+                                stringFieldWithPath("[].operationStatus", "운영 상태 (SCHEDULED, IN_PROGRESS, CLOSED)")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #174 

## 📜 작업 내용

- 제출 항목 목록 조회 API 개발
- 제출 항목 추가 API 개발
- 제출 항목 수정 API 개발
- 제출 항목 삭제 API 개발
- 제출 항목의 설정값 조회 API 개발

## 💬 리뷰 요구사항

- 개발하고보니, 제가 기록을 잘못해뒀는지 제출 항목이 태윤님 작업과 관련있는 것으로 생각하고 먼저 작업했는데.. related issue tagging 하려고 보니까 역할 배정이 먼저였군요?!
  - 이 부분은 내일 늦은 저녁(지금 시간과 비슷한 때) 올리겠습니다ㅠㅠ

## ✨ 기타

- 오늘은 금요일✨
