### PR TITLE
Feature/#153 교수 멘토 배정 관련 기능 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
@@ -73,3 +73,19 @@ include::{snippets}/update-contest-member/request-fields.adoc[]
 
 .HTTP Response
 include::{snippets}/update-contest-member/http-response.adoc[]
+
+== `DELETE`: 배정 삭제
+
+해당 배정을 삭제하여 회원의 모든 담당 팀 배정을 제거한다.
+
+.HTTP Request Headers
+include::{snippets}/delete-contest-member/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/delete-contest-member/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/delete-contest-member/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/delete-contest-member/http-response.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
@@ -35,3 +35,22 @@ include::{snippets}/get-contest-member/http-response.adoc[]
 
 .Response Body's Fields
 include::{snippets}/get-contest-member/response-fields.adoc[]
+
+== `POST`: 일괄 배정
+
+여러 교수/외부멘토를 동일한 담당 팀 목록으로 한 번에 배정한다.
+
+.HTTP Request Headers
+include::{snippets}/assign-contest-member/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/assign-contest-member/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/assign-contest-member/http-request.adoc[]
+
+.Request Fields
+include::{snippets}/assign-contest-member/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/assign-contest-member/http-response.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
@@ -1,0 +1,37 @@
+ifndef::snippets[]
+:snippets: ./build/generated-snippets
+endif::[]
+
+= CONTEST MEMBER API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 3
+:sectnums:
+
+== API 목록
+
+link:./opus.html[API 목록으로 돌아가기]
+
+== `GET`: 배정 목록 조회
+
+교수/외부멘토 별 배정된 팀 리스트를 조회한다.
+
+.HTTP Request Headers
+include::{snippets}/get-contest-member/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/get-contest-member/path-parameters.adoc[]
+
+.Query Parameters
+include::{snippets}/get-contest-member/query-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/get-contest-member/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/get-contest-member/http-response.adoc[]
+
+.Response Body's Fields
+include::{snippets}/get-contest-member/response-fields.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/contest-member.adoc
@@ -54,3 +54,22 @@ include::{snippets}/assign-contest-member/request-fields.adoc[]
 
 .HTTP Response
 include::{snippets}/assign-contest-member/http-response.adoc[]
+
+== `PATCH`: 배정 팀 수정
+
+배정된 담당 팀 목록을 추가/삭제하여 수정한다.
+
+.HTTP Request Headers
+include::{snippets}/update-contest-member/request-headers.adoc[]
+
+.Path Parameters
+include::{snippets}/update-contest-member/path-parameters.adoc[]
+
+.HTTP Request
+include::{snippets}/update-contest-member/http-request.adoc[]
+
+.Request Fields
+include::{snippets}/update-contest-member/request-fields.adoc[]
+
+.HTTP Response
+include::{snippets}/update-contest-member/http-response.adoc[]

--- a/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/opus.adoc
@@ -34,3 +34,5 @@ link:./contest.html[대회 API]
 link:./contest-category.html[대회 카테고리 API]
 
 link:./contest-track.html[대회 분과 API]
+
+link:./contest-member.html[대회 배정(교수/외부멘토) API]

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
@@ -1,0 +1,31 @@
+package com.opus.opus.modules.contest.api;
+
+import com.opus.opus.modules.contest.application.ContestMemberQueryService;
+import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Validated
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/contests/{contestId}/staff")
+public class ContestMemberController {
+
+    private final ContestMemberQueryService contestMemberQueryService;
+
+    @Secured("ROLE_관리자")
+    @GetMapping
+    public ResponseEntity<List<ContestStaffResponse>> getAssignedStaff(@PathVariable final Long contestId,
+                                                                       @RequestParam(required = false) final String memberType,
+                                                                       @RequestParam(required = false) final String search) {
+        return ResponseEntity.ok(contestMemberQueryService.getAssignedStaff(contestId, memberType, search));
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
@@ -12,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -52,6 +53,14 @@ public class ContestMemberController {
                                                     @PathVariable final Long contestMemberId,
                                                     @Valid @RequestBody final StaffTeamUpdateRequest request) {
         contestMemberCommandService.updateAssignedTeams(contestId, contestMemberId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Secured("ROLE_관리자")
+    @DeleteMapping("/{contestMemberId}")
+    public ResponseEntity<Void> deleteAssignment(@PathVariable final Long contestId,
+                                                 @PathVariable final Long contestMemberId) {
+        contestMemberCommandService.deleteAssignment(contestId, contestMemberId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
@@ -3,6 +3,7 @@ package com.opus.opus.modules.contest.api;
 import com.opus.opus.modules.contest.application.ContestMemberCommandService;
 import com.opus.opus.modules.contest.application.ContestMemberQueryService;
 import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
+import com.opus.opus.modules.contest.application.dto.request.StaffTeamUpdateRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -42,5 +44,14 @@ public class ContestMemberController {
                                             @Valid @RequestBody final StaffBatchAssignRequest request) {
         contestMemberCommandService.assignStaff(contestId, request);
         return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @Secured("ROLE_관리자")
+    @PatchMapping("/{contestMemberId}")
+    public ResponseEntity<Void> updateAssignedTeams(@PathVariable final Long contestId,
+                                                    @PathVariable final Long contestMemberId,
+                                                    @Valid @RequestBody final StaffTeamUpdateRequest request) {
+        contestMemberCommandService.updateAssignedTeams(contestId, contestMemberId, request);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestMemberController.java
@@ -1,14 +1,20 @@
 package com.opus.opus.modules.contest.api;
 
+import com.opus.opus.modules.contest.application.ContestMemberCommandService;
 import com.opus.opus.modules.contest.application.ContestMemberQueryService;
+import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -20,6 +26,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ContestMemberController {
 
     private final ContestMemberQueryService contestMemberQueryService;
+    private final ContestMemberCommandService contestMemberCommandService;
 
     @Secured("ROLE_관리자")
     @GetMapping
@@ -27,5 +34,13 @@ public class ContestMemberController {
                                                                        @RequestParam(required = false) final String memberType,
                                                                        @RequestParam(required = false) final String search) {
         return ResponseEntity.ok(contestMemberQueryService.getAssignedStaff(contestId, memberType, search));
+    }
+
+    @Secured("ROLE_관리자")
+    @PostMapping("/batch")
+    public ResponseEntity<Void> assignStaff(@PathVariable final Long contestId,
+                                            @Valid @RequestBody final StaffBatchAssignRequest request) {
+        contestMemberCommandService.assignStaff(contestId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -2,10 +2,12 @@ package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_FOUND_CONTEST_MEMBER;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
+import com.opus.opus.modules.contest.application.dto.request.StaffTeamUpdateRequest;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestMember;
 import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
@@ -37,6 +39,19 @@ public class ContestMemberCommandService {
         validateTeams(contestId, request.teamIds());
         validateNotAlreadyAssigned(contestId, request.memberIds());
         saveAssignments(contest, request);
+    }
+
+    public void updateAssignedTeams(final Long contestId, final Long contestMemberId,
+                                    final StaffTeamUpdateRequest request) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestMember contestMember = getContestMember(contestId, contestMemberId);
+        validateTeams(contestId, request.addTeamIds());
+        contestMember.updateTeams(request.addTeamIds(), request.deleteTeamIds());
+    }
+
+    private ContestMember getContestMember(final Long contestId, final Long contestMemberId) {
+        return contestMemberRepository.findByIdAndContestId(contestMemberId, contestId)
+                .orElseThrow(() -> new ContestMemberException(NOT_FOUND_CONTEST_MEMBER));
     }
 
     private void validateMembers(final List<Long> memberIds) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.DUPLICATE_MEMBER;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_MEMBER_TYPE;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_FOUND_CONTEST_MEMBER;
@@ -22,6 +23,7 @@ import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.exception.TeamException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,6 +40,7 @@ public class ContestMemberCommandService {
 
     public void assignStaff(final Long contestId, final StaffBatchAssignRequest request) {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        validateNoDuplicateMembers(request.memberIds());
         validateMembers(request.memberIds());
         validateTeams(contestId, request.teamIds());
         validateNotAlreadyAssigned(contestId, request.memberIds());
@@ -61,6 +64,12 @@ public class ContestMemberCommandService {
     private ContestMember getContestMember(final Long contestId, final Long contestMemberId) {
         return contestMemberRepository.findByIdAndContestId(contestMemberId, contestId)
                 .orElseThrow(() -> new ContestMemberException(NOT_FOUND_CONTEST_MEMBER));
+    }
+
+    private void validateNoDuplicateMembers(final List<Long> memberIds) {
+        if (memberIds.size() != Set.copyOf(memberIds).size()) {
+            throw new ContestMemberException(DUPLICATE_MEMBER);
+        }
     }
 
     private void validateMembers(final List<Long> memberIds) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -20,7 +20,6 @@ import com.opus.opus.modules.member.exception.MemberException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.exception.TeamException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -111,7 +110,7 @@ public class ContestMemberCommandService {
         return ContestMember.builder()
                 .contest(contest)
                 .memberId(memberId)
-                .teamIds(new ArrayList<>(teamIds))
+                .teamIds(teamIds)
                 .build();
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -3,10 +3,8 @@ package com.opus.opus.modules.contest.application;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.DUPLICATE_MEMBER;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_MEMBER_TYPE;
-import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_FOUND_CONTEST_MEMBER;
 import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
-import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
@@ -19,8 +17,6 @@ import com.opus.opus.modules.member.application.convenience.MemberConvenience;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.member.exception.MemberException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
-import com.opus.opus.modules.team.domain.Team;
-import com.opus.opus.modules.team.exception.TeamException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +38,7 @@ public class ContestMemberCommandService {
         final Contest contest = contestConvenience.getValidateExistContest(contestId);
         validateNoDuplicateMembers(request.memberIds());
         validateMembers(request.memberIds());
-        validateTeams(contestId, request.teamIds());
+        teamConvenience.validateTeamsInContest(contestId, request.teamIds());
         validateNotAlreadyAssigned(contestId, request.memberIds());
         saveAssignments(contest, request);
     }
@@ -51,7 +47,7 @@ public class ContestMemberCommandService {
                                     final StaffTeamUpdateRequest request) {
         contestConvenience.validateExistContest(contestId);
         final ContestMember contestMember = getContestMember(contestId, contestMemberId);
-        validateTeams(contestId, request.addTeamIds());
+        teamConvenience.validateTeamsInContest(contestId, request.addTeamIds());
         contestMember.updateTeams(request.addTeamIds(), request.deleteTeamIds());
     }
 
@@ -83,20 +79,6 @@ public class ContestMemberCommandService {
         }
         if (!member.hasStaffRole()) {
             throw new ContestMemberException(INVALID_MEMBER_TYPE);
-        }
-    }
-
-    private void validateTeams(final Long contestId, final List<Long> teamIds) {
-        final Map<Long, Team> teams = teamConvenience.getTeamsByIds(teamIds);
-        teamIds.forEach(teamId -> validateTeamInContest(contestId, teams.get(teamId)));
-    }
-
-    private void validateTeamInContest(final Long contestId, final Team team) {
-        if (team == null) {
-            throw new TeamException(NOT_FOUND_TEAM);
-        }
-        if (!team.getContestId().equals(contestId)) {
-            throw new ContestMemberException(INVALID_TEAM_FOR_CONTEST);
         }
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -1,0 +1,82 @@
+package com.opus.opus.modules.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestMember;
+import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
+import com.opus.opus.modules.contest.exception.ContestMemberException;
+import com.opus.opus.modules.member.application.convenience.MemberConvenience;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.exception.TeamException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ContestMemberCommandService {
+
+    private final ContestMemberRepository contestMemberRepository;
+    private final ContestConvenience contestConvenience;
+    private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
+
+    public void assignStaff(final Long contestId, final StaffBatchAssignRequest request) {
+        final Contest contest = contestConvenience.getValidateExistContest(contestId);
+        validateMembers(request.memberIds());
+        validateTeams(contestId, request.teamIds());
+        validateNotAlreadyAssigned(contestId, request.memberIds());
+        saveAssignments(contest, request);
+    }
+
+    private void validateMembers(final List<Long> memberIds) {
+        memberIds.forEach(memberConvenience::validateExistMember);
+    }
+
+    private void validateTeams(final Long contestId, final List<Long> teamIds) {
+        final Map<Long, Team> teams = teamConvenience.getTeamsByIds(teamIds);
+        teamIds.forEach(teamId -> validateTeamInContest(contestId, teams.get(teamId)));
+    }
+
+    private void validateTeamInContest(final Long contestId, final Team team) {
+        if (team == null) {
+            throw new TeamException(NOT_FOUND_TEAM);
+        }
+        if (!team.getContestId().equals(contestId)) {
+            throw new ContestMemberException(INVALID_TEAM_FOR_CONTEST);
+        }
+    }
+
+    private void validateNotAlreadyAssigned(final Long contestId, final List<Long> memberIds) {
+        memberIds.forEach(memberId -> {
+            if (contestMemberRepository.existsByContestIdAndMemberId(contestId, memberId)) {
+                throw new ContestMemberException(ALREADY_ASSIGNED_MEMBER);
+            }
+        });
+    }
+
+    private void saveAssignments(final Contest contest, final StaffBatchAssignRequest request) {
+        final List<ContestMember> contestMembers = request.memberIds().stream()
+                .map(memberId -> toContestMember(contest, memberId, request.teamIds()))
+                .toList();
+        contestMemberRepository.saveAll(contestMembers);
+    }
+
+    private ContestMember toContestMember(final Contest contest, final Long memberId, final List<Long> teamIds) {
+        return ContestMember.builder()
+                .contest(contest)
+                .memberId(memberId)
+                .teamIds(new ArrayList<>(teamIds))
+                .build();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -1,8 +1,10 @@
 package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_MEMBER_TYPE;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_FOUND_CONTEST_MEMBER;
+import static com.opus.opus.modules.member.exception.MemberExceptionType.NOT_FOUND_MEMBER;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
@@ -13,6 +15,8 @@ import com.opus.opus.modules.contest.domain.ContestMember;
 import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
 import com.opus.opus.modules.contest.exception.ContestMemberException;
 import com.opus.opus.modules.member.application.convenience.MemberConvenience;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.exception.MemberException;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.domain.Team;
 import com.opus.opus.modules.team.exception.TeamException;
@@ -61,7 +65,17 @@ public class ContestMemberCommandService {
     }
 
     private void validateMembers(final List<Long> memberIds) {
-        memberIds.forEach(memberConvenience::validateExistMember);
+        final Map<Long, Member> members = memberConvenience.getMembersByIds(memberIds);
+        memberIds.forEach(memberId -> validateStaffMember(members.get(memberId)));
+    }
+
+    private void validateStaffMember(final Member member) {
+        if (member == null) {
+            throw new MemberException(NOT_FOUND_MEMBER);
+        }
+        if (!member.hasStaffRole()) {
+            throw new ContestMemberException(INVALID_MEMBER_TYPE);
+        }
     }
 
     private void validateTeams(final Long contestId, final List<Long> teamIds) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberCommandService.java
@@ -49,6 +49,12 @@ public class ContestMemberCommandService {
         contestMember.updateTeams(request.addTeamIds(), request.deleteTeamIds());
     }
 
+    public void deleteAssignment(final Long contestId, final Long contestMemberId) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestMember contestMember = getContestMember(contestId, contestMemberId);
+        contestMemberRepository.delete(contestMember);
+    }
+
     private ContestMember getContestMember(final Long contestId, final Long contestMemberId) {
         return contestMemberRepository.findByIdAndContestId(contestMemberId, contestId)
                 .orElseThrow(() -> new ContestMemberException(NOT_FOUND_CONTEST_MEMBER));

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberQueryService.java
@@ -1,8 +1,6 @@
 package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_MEMBER_TYPE;
-import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
-import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
@@ -65,14 +63,10 @@ public class ContestMemberQueryService {
 
     private String resolveRoleType(final Member member) {
         return member.getRoles().stream()
-                .filter(this::isStaffRole)
+                .filter(MemberRoleType::isStaff)
                 .map(Enum::name)
                 .findFirst()
                 .orElse(null);
-    }
-
-    private boolean isStaffRole(final MemberRoleType role) {
-        return role == ROLE_교수 || role == ROLE_외부멘토;
     }
 
     private List<ContestStaffResponse> filterStaff(final List<ContestStaffResponse> staff, final String memberType,

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberQueryService.java
@@ -99,6 +99,14 @@ public class ContestMemberQueryService {
         if (memberType == null || memberType.isBlank()) {
             return null;
         }
+        final MemberRoleType roleType = toMemberRoleType(memberType);
+        if (!roleType.isStaff()) {
+            throw new ContestMemberException(INVALID_MEMBER_TYPE);
+        }
+        return roleType;
+    }
+
+    private MemberRoleType toMemberRoleType(final String memberType) {
         try {
             return MemberRoleType.valueOf(memberType);
         } catch (final IllegalArgumentException exception) {

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMemberQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMemberQueryService.java
@@ -1,0 +1,127 @@
+package com.opus.opus.modules.contest.application;
+
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_MEMBER_TYPE;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
+
+import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
+import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
+import com.opus.opus.modules.contest.domain.ContestMember;
+import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
+import com.opus.opus.modules.contest.exception.ContestMemberException;
+import com.opus.opus.modules.member.application.convenience.MemberConvenience;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.MemberRoleType;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
+import com.opus.opus.modules.team.domain.Team;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContestMemberQueryService {
+
+    private final ContestMemberRepository contestMemberRepository;
+    private final ContestConvenience contestConvenience;
+    private final MemberConvenience memberConvenience;
+    private final TeamConvenience teamConvenience;
+
+    public List<ContestStaffResponse> getAssignedStaff(final Long contestId, final String memberType,
+                                                       final String search) {
+        contestConvenience.validateExistContest(contestId);
+        final List<ContestMember> contestMembers = contestMemberRepository.findAllByContestId(contestId);
+        return filterStaff(toResponses(contestMembers), memberType, search);
+    }
+
+    private List<ContestStaffResponse> toResponses(final List<ContestMember> contestMembers) {
+        final Map<Long, Member> members = memberConvenience.getMembersByIds(extractMemberIds(contestMembers));
+        final Map<Long, Team> teams = teamConvenience.getTeamsByIds(extractTeamIds(contestMembers));
+        return contestMembers.stream()
+                .map(contestMember -> toResponse(contestMember, members, teams))
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private ContestStaffResponse toResponse(final ContestMember contestMember, final Map<Long, Member> members,
+                                            final Map<Long, Team> teams) {
+        final Member member = members.get(contestMember.getMemberId());
+        if (member == null) {
+            return null;
+        }
+        return ContestStaffResponse.of(contestMember, member, mapTeams(contestMember, teams), resolveRoleType(member));
+    }
+
+    private List<Team> mapTeams(final ContestMember contestMember, final Map<Long, Team> teams) {
+        return contestMember.getTeamIds().stream()
+                .map(teams::get)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private String resolveRoleType(final Member member) {
+        return member.getRoles().stream()
+                .filter(this::isStaffRole)
+                .map(Enum::name)
+                .findFirst()
+                .orElse(null);
+    }
+
+    private boolean isStaffRole(final MemberRoleType role) {
+        return role == ROLE_교수 || role == ROLE_외부멘토;
+    }
+
+    private List<ContestStaffResponse> filterStaff(final List<ContestStaffResponse> staff, final String memberType,
+                                                   final String search) {
+        final MemberRoleType roleType = parseMemberType(memberType);
+        return staff.stream()
+                .filter(response -> matchesRole(response, roleType))
+                .filter(response -> matchesSearch(response, search))
+                .toList();
+    }
+
+    private boolean matchesRole(final ContestStaffResponse staff, final MemberRoleType roleType) {
+        return roleType == null || roleType.name().equals(staff.roleType());
+    }
+
+    private boolean matchesSearch(final ContestStaffResponse staff, final String search) {
+        if (search == null || search.isBlank()) {
+            return true;
+        }
+        final String keyword = search.toLowerCase();
+        return staff.name().toLowerCase().contains(keyword) || matchesTeamName(staff, keyword);
+    }
+
+    private boolean matchesTeamName(final ContestStaffResponse staff, final String keyword) {
+        return staff.teams().stream()
+                .anyMatch(team -> team.teamName().toLowerCase().contains(keyword));
+    }
+
+    private MemberRoleType parseMemberType(final String memberType) {
+        if (memberType == null || memberType.isBlank()) {
+            return null;
+        }
+        try {
+            return MemberRoleType.valueOf(memberType);
+        } catch (final IllegalArgumentException exception) {
+            throw new ContestMemberException(INVALID_MEMBER_TYPE);
+        }
+    }
+
+    private List<Long> extractMemberIds(final List<ContestMember> contestMembers) {
+        return contestMembers.stream()
+                .map(ContestMember::getMemberId)
+                .toList();
+    }
+
+    private List<Long> extractTeamIds(final List<ContestMember> contestMembers) {
+        return contestMembers.stream()
+                .flatMap(contestMember -> contestMember.getTeamIds().stream())
+                .distinct()
+                .toList();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/StaffBatchAssignRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/StaffBatchAssignRequest.java
@@ -1,0 +1,14 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record StaffBatchAssignRequest(
+
+        @NotEmpty(message = "배정할 회원을 선택해 주세요.")
+        List<Long> memberIds,
+
+        @NotEmpty(message = "담당 팀을 선택해 주세요.")
+        List<Long> teamIds
+) {
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/request/StaffTeamUpdateRequest.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/request/StaffTeamUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.opus.opus.modules.contest.application.dto.request;
+
+import java.util.List;
+
+public record StaffTeamUpdateRequest(
+
+        List<Long> addTeamIds,
+
+        List<Long> deleteTeamIds
+) {
+
+    public StaffTeamUpdateRequest {
+        addTeamIds = addTeamIds != null ? addTeamIds : List.of();
+        deleteTeamIds = deleteTeamIds != null ? deleteTeamIds : List.of();
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestStaffResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestStaffResponse.java
@@ -1,0 +1,36 @@
+package com.opus.opus.modules.contest.application.dto.response;
+
+import com.opus.opus.modules.contest.domain.ContestMember;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.team.domain.Team;
+import java.util.List;
+
+public record ContestStaffResponse(
+        Long contestMemberId,
+        Long memberId,
+        String name,
+        String email,
+        String roleType,
+        List<TeamInfo> teams
+) {
+    public static ContestStaffResponse of(final ContestMember contestMember, final Member member,
+                                          final List<Team> teams, final String roleType) {
+        return new ContestStaffResponse(
+                contestMember.getId(),
+                member.getId(),
+                member.getName(),
+                member.getEmail(),
+                roleType,
+                teams.stream().map(TeamInfo::from).toList()
+        );
+    }
+
+    public record TeamInfo(
+            Long teamId,
+            String teamName
+    ) {
+        public static TeamInfo from(final Team team) {
+            return new TeamInfo(team.getId(), team.getTeamName());
+        }
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestMember.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestMember.java
@@ -13,7 +13,9 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -55,6 +57,13 @@ public class ContestMember extends BaseEntity {
         this.memberId = memberId;
         this.teamIds = teamIds != null ? teamIds : new ArrayList<>();
         this.isDeleted = false;
+    }
+
+    public void updateTeams(final List<Long> addTeamIds, final List<Long> deleteTeamIds) {
+        final Set<Long> updatedTeamIds = new LinkedHashSet<>(teamIds);
+        updatedTeamIds.addAll(addTeamIds);
+        deleteTeamIds.forEach(updatedTeamIds::remove);
+        this.teamIds = new ArrayList<>(updatedTeamIds);
     }
 
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestMember.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestMember.java
@@ -12,7 +12,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -46,7 +45,7 @@ public class ContestMember extends BaseEntity {
             name = "contest_member_team_ids",
             joinColumns = @JoinColumn(name = "contest_member_id"))
     @Column(name = "team_id", nullable = false)
-    private List<Long> teamIds = new ArrayList<>();
+    private Set<Long> teamIds = new LinkedHashSet<>();
 
     @Column(nullable = false)
     private Boolean isDeleted;
@@ -55,15 +54,13 @@ public class ContestMember extends BaseEntity {
     private ContestMember(final Contest contest, final Long memberId, final List<Long> teamIds) {
         this.contest = contest;
         this.memberId = memberId;
-        this.teamIds = teamIds != null ? teamIds : new ArrayList<>();
+        this.teamIds = teamIds != null ? new LinkedHashSet<>(teamIds) : new LinkedHashSet<>();
         this.isDeleted = false;
     }
 
     public void updateTeams(final List<Long> addTeamIds, final List<Long> deleteTeamIds) {
-        final Set<Long> updatedTeamIds = new LinkedHashSet<>(teamIds);
-        updatedTeamIds.addAll(addTeamIds);
-        deleteTeamIds.forEach(updatedTeamIds::remove);
-        this.teamIds = new ArrayList<>(updatedTeamIds);
+        teamIds.addAll(addTeamIds);
+        deleteTeamIds.forEach(teamIds::remove);
     }
 
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestMember.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestMember.java
@@ -1,0 +1,60 @@
+package com.opus.opus.modules.contest.domain;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+import com.opus.opus.global.base.BaseEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("is_deleted = false")
+@SQLDelete(sql = "UPDATE contest_member SET is_deleted = true WHERE id = ?")
+public class ContestMember extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "contest_id", nullable = false)
+    private Contest contest;
+
+    @Column(nullable = false)
+    private Long memberId;
+
+    @ElementCollection
+    @CollectionTable(
+            name = "contest_member_team_ids",
+            joinColumns = @JoinColumn(name = "contest_member_id"))
+    @Column(name = "team_id", nullable = false)
+    private List<Long> teamIds = new ArrayList<>();
+
+    @Column(nullable = false)
+    private Boolean isDeleted;
+
+    @Builder
+    private ContestMember(final Contest contest, final Long memberId, final List<Long> teamIds) {
+        this.contest = contest;
+        this.memberId = memberId;
+        this.teamIds = teamIds != null ? teamIds : new ArrayList<>();
+        this.isDeleted = false;
+    }
+
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface ContestMemberRepository extends JpaRepository<ContestMember, Long> {
 
     List<ContestMember> findAllByContestId(final Long contestId);
+
+    boolean existsByContestIdAndMemberId(final Long contestId, final Long memberId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
@@ -2,6 +2,7 @@ package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.ContestMember;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestMemberRepository extends JpaRepository<ContestMember, Long> {
@@ -9,4 +10,6 @@ public interface ContestMemberRepository extends JpaRepository<ContestMember, Lo
     List<ContestMember> findAllByContestId(final Long contestId);
 
     boolean existsByContestIdAndMemberId(final Long contestId, final Long memberId);
+
+    Optional<ContestMember> findByIdAndContestId(final Long id, final Long contestId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
@@ -1,0 +1,8 @@
+package com.opus.opus.modules.contest.domain.dao;
+
+import com.opus.opus.modules.contest.domain.ContestMember;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContestMemberRepository extends JpaRepository<ContestMember, Long> {
+
+}

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
@@ -1,8 +1,10 @@
 package com.opus.opus.modules.contest.domain.dao;
 
 import com.opus.opus.modules.contest.domain.ContestMember;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ContestMemberRepository extends JpaRepository<ContestMember, Long> {
 
+    List<ContestMember> findAllByContestId(final Long contestId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberException.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberException.java
@@ -1,0 +1,23 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseException;
+import com.opus.opus.global.base.BaseExceptionType;
+
+public class ContestMemberException extends BaseException {
+    private final ContestMemberExceptionType exceptionType;
+
+    public ContestMemberException(final ContestMemberExceptionType exceptionType) {
+        super(exceptionType.errorMessage());
+        this.exceptionType = exceptionType;
+    }
+
+    public ContestMemberException(final ContestMemberExceptionType exceptionType, final String message) {
+        super(message);
+        this.exceptionType = exceptionType;
+    }
+
+    @Override
+    public BaseExceptionType exceptionType() {
+        return exceptionType;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
@@ -7,7 +7,6 @@ public enum ContestMemberExceptionType implements BaseExceptionType {
 
     INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 회원 유형입니다."),
     DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST, "중복된 회원이 포함되어 있습니다."),
-    INVALID_TEAM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
     ALREADY_ASSIGNED_MEMBER(HttpStatus.CONFLICT, "이미 배정된 회원입니다."),
     NOT_FOUND_CONTEST_MEMBER(HttpStatus.NOT_FOUND, "배정 정보를 찾을 수 없습니다.");
 

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum ContestMemberExceptionType implements BaseExceptionType {
 
     INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 회원 유형입니다."),
+    DUPLICATE_MEMBER(HttpStatus.BAD_REQUEST, "중복된 회원이 포함되어 있습니다."),
     INVALID_TEAM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
     ALREADY_ASSIGNED_MEMBER(HttpStatus.CONFLICT, "이미 배정된 회원입니다."),
     NOT_FOUND_CONTEST_MEMBER(HttpStatus.NOT_FOUND, "배정 정보를 찾을 수 없습니다.");

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
@@ -1,0 +1,27 @@
+package com.opus.opus.modules.contest.exception;
+
+import com.opus.opus.global.base.BaseExceptionType;
+import org.springframework.http.HttpStatus;
+
+public enum ContestMemberExceptionType implements BaseExceptionType {
+
+    INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 회원 유형입니다.");
+
+    private final HttpStatus httpStatus;
+    private final String errorMessage;
+
+    ContestMemberExceptionType(final HttpStatus httpStatus, final String errorMessage) {
+        this.httpStatus = httpStatus;
+        this.errorMessage = errorMessage;
+    }
+
+    @Override
+    public HttpStatus httpStatus() {
+        return httpStatus;
+    }
+
+    @Override
+    public String errorMessage() {
+        return errorMessage;
+    }
+}

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
@@ -5,7 +5,9 @@ import org.springframework.http.HttpStatus;
 
 public enum ContestMemberExceptionType implements BaseExceptionType {
 
-    INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 회원 유형입니다.");
+    INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 회원 유형입니다."),
+    INVALID_TEAM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
+    ALREADY_ASSIGNED_MEMBER(HttpStatus.CONFLICT, "이미 배정된 회원입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestMemberExceptionType.java
@@ -7,7 +7,8 @@ public enum ContestMemberExceptionType implements BaseExceptionType {
 
     INVALID_MEMBER_TYPE(HttpStatus.BAD_REQUEST, "유효하지 않은 회원 유형입니다."),
     INVALID_TEAM_FOR_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
-    ALREADY_ASSIGNED_MEMBER(HttpStatus.CONFLICT, "이미 배정된 회원입니다.");
+    ALREADY_ASSIGNED_MEMBER(HttpStatus.CONFLICT, "이미 배정된 회원입니다."),
+    NOT_FOUND_CONTEST_MEMBER(HttpStatus.NOT_FOUND, "배정 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/opus/opus/modules/member/domain/Member.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/Member.java
@@ -119,6 +119,10 @@ public class Member extends BaseEntity {
         return roles.contains(MemberRoleType.ROLE_관리자);
     }
 
+    public boolean hasStaffRole() {
+        return roles.stream().anyMatch(MemberRoleType::isStaff);
+    }
+
     public void updateGithubUrl(final String githubUrl) {
         this.githubUrl = githubUrl;
     }

--- a/src/main/java/com/opus/opus/modules/member/domain/MemberRoleType.java
+++ b/src/main/java/com/opus/opus/modules/member/domain/MemberRoleType.java
@@ -1,5 +1,6 @@
 package com.opus.opus.modules.member.domain;
 
+import java.util.Set;
 import lombok.Getter;
 
 @Getter
@@ -11,9 +12,15 @@ public enum MemberRoleType {
     ROLE_외부멘토(5),
     ;
 
+    private static final Set<MemberRoleType> STAFF_ROLES = Set.of(ROLE_교수, ROLE_외부멘토);
+
     private final long id;
 
     MemberRoleType(final long id) {
         this.id = id;
+    }
+
+    public boolean isStaff() {
+        return STAFF_ROLES.contains(this);
     }
 }

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -5,6 +5,7 @@ import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_F
 import static com.opus.opus.modules.team.exception.TeamExceptionType.CONTEST_HAS_TEAM;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.TRACK_HAS_TEAM;
+import static java.util.stream.Collectors.toMap;
 
 import com.opus.opus.modules.contest.domain.SortType;
 import com.opus.opus.modules.contest.exception.ContestException;
@@ -16,7 +17,9 @@ import com.opus.opus.modules.team.exception.TeamException;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.function.Function;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,6 +53,11 @@ public class TeamConvenience {
 
     public List<Team> getTeamsOfContest(final Long contestId) {
         return teamRepository.findAllByContestId(contestId);
+    }
+
+    public Map<Long, Team> getTeamsByIds(final List<Long> teamIds) {
+        return teamRepository.findAllById(teamIds).stream()
+                .collect(toMap(Team::getId, Function.identity()));
     }
 
     public Team save(final Team team) {

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -4,6 +4,7 @@ package com.opus.opus.modules.team.application.convenience;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST_SORT;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.CONTEST_HAS_TEAM;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.TEAM_NOT_IN_CONTEST;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.TRACK_HAS_TEAM;
 import static java.util.stream.Collectors.toMap;
 
@@ -62,6 +63,20 @@ public class TeamConvenience {
                         Function.identity(),
                         (existing, replacement) -> existing
                 ));
+    }
+
+    public void validateTeamsInContest(final Long contestId, final List<Long> teamIds) {
+        final Map<Long, Team> teams = getTeamsByIds(teamIds);
+        teamIds.forEach(teamId -> validateTeamInContest(contestId, teams.get(teamId)));
+    }
+
+    private void validateTeamInContest(final Long contestId, final Team team) {
+        if (team == null) {
+            throw new TeamException(NOT_FOUND_TEAM);
+        }
+        if (!team.getContestId().equals(contestId)) {
+            throw new TeamException(TEAM_NOT_IN_CONTEST);
+        }
     }
 
     public Team save(final Team team) {

--- a/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
+++ b/src/main/java/com/opus/opus/modules/team/application/convenience/TeamConvenience.java
@@ -57,7 +57,11 @@ public class TeamConvenience {
 
     public Map<Long, Team> getTeamsByIds(final List<Long> teamIds) {
         return teamRepository.findAllById(teamIds).stream()
-                .collect(toMap(Team::getId, Function.identity()));
+                .collect(toMap(
+                        Team::getId,
+                        Function.identity(),
+                        (existing, replacement) -> existing
+                ));
     }
 
     public Team save(final Team team) {

--- a/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/team/exception/TeamExceptionType.java
@@ -6,6 +6,7 @@ import org.springframework.http.HttpStatus;
 public enum TeamExceptionType implements BaseExceptionType {
 
     NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀이 존재하지 않습니다."),
+    TEAM_NOT_IN_CONTEST(HttpStatus.BAD_REQUEST, "해당 대회에 속하지 않는 팀입니다."),
     CONTEST_HAS_TEAM(HttpStatus.CONFLICT, "해당 대회에 속한 팀이 존재합니다."),
     TRACK_HAS_TEAM(HttpStatus.CONFLICT, "해당 분과에 속한 팀이 존재합니다."),
     REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "팀 상세보기의 필수 항목이 누락되었습니다."),

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -3,6 +3,8 @@ USE opus;
 DROP TABLE IF EXISTS `contest_submission`;
 DROP TABLE IF EXISTS `contest_submission_item_file_formats`;
 DROP TABLE IF EXISTS `contest_submission_item`;
+DROP TABLE IF EXISTS `contest_member_team_ids`;
+DROP TABLE IF EXISTS `contest_member`;
 DROP TABLE IF EXISTS `team_member_roles`;
 DROP TABLE IF EXISTS `team_vote`;
 DROP TABLE IF EXISTS `team_like`;
@@ -124,6 +126,21 @@ CREATE TABLE `contest_submission` (
   `team_id` bigint NOT NULL,
   `contest_submission_item_id` bigint NOT NULL,
   PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `contest_member` (
+  `id` bigint NOT NULL AUTO_INCREMENT,
+  `created_at` datetime(6) DEFAULT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `is_deleted` bit(1) NOT NULL,
+  `member_id` bigint NOT NULL,
+  `contest_id` bigint NOT NULL,
+  PRIMARY KEY (`id`)
+);
+
+CREATE TABLE `contest_member_team_ids` (
+  `contest_member_id` bigint NOT NULL,
+  `team_id` bigint NOT NULL
 );
 
 CREATE TABLE `contest_sort` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -140,7 +140,8 @@ CREATE TABLE `contest_member` (
 
 CREATE TABLE `contest_member_team_ids` (
   `contest_member_id` bigint NOT NULL,
-  `team_id` bigint NOT NULL
+  `team_id` bigint NOT NULL,
+  PRIMARY KEY (`contest_member_id`,`team_id`)
 );
 
 CREATE TABLE `contest_sort` (

--- a/src/test/java/com/opus/opus/contest/ContestMemberFixture.java
+++ b/src/test/java/com/opus/opus/contest/ContestMemberFixture.java
@@ -1,0 +1,18 @@
+package com.opus.opus.contest;
+
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestMember;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ContestMemberFixture {
+
+    public static ContestMember createContestMember(final Contest contest, final Long memberId,
+                                                    final List<Long> teamIds) {
+        return ContestMember.builder()
+                .contest(contest)
+                .memberId(memberId)
+                .teamIds(new ArrayList<>(teamIds))
+                .build();
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
@@ -4,11 +4,11 @@ import static com.opus.opus.contest.ContestMemberFixture.createContestMember;
 import static com.opus.opus.member.MemberFixture.createMemberWithRole;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
-import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_FOUND_CONTEST_MEMBER;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.TEAM_NOT_IN_CONTEST;
 import static com.opus.opus.team.TeamFixture.createTeamWithContestId;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -125,8 +125,8 @@ public class ContestMemberCommandServiceTest extends IntegrationTest {
                 List.of(professor.getId()), List.of(otherTeam.getId()));
 
         assertThatThrownBy(() -> contestMemberCommandService.assignStaff(contest.getId(), request))
-                .isInstanceOf(ContestMemberException.class)
-                .hasMessage(INVALID_TEAM_FOR_CONTEST.errorMessage());
+                .isInstanceOf(TeamException.class)
+                .hasMessage(TEAM_NOT_IN_CONTEST.errorMessage());
     }
 
     @Test
@@ -192,8 +192,8 @@ public class ContestMemberCommandServiceTest extends IntegrationTest {
 
         assertThatThrownBy(
                 () -> contestMemberCommandService.updateAssignedTeams(contest.getId(), contestMember.getId(), request))
-                .isInstanceOf(ContestMemberException.class)
-                .hasMessage(INVALID_TEAM_FOR_CONTEST.errorMessage());
+                .isInstanceOf(TeamException.class)
+                .hasMessage(TEAM_NOT_IN_CONTEST.errorMessage());
     }
 
     @Test

--- a/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
@@ -1,0 +1,141 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.contest.ContestMemberFixture.createContestMember;
+import static com.opus.opus.member.MemberFixture.createMemberWithRole;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
+import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
+import static com.opus.opus.team.TeamFixture.createTeamWithContestId;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestMemberCommandService;
+import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestMember;
+import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestMemberException;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import com.opus.opus.modules.team.exception.TeamException;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContestMemberCommandServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestMemberCommandService contestMemberCommandService;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private ContestMemberRepository contestMemberRepository;
+
+    private Contest contest;
+    private Member professor;
+    private Member mentor;
+    private Team teamA;
+    private Team teamB;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContest());
+        teamA = teamRepository.save(createTeamWithContestId(contest.getId()));
+        teamB = teamRepository.save(createTeamWithContestId(contest.getId()));
+        professor = memberRepository.save(createMemberWithRole("김교수", 1, ROLE_교수));
+        mentor = memberRepository.save(createMemberWithRole("이멘토", 2, ROLE_외부멘토));
+    }
+
+    @Test
+    @DisplayName("[성공] 여러 회원을 동일한 담당 팀으로 일괄 배정한다.")
+    void 여러_회원을_동일한_담당_팀으로_일괄_배정한다() {
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(professor.getId(), mentor.getId()),
+                List.of(teamA.getId(), teamB.getId()));
+
+        contestMemberCommandService.assignStaff(contest.getId(), request);
+
+        final List<ContestMember> assigned = contestMemberRepository.findAllByContestId(contest.getId());
+        assertThat(assigned).hasSize(2);
+        assertThat(assigned)
+                .extracting(ContestMember::getMemberId)
+                .containsExactlyInAnyOrder(professor.getId(), mentor.getId());
+        assertThat(assigned.get(0).getTeamIds())
+                .containsExactlyInAnyOrder(teamA.getId(), teamB.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 회원마다 독립된 담당 팀 목록을 가진다.")
+    void 회원마다_독립된_담당_팀_목록을_가진다() {
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(professor.getId(), mentor.getId()),
+                List.of(teamA.getId()));
+
+        contestMemberCommandService.assignStaff(contest.getId(), request);
+
+        final List<ContestMember> assigned = contestMemberRepository.findAllByContestId(contest.getId());
+        assertThat(assigned).allSatisfy(member -> assertThat(member.getTeamIds()).containsExactly(teamA.getId()));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회에는 배정할 수 없다.")
+    void 존재하지_않는_대회에는_배정할_수_없다() {
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(professor.getId()), List.of(teamA.getId()));
+
+        assertThatThrownBy(() -> contestMemberCommandService.assignStaff(999L, request))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 팀이 포함되면 배정할 수 없다.")
+    void 존재하지_않는_팀이_포함되면_배정할_수_없다() {
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(professor.getId()), List.of(teamA.getId(), 999L));
+
+        assertThatThrownBy(() -> contestMemberCommandService.assignStaff(contest.getId(), request))
+                .isInstanceOf(TeamException.class)
+                .hasMessage(NOT_FOUND_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 대회의 팀으로는 배정할 수 없다.")
+    void 다른_대회의_팀으로는_배정할_수_없다() {
+        final Contest otherContest = contestRepository.save(ContestFixture.createContest());
+        final Team otherTeam = teamRepository.save(createTeamWithContestId(otherContest.getId()));
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(professor.getId()), List.of(otherTeam.getId()));
+
+        assertThatThrownBy(() -> contestMemberCommandService.assignStaff(contest.getId(), request))
+                .isInstanceOf(ContestMemberException.class)
+                .hasMessage(INVALID_TEAM_FOR_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 이미 배정된 회원은 다시 배정할 수 없다.")
+    void 이미_배정된_회원은_다시_배정할_수_없다() {
+        contestMemberRepository.save(createContestMember(contest, professor.getId(), List.of(teamA.getId())));
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(professor.getId()), List.of(teamB.getId()));
+
+        assertThatThrownBy(() -> contestMemberCommandService.assignStaff(contest.getId(), request))
+                .isInstanceOf(ContestMemberException.class)
+                .hasMessage(ALREADY_ASSIGNED_MEMBER.errorMessage());
+    }
+}

--- a/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
@@ -5,6 +5,7 @@ import static com.opus.opus.member.MemberFixture.createMemberWithRole;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.ALREADY_ASSIGNED_MEMBER;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_TEAM_FOR_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_FOUND_CONTEST_MEMBER;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
 import static com.opus.opus.modules.team.exception.TeamExceptionType.NOT_FOUND_TEAM;
@@ -16,6 +17,7 @@ import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.modules.contest.application.ContestMemberCommandService;
 import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
+import com.opus.opus.modules.contest.application.dto.request.StaffTeamUpdateRequest;
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestMember;
 import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
@@ -137,5 +139,60 @@ public class ContestMemberCommandServiceTest extends IntegrationTest {
         assertThatThrownBy(() -> contestMemberCommandService.assignStaff(contest.getId(), request))
                 .isInstanceOf(ContestMemberException.class)
                 .hasMessage(ALREADY_ASSIGNED_MEMBER.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 배정된 팀을 추가하고 삭제한다.")
+    void 배정된_팀을_추가하고_삭제한다() {
+        final ContestMember contestMember = contestMemberRepository.save(
+                createContestMember(contest, professor.getId(), List.of(teamA.getId())));
+        final StaffTeamUpdateRequest request = new StaffTeamUpdateRequest(
+                List.of(teamB.getId()), List.of(teamA.getId()));
+
+        contestMemberCommandService.updateAssignedTeams(contest.getId(), contestMember.getId(), request);
+
+        assertThat(contestMemberRepository.findById(contestMember.getId()).orElseThrow().getTeamIds())
+                .containsExactly(teamB.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 이미 배정된 팀을 추가해도 중복되지 않는다.")
+    void 이미_배정된_팀을_추가해도_중복되지_않는다() {
+        final ContestMember contestMember = contestMemberRepository.save(
+                createContestMember(contest, professor.getId(), List.of(teamA.getId(), teamB.getId())));
+        final StaffTeamUpdateRequest request = new StaffTeamUpdateRequest(
+                List.of(teamA.getId()), List.of());
+
+        contestMemberCommandService.updateAssignedTeams(contest.getId(), contestMember.getId(), request);
+
+        assertThat(contestMemberRepository.findById(contestMember.getId()).orElseThrow().getTeamIds())
+                .containsExactlyInAnyOrder(teamA.getId(), teamB.getId());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 배정은 수정할 수 없다.")
+    void 존재하지_않는_배정은_수정할_수_없다() {
+        final StaffTeamUpdateRequest request = new StaffTeamUpdateRequest(
+                List.of(teamA.getId()), List.of());
+
+        assertThatThrownBy(() -> contestMemberCommandService.updateAssignedTeams(contest.getId(), 999L, request))
+                .isInstanceOf(ContestMemberException.class)
+                .hasMessage(NOT_FOUND_CONTEST_MEMBER.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 대회의 팀은 추가할 수 없다.")
+    void 다른_대회의_팀은_추가할_수_없다() {
+        final ContestMember contestMember = contestMemberRepository.save(
+                createContestMember(contest, professor.getId(), List.of(teamA.getId())));
+        final Contest otherContest = contestRepository.save(ContestFixture.createContest());
+        final Team otherTeam = teamRepository.save(createTeamWithContestId(otherContest.getId()));
+        final StaffTeamUpdateRequest request = new StaffTeamUpdateRequest(
+                List.of(otherTeam.getId()), List.of());
+
+        assertThatThrownBy(
+                () -> contestMemberCommandService.updateAssignedTeams(contest.getId(), contestMember.getId(), request))
+                .isInstanceOf(ContestMemberException.class)
+                .hasMessage(INVALID_TEAM_FOR_CONTEST.errorMessage());
     }
 }

--- a/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
@@ -195,4 +195,23 @@ public class ContestMemberCommandServiceTest extends IntegrationTest {
                 .isInstanceOf(ContestMemberException.class)
                 .hasMessage(INVALID_TEAM_FOR_CONTEST.errorMessage());
     }
+
+    @Test
+    @DisplayName("[성공] 배정을 삭제하면 더 이상 조회되지 않는다.")
+    void 배정을_삭제하면_더_이상_조회되지_않는다() {
+        final ContestMember contestMember = contestMemberRepository.save(
+                createContestMember(contest, professor.getId(), List.of(teamA.getId(), teamB.getId())));
+
+        contestMemberCommandService.deleteAssignment(contest.getId(), contestMember.getId());
+
+        assertThat(contestMemberRepository.findById(contestMember.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 배정은 삭제할 수 없다.")
+    void 존재하지_않는_배정은_삭제할_수_없다() {
+        assertThatThrownBy(() -> contestMemberCommandService.deleteAssignment(contest.getId(), 999L))
+                .isInstanceOf(ContestMemberException.class)
+                .hasMessage(NOT_FOUND_CONTEST_MEMBER.errorMessage());
+    }
 }

--- a/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMemberCommandServiceTest.java
@@ -77,8 +77,8 @@ public class ContestMemberCommandServiceTest extends IntegrationTest {
         assertThat(assigned)
                 .extracting(ContestMember::getMemberId)
                 .containsExactlyInAnyOrder(professor.getId(), mentor.getId());
-        assertThat(assigned.get(0).getTeamIds())
-                .containsExactlyInAnyOrder(teamA.getId(), teamB.getId());
+        assertThat(assigned).allSatisfy(member -> assertThat(member.getTeamIds())
+                .containsExactlyInAnyOrder(teamA.getId(), teamB.getId()));
     }
 
     @Test

--- a/src/test/java/com/opus/opus/contest/application/ContestMemberQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMemberQueryServiceTest.java
@@ -1,0 +1,136 @@
+package com.opus.opus.contest.application;
+
+import static com.opus.opus.contest.ContestMemberFixture.createContestMember;
+import static com.opus.opus.member.MemberFixture.createMemberWithRole;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
+import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.INVALID_MEMBER_TYPE;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
+import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
+import static com.opus.opus.team.TeamFixture.createTeamWithContestIdAndTeamName;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.opus.opus.contest.ContestFixture;
+import com.opus.opus.helper.IntegrationTest;
+import com.opus.opus.modules.contest.application.ContestMemberQueryService;
+import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse.TeamInfo;
+import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestRepository;
+import com.opus.opus.modules.contest.exception.ContestException;
+import com.opus.opus.modules.contest.exception.ContestMemberException;
+import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.dao.MemberRepository;
+import com.opus.opus.modules.team.domain.Team;
+import com.opus.opus.modules.team.domain.dao.TeamRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class ContestMemberQueryServiceTest extends IntegrationTest {
+
+    @Autowired
+    private ContestMemberQueryService contestMemberQueryService;
+    @Autowired
+    private ContestRepository contestRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private TeamRepository teamRepository;
+    @Autowired
+    private ContestMemberRepository contestMemberRepository;
+
+    private Contest contest;
+    private Member professor;
+    private Member mentor;
+    private Team developTeam;
+    private Team planningTeam;
+
+    @BeforeEach
+    void setUp() {
+        contest = contestRepository.save(ContestFixture.createContest());
+        developTeam = teamRepository.save(createTeamWithContestIdAndTeamName(contest.getId(), "개발 1팀"));
+        planningTeam = teamRepository.save(createTeamWithContestIdAndTeamName(contest.getId(), "운영 기획팀"));
+        professor = memberRepository.save(createMemberWithRole("김교수", 1, ROLE_교수));
+        mentor = memberRepository.save(createMemberWithRole("이멘토", 2, ROLE_외부멘토));
+
+        contestMemberRepository.save(
+                createContestMember(contest, professor.getId(), List.of(developTeam.getId(), planningTeam.getId())));
+        contestMemberRepository.save(createContestMember(contest, mentor.getId(), List.of(developTeam.getId())));
+    }
+
+    @Test
+    @DisplayName("[성공] 배정된 회원과 담당 팀 정보를 함께 조회한다.")
+    void 배정된_회원과_담당_팀_정보를_함께_조회한다() {
+        final List<ContestStaffResponse> responses = contestMemberQueryService.getAssignedStaff(contest.getId(), null,
+                null);
+
+        final ContestStaffResponse professorStaff = findByMemberId(responses, professor.getId());
+        assertThat(responses).hasSize(2);
+        assertThat(professorStaff.name()).isEqualTo("김교수");
+        assertThat(professorStaff.email()).isEqualTo(professor.getEmail());
+        assertThat(professorStaff.roleType()).isEqualTo(ROLE_교수.name());
+        assertThat(professorStaff.teams())
+                .extracting(TeamInfo::teamName)
+                .containsExactlyInAnyOrder("개발 1팀", "운영 기획팀");
+    }
+
+    @Test
+    @DisplayName("[성공] memberType으로 회원 유형을 필터링한다.")
+    void memberType으로_회원_유형을_필터링한다() {
+        final List<ContestStaffResponse> responses = contestMemberQueryService.getAssignedStaff(contest.getId(),
+                ROLE_외부멘토.name(), null);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).memberId()).isEqualTo(mentor.getId());
+        assertThat(responses.get(0).roleType()).isEqualTo(ROLE_외부멘토.name());
+    }
+
+    @Test
+    @DisplayName("[성공] 이름으로 검색한다.")
+    void 이름으로_검색한다() {
+        final List<ContestStaffResponse> responses = contestMemberQueryService.getAssignedStaff(contest.getId(), null,
+                "이멘토");
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).memberId()).isEqualTo(mentor.getId());
+    }
+
+    @Test
+    @DisplayName("[성공] 담당 팀 이름으로 검색한다.")
+    void 담당_팀_이름으로_검색한다() {
+        final List<ContestStaffResponse> responses = contestMemberQueryService.getAssignedStaff(contest.getId(), null,
+                "기획");
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).memberId()).isEqualTo(professor.getId());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회의 배정 목록은 조회할 수 없다.")
+    void 존재하지_않는_대회의_배정_목록은_조회할_수_없다() {
+        final Long invalidContestId = 999L;
+
+        assertThatThrownBy(() -> contestMemberQueryService.getAssignedStaff(invalidContestId, null, null))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 유효하지 않은 memberType이면 예외가 발생한다.")
+    void 유효하지_않은_memberType이면_예외가_발생한다() {
+        assertThatThrownBy(() -> contestMemberQueryService.getAssignedStaff(contest.getId(), "ROLE_INVALID", null))
+                .isInstanceOf(ContestMemberException.class)
+                .hasMessage(INVALID_MEMBER_TYPE.errorMessage());
+    }
+
+    private ContestStaffResponse findByMemberId(final List<ContestStaffResponse> responses, final Long memberId) {
+        return responses.stream()
+                .filter(response -> response.memberId().equals(memberId))
+                .findFirst()
+                .orElseThrow();
+    }
+}

--- a/src/test/java/com/opus/opus/member/MemberFixture.java
+++ b/src/test/java/com/opus/opus/member/MemberFixture.java
@@ -3,11 +3,22 @@ package com.opus.opus.member;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_학생;
 
 import com.opus.opus.modules.member.domain.Member;
+import com.opus.opus.modules.member.domain.MemberRoleType;
 import com.opus.opus.modules.member.domain.SocialType;
 import java.util.HashSet;
 import java.util.Set;
 
 public class MemberFixture {
+
+    public static Member createMemberWithRole(final String name, final int number, final MemberRoleType role) {
+        return Member.generalMember()
+                .name(name)
+                .email("example" + number + "@pusan.ac.kr")
+                .password("{noop}123456789")
+                .studentId("20211234" + number)
+                .roles(new HashSet<>(Set.of(role)))
+                .build();
+    }
 
     public static Member createSocialMember(String email, String socialId) {
         return Member.socialMember()

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -10,10 +10,12 @@ import com.opus.opus.global.security.annotation.MemberArgumentResolver;
 import com.opus.opus.helper.ApiTestHelper;
 import com.opus.opus.modules.contest.api.ContestCategoryController;
 import com.opus.opus.modules.contest.api.ContestController;
+import com.opus.opus.modules.contest.api.ContestMemberController;
 import com.opus.opus.modules.contest.api.ContestTrackController;
 import com.opus.opus.modules.contest.application.ContestCategoryCommandService;
 import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
 import com.opus.opus.modules.contest.application.ContestCommandService;
+import com.opus.opus.modules.contest.application.ContestMemberQueryService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
 import com.opus.opus.modules.contest.application.ContestTrackQueryService;
@@ -60,6 +62,7 @@ import org.springframework.web.filter.CharacterEncodingFilter;
         TeamCommentController.class,
         ContestCategoryController.class,
         ContestTrackController.class,
+        ContestMemberController.class,
 })
 @Import(RestDocsConfig.class)
 @ExtendWith(RestDocumentationExtension.class)
@@ -119,6 +122,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected ContestTrackQueryService contestTrackQueryService;
+
+    @MockitoBean
+    protected ContestMemberQueryService contestMemberQueryService;
 
     // Setting
     @Autowired

--- a/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/RestDocsTest.java
@@ -15,6 +15,7 @@ import com.opus.opus.modules.contest.api.ContestTrackController;
 import com.opus.opus.modules.contest.application.ContestCategoryCommandService;
 import com.opus.opus.modules.contest.application.ContestCategoryQueryService;
 import com.opus.opus.modules.contest.application.ContestCommandService;
+import com.opus.opus.modules.contest.application.ContestMemberCommandService;
 import com.opus.opus.modules.contest.application.ContestMemberQueryService;
 import com.opus.opus.modules.contest.application.ContestQueryService;
 import com.opus.opus.modules.contest.application.ContestTrackCommandService;
@@ -125,6 +126,9 @@ public abstract class RestDocsTest extends ApiTestHelper {
 
     @MockitoBean
     protected ContestMemberQueryService contestMemberQueryService;
+
+    @MockitoBean
+    protected ContestMemberCommandService contestMemberCommandService;
 
     // Setting
     @Autowired

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
@@ -7,6 +7,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
 import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
@@ -16,6 +17,7 @@ import static org.springframework.restdocs.request.RequestDocumentation.queryPar
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
+import com.opus.opus.modules.contest.application.dto.request.StaffTeamUpdateRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse.TeamInfo;
 import com.opus.opus.restdocs.RestDocsTest;
@@ -97,6 +99,35 @@ public class ContestMemberApiDocsTest extends RestDocsTest {
                         requestFields(
                                 arrayFieldWithPath("memberIds", "배정할 회원 ID 목록"),
                                 arrayFieldWithPath("teamIds", "담당 팀 ID 목록")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 배정된 담당 팀 목록을 수정한다.")
+    void 배정된_담당_팀_목록을_수정한다() throws Exception {
+        final StaffTeamUpdateRequest request = new StaffTeamUpdateRequest(
+                List.of(12L),
+                List.of(10L));
+
+        doNothing().when(contestMemberCommandService).updateAssignedTeams(any(), any(), any());
+
+        mockMvc.perform(patch("/contests/{contestId}/staff/{contestMemberId}", 1, 2)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(document("update-contest-member",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("contestMemberId").description("배정 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                arrayFieldWithPath("addTeamIds", "추가할 팀 ID 목록"),
+                                arrayFieldWithPath("deleteTeamIds", "삭제할 팀 ID 목록")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
@@ -1,0 +1,70 @@
+package com.opus.opus.restdocs.docs;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
+import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse.TeamInfo;
+import com.opus.opus.restdocs.RestDocsTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+
+public class ContestMemberApiDocsTest extends RestDocsTest {
+
+    private static final String ADMIN_TOKEN = "Bearer admin.access.token";
+
+    @Test
+    @DisplayName("[성공] 배정된 교수/외부멘토 목록을 조회한다.")
+    void 배정된_교수_외부멘토_목록을_조회한다() throws Exception {
+        final List<ContestStaffResponse> responses = List.of(
+                new ContestStaffResponse(1L, 2L, "홍길동", "gildong@example.com", "ROLE_교수",
+                        List.of(new TeamInfo(10L, "개발 1팀"), new TeamInfo(12L, "운영 기획팀"))),
+                new ContestStaffResponse(2L, 3L, "이멘토", "mentor@example.com", "ROLE_외부멘토",
+                        List.of(new TeamInfo(10L, "개발 1팀")))
+        );
+
+        when(contestMemberQueryService.getAssignedStaff(any(), any(), any())).thenReturn(responses);
+
+        mockMvc.perform(get("/contests/{contestId}/staff", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .param("memberType", "ROLE_교수")
+                        .param("search", "개발"))
+                .andExpect(status().isOk())
+                .andDo(document("get-contest-member",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        queryParameters(
+                                parameterWithName("memberType").optional()
+                                        .description("회원 유형 필터 (MemberRoleType: ROLE_교수, ROLE_외부멘토)"),
+                                parameterWithName("search").optional()
+                                        .description("이름 또는 담당 팀 이름 검색어")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        responseFields(
+                                arrayFieldWithPath("[]", "배정 목록"),
+                                numberFieldWithPath("[].contestMemberId", "배정 ID"),
+                                numberFieldWithPath("[].memberId", "회원 ID"),
+                                stringFieldWithPath("[].name", "이름"),
+                                stringFieldWithPath("[].email", "이메일"),
+                                stringFieldWithPath("[].roleType", "회원 유형 (MemberRoleType)"),
+                                arrayFieldWithPath("[].teams", "담당 팀 목록"),
+                                numberFieldWithPath("[].teams[].teamId", "팀 ID"),
+                                stringFieldWithPath("[].teams[].teamName", "팀 이름")
+                        )
+                ));
+    }
+}

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
@@ -128,6 +129,25 @@ public class ContestMemberApiDocsTest extends RestDocsTest {
                         requestFields(
                                 arrayFieldWithPath("addTeamIds", "추가할 팀 ID 목록"),
                                 arrayFieldWithPath("deleteTeamIds", "삭제할 팀 ID 목록")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 배정을 삭제한다.")
+    void 배정을_삭제한다() throws Exception {
+        doNothing().when(contestMemberCommandService).deleteAssignment(any(), any());
+
+        mockMvc.perform(delete("/contests/{contestId}/staff/{contestMemberId}", 1, 2)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNoContent())
+                .andDo(document("delete-contest-member",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("contestMemberId").description("배정 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
                         )
                 ));
     }

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestMemberApiDocsTest.java
@@ -1,17 +1,21 @@
 package com.opus.opus.restdocs.docs;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.opus.opus.modules.contest.application.dto.request.StaffBatchAssignRequest;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestStaffResponse.TeamInfo;
 import com.opus.opus.restdocs.RestDocsTest;
@@ -19,6 +23,7 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 
 public class ContestMemberApiDocsTest extends RestDocsTest {
 
@@ -64,6 +69,34 @@ public class ContestMemberApiDocsTest extends RestDocsTest {
                                 arrayFieldWithPath("[].teams", "담당 팀 목록"),
                                 numberFieldWithPath("[].teams[].teamId", "팀 ID"),
                                 stringFieldWithPath("[].teams[].teamName", "팀 이름")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[성공] 교수/외부멘토를 담당 팀에 일괄 배정한다.")
+    void 교수_외부멘토를_담당_팀에_일괄_배정한다() throws Exception {
+        final StaffBatchAssignRequest request = new StaffBatchAssignRequest(
+                List.of(2L, 3L),
+                List.of(10L, 12L));
+
+        doNothing().when(contestMemberCommandService).assignStaff(any(), any());
+
+        mockMvc.perform(post("/contests/{contestId}/staff/batch", 1)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andDo(document("assign-contest-member",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID")
+                        ),
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")
+                        ),
+                        requestFields(
+                                arrayFieldWithPath("memberIds", "배정할 회원 ID 목록"),
+                                arrayFieldWithPath("teamIds", "담당 팀 ID 목록")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #153

## 📜 작업 내용

- ContestMember entity가 추가되었습니다. (이 부분이 태윤님과 연관된 부분인 것 같네요..!)
- 배정 목록 조회 API, 일괄 배정 API 개발, 배정 팀 수정 API, 배정 삭제 API를 개발했습니다.
  - 배정 목록 조회 API는 `memberType`, `search` 쿼리 파라미터로 필터링을 지원합니다.
    - `memberType`: `ROLE_교수` / `ROLE_외부멘토` 등 역할 기준 필터 (잘못된 값은 `INVALID_MEMBER_TYPE` 예외 처리)
    - `search`: **스태프 이름** 또는 **배정된 팀명**을 OR 조건으로 검색 (대소문자 무시, 부분일치)
    - 두 파라미터는 AND로 함께 적용되며, 값이 없으면 전체 목록을 반환합니다.

## 💬 리뷰 요구사항

- 배정 팀 수정 API 같은 경우 삭제할 팀과 추가할 팀을 구분해서 보내줄 수 있다는 FE 담당자의 의견에 따라 List에서 구분해서 받도록 수정했습니다.
- 배정 삭제는 contestMember가 가지고 있는 모든 팀 삭제입니다. 
  - 단건 삭제를 하고 싶은 경우 배정 팀 수정 API를 이용합니다.

## ✨ 기타

- ContestMember 관련 다른 작업들과 연관된 부분이 있어서 우선적인 리뷰가 필요합니다!
