### PR TITLE
Bug/#189 제출물 상세 조회 api의 track name 누락 및 feedback count로 명칭 변경

### DIFF
--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionCommandService.java
@@ -1,6 +1,7 @@
 package com.opus.opus.modules.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_ITEM_FOR_TRACK;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_SUBMISSION_ITEM;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
@@ -23,6 +24,7 @@ import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.member.domain.Member;
 import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import com.opus.opus.modules.team.application.convenience.TeamMemberConvenience;
+import com.opus.opus.modules.team.domain.Team;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -50,11 +52,11 @@ public class ContestSubmissionCommandService {
                                                      final Long teamId, final List<MultipartFile> files,
                                                      final Member member) {
         contestConvenience.validateExistContest(contestId);
-        teamConvenience.getValidateTeamInContest(teamId, contestId);
+        final Team team = teamConvenience.getValidateTeamInContest(teamId, contestId);
         final ContestSubmissionItem submissionItem =
                 contestSubmissionItemConvenience.getValidateExistSubmissionItem(submissionItemId);
 
-        validateSubmission(contestId, teamId, submissionItem, files, member);
+        validateSubmission(contestId, team, submissionItem, files, member);
 
         final ContestSubmission submission = contestSubmissionRepository.save(ContestSubmission.builder()
                 .teamId(teamId)
@@ -103,12 +105,13 @@ public class ContestSubmissionCommandService {
         }
     }
 
-    private void validateSubmission(final Long contestId, final Long teamId,
+    private void validateSubmission(final Long contestId, final Team team,
                                     final ContestSubmissionItem submissionItem, final List<MultipartFile> files,
                                     final Member member) {
         validateSubmissionItemInContest(submissionItem, contestId);
-        teamMemberConvenience.validateTeamMemberUnlessAdmin(teamId, member);
-        validateNotAlreadySubmitted(teamId, submissionItem);
+        teamMemberConvenience.validateTeamMemberUnlessAdmin(team.getId(), member);
+        validateItemInTeamTrack(submissionItem, team.getTrackId());
+        validateNotAlreadySubmitted(team.getId(), submissionItem);
         validateSubmittable(submissionItem);
         validateFilesNotEmpty(files);
         validateFiles(submissionItem, files, files.size());
@@ -135,6 +138,12 @@ public class ContestSubmissionCommandService {
     private void validateSubmissionItemInContest(final ContestSubmissionItem submissionItem, final Long contestId) {
         if (!submissionItem.isInContest(contestId)) {
             throw new ContestException(NOT_FOUND_SUBMISSION_ITEM);
+        }
+    }
+
+    private void validateItemInTeamTrack(final ContestSubmissionItem submissionItem, final Long trackId) {
+        if (!submissionItem.isInTrack(trackId)) {
+            throw new ContestException(INVALID_SUBMISSION_ITEM_FOR_TRACK);
         }
     }
 

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionQueryService.java
@@ -2,6 +2,7 @@ package com.opus.opus.modules.contest.application;
 
 import com.opus.opus.modules.contest.application.convenience.ContestConvenience;
 import com.opus.opus.modules.contest.application.convenience.ContestSubmissionConvenience;
+import com.opus.opus.modules.contest.application.convenience.ContestTrackConvenience;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionDetailResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionStatusResponse;
 import com.opus.opus.modules.contest.application.dto.response.ContestSubmissionSummaryResponse;
@@ -10,7 +11,7 @@ import com.opus.opus.modules.contest.application.dto.response.TeamSubmissionItem
 import com.opus.opus.modules.contest.application.dto.response.TeamSubmissionSummaryResponse;
 import com.opus.opus.modules.contest.application.dto.response.UpcomingSubmissionResponse;
 import com.opus.opus.modules.contest.domain.ContestSubmission;
-import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionFeedbackRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
@@ -41,6 +42,7 @@ public class ContestSubmissionQueryService {
 
     private final ContestConvenience contestConvenience;
     private final ContestSubmissionConvenience contestSubmissionConvenience;
+    private final ContestTrackConvenience contestTrackConvenience;
     private final ContestSubmissionRepository contestSubmissionRepository;
     private final ContestSubmissionItemRepository contestSubmissionItemRepository;
     private final ContestSubmissionFeedbackRepository contestSubmissionFeedbackRepository;
@@ -54,23 +56,21 @@ public class ContestSubmissionQueryService {
 
         final ContestSubmission submission = contestSubmissionConvenience.getValidateSubmissionInContest(contestId,
                 submissionId);
-        final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
 
         final Team team = teamConvenience.getValidateTeamInContest(submission.getTeamId(), contestId);
         // 학생은 해당 팀의 팀장/팀원만 조회할 수 있다. (관리자/교수/직원/외부멘토는 제한 없음)
         teamMemberConvenience.validateTeamMemberIfStudent(team.getId(), member);
 
-        final String trackName = submissionItem.getTrackName();
+        final ContestTrack track = team.getTrackId() != null
+                ? contestTrackConvenience.getValidateExistTrack(team.getContestId(), team.getTrackId())
+                : null;
+        final String trackName = track != null ? track.getTrackName() : null;
         final List<FileDocument> fileDocuments = fileDocumentConvenience.findAllBySubmissionId(submissionId);
 
-        /* TODO
-        제출물 코멘트 기능이 아직 없어서, 제출물 카운트를 0으로 고정하였습니다.
-        코멘트 기능 추가 시 실제 개수로 교체가 필요합니다.
-         */
-        final int commentCount = 0;
+        final long feedbackCount = contestSubmissionFeedbackRepository.countBySubmissionId(submissionId);
 
         final SubmissionStatus status = submission.isLate() ? SubmissionStatus.LATE : SubmissionStatus.SUBMITTED;
-        return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, commentCount, status);
+        return ContestSubmissionDetailResponse.of(submission, team, trackName, fileDocuments, feedbackCount, status);
     }
 
     public List<ContestSubmissionStatusResponse> getSubmissionStatuses(final Long contestId,
@@ -149,10 +149,11 @@ public class ContestSubmissionQueryService {
     public TeamSubmissionSummaryResponse getTeamSubmissionSummary(final Long contestId, final Long teamId,
                                                                   final Member member) {
         contestConvenience.validateExistContest(contestId);
-        teamConvenience.getValidateTeamInContest(teamId, contestId);
+        final Team team = teamConvenience.getValidateTeamInContest(teamId, contestId);
         teamMemberConvenience.validateTeamMemberIfStudent(teamId, member);
 
-        final long totalItemCount = contestSubmissionItemRepository.countByContestId(contestId);
+        final long totalItemCount = contestSubmissionItemRepository.countByContestAndTrack(contestId,
+                team.getTrackId());
         final List<ContestSubmission> submissions = contestSubmissionRepository.findAllByTeamIdAndContestId(teamId,
                 contestId);
         final long submittedCount = submissions.size();

--- a/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/dto/response/ContestSubmissionDetailResponse.java
@@ -20,11 +20,11 @@ public record ContestSubmissionDetailResponse(
         LocalDateTime firstSubmittedAt,
         LocalDateTime lastModifiedAt,
         List<ContestSubmissionFileResponse> files,
-        Integer commentCount
+        long feedbackCount
 ) {
     public static ContestSubmissionDetailResponse of(final ContestSubmission submission, final Team team,
                                                      final String trackName, final List<FileDocument> fileDocuments,
-                                                     final int commentCount, final SubmissionStatus status) {
+                                                     final long feedbackCount, final SubmissionStatus status) {
         final ContestSubmissionItem submissionItem = submission.getSubmissionItem();
         return new ContestSubmissionDetailResponse(
                 submission.getId(),
@@ -38,7 +38,7 @@ public record ContestSubmissionDetailResponse(
                 submission.getFirstSubmittedAt(),
                 submission.getUpdatedAt(),
                 fileDocuments.stream().map(ContestSubmissionFileResponse::from).toList(),
-                commentCount
+                feedbackCount
         );
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/ContestSubmissionItem.java
@@ -104,6 +104,10 @@ public class ContestSubmissionItem extends BaseEntity {
         return contest.getId().equals(contestId);
     }
 
+    public boolean isInTrack(final Long trackId) {
+        return contestTrack == null || contestTrack.getId().equals(trackId);
+    }
+
     public String getTrackName() {
         return contestTrack != null ? contestTrack.getTrackName() : null;
     }

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionFeedbackRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionFeedbackRepository.java
@@ -17,6 +17,8 @@ public interface ContestSubmissionFeedbackRepository extends JpaRepository<Conte
 
     Optional<ContestSubmissionFeedback> findTopBySubmission_TeamIdOrderByCreatedAtDesc(Long teamId);
 
+    long countBySubmissionId(Long submissionId);
+
     long countBySubmissionIdIn(List<Long> submissionIds);
 
     @Query("""

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionItemRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestSubmissionItemRepository.java
@@ -17,5 +17,6 @@ public interface ContestSubmissionItemRepository extends JpaRepository<ContestSu
     @Query("SELECT i FROM ContestSubmissionItem i WHERE i.contest.id = :contestId AND i.endAt > :now AND i.contestTrack IS NULL")
     List<ContestSubmissionItem> findFutureCommonItemsByContest(@Param("contestId") Long contestId, @Param("now") LocalDateTime now);
 
-    long countByContestId(Long contestId);
+    @Query("SELECT COUNT(i) FROM ContestSubmissionItem i WHERE i.contest.id = :contestId AND (i.contestTrack IS NULL OR i.contestTrack.id = :trackId)")
+    long countByContestAndTrack(@Param("contestId") Long contestId, @Param("trackId") Long trackId);
 }

--- a/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
+++ b/src/main/java/com/opus/opus/modules/contest/exception/ContestExceptionType.java
@@ -15,6 +15,7 @@ public enum ContestExceptionType implements BaseExceptionType {
     SUBMISSION_FILE_COUNT_EXCEEDED(HttpStatus.BAD_REQUEST, "제출 가능한 파일 수를 초과했습니다."),
     SUBMISSION_FILE_SIZE_EXCEEDED(HttpStatus.BAD_REQUEST, "제출 가능한 파일 크기를 초과했습니다."),
     SUBMISSION_PERIOD_ENDED(HttpStatus.BAD_REQUEST, "제출 기간이 종료되었습니다."),
+    INVALID_SUBMISSION_ITEM_FOR_TRACK(HttpStatus.BAD_REQUEST, "팀의 분과와 일치하지 않는 제출 항목입니다."),
     CONTEST_HAS_TEAMS(HttpStatus.CONFLICT, "먼저 해당 대회의 모든 팀을 삭제해주세요."),
     CURRENT_CONTEST_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "현재 진행 중인 대회는 최대 2개까지 설정할 수 있습니다."),
     ALREADY_CURRENT_CONTEST(HttpStatus.BAD_REQUEST, "이미 현재 대회입니다."),

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionCommandServiceTest.java
@@ -1,6 +1,7 @@
 package com.opus.opus.contest.application;
 
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_FILE_FORMAT;
+import static com.opus.opus.modules.contest.exception.ContestExceptionType.INVALID_SUBMISSION_ITEM_FOR_TRACK;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_ALREADY_EXISTS;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_COUNT_EXCEEDED;
 import static com.opus.opus.modules.contest.exception.ContestExceptionType.SUBMISSION_FILE_REQUIRED;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verify;
 import com.opus.opus.contest.ContestFixture;
 import com.opus.opus.contest.ContestSubmissionFixture;
 import com.opus.opus.contest.ContestSubmissionItemFixture;
+import com.opus.opus.contest.ContestTrackFixture;
 import com.opus.opus.helper.IntegrationTest;
 import com.opus.opus.member.MemberFixture;
 import com.opus.opus.modules.contest.application.ContestSubmissionCommandService;
@@ -22,9 +24,11 @@ import com.opus.opus.modules.contest.application.dto.response.SubmissionCreateRe
 import com.opus.opus.modules.contest.domain.Contest;
 import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.ContestSubmissionItem;
+import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
+import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
 import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.FileDocument;
@@ -65,6 +69,8 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
     private ContestSubmissionItemRepository contestSubmissionItemRepository;
     @Autowired
     private ContestSubmissionRepository contestSubmissionRepository;
+    @Autowired
+    private ContestTrackRepository contestTrackRepository;
     @Autowired
     private FileDocumentRepository fileDocumentRepository;
     @Autowired
@@ -194,6 +200,48 @@ public class ContestSubmissionCommandServiceTest extends IntegrationTest {
                 contest.getId(), submissionItem.getId(), team.getId(), List.of(pdf("발표자료.pdf")), other))
                 .isInstanceOf(TeamMemberException.class)
                 .hasMessage(TeamMemberExceptionType.TEAM_MEMBER_NOT_FOUND_IN_TEAM.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 팀의 분과와 다른 분과의 제출 항목에는 제출할 수 없다.")
+    void 분과_불일치_제출_예외() {
+        final ContestTrack itemTrack = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+        final ContestSubmissionItem trackItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest, itemTrack));
+        final Team otherTrackTeam = teamRepository.save(
+                TeamFixture.createTeamWithContestIdAndTrackId(contest.getId(), itemTrack.getId() + 1L));
+        final Member leader = saveTeamLeader(otherTrackTeam, 2);
+
+        assertThatThrownBy(() -> contestSubmissionCommandService.createSubmission(
+                contest.getId(), trackItem.getId(), otherTrackTeam.getId(), List.of(pdf("발표자료.pdf")), leader))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(INVALID_SUBMISSION_ITEM_FOR_TRACK.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[성공] 팀의 분과와 같은 분과의 제출 항목에는 제출할 수 있다.")
+    void 동일_분과_제출_성공() {
+        final ContestTrack itemTrack = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+        final ContestSubmissionItem trackItem = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest, itemTrack));
+        final Team trackTeam = teamRepository.save(
+                TeamFixture.createTeamWithContestIdAndTrackId(contest.getId(), itemTrack.getId()));
+        final Member leader = saveTeamLeader(trackTeam, 3);
+
+        final SubmissionCreateResponse response = contestSubmissionCommandService.createSubmission(
+                contest.getId(), trackItem.getId(), trackTeam.getId(), List.of(pdf("발표자료.pdf")), leader);
+
+        assertThat(response.submissionId()).isNotNull();
+    }
+
+    private Member saveTeamLeader(final Team newTeam, final int uniqueNum) {
+        final Member leader = memberRepository.save(MemberFixture.createMemberWithUniqueNum(uniqueNum));
+        teamMemberRepository.save(TeamMember.builder()
+                .memberId(leader.getId())
+                .team(newTeam)
+                .roles(Set.of(TeamMemberRoleType.ROLE_팀장))
+                .build());
+        return leader;
     }
 
     @Test

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionQueryServiceTest.java
@@ -92,7 +92,7 @@ public class ContestSubmissionQueryServiceTest extends IntegrationTest {
     }
 
     private void prepareTeamAndMember() {
-        team = teamRepository.save(TeamFixture.createTeamWithContestId(contest.getId()));
+        team = teamRepository.save(TeamFixture.createTeamWithContestIdAndTrackId(contest.getId(), track.getId()));
         member = memberRepository.save(MemberFixture.createMember());
     }
 
@@ -130,10 +130,32 @@ public class ContestSubmissionQueryServiceTest extends IntegrationTest {
         assertThat(response.trackName()).isEqualTo(track.getTrackName());
         assertThat(response.submissionItemName()).isEqualTo(item.getName());
         assertThat(response.status()).isEqualTo(SubmissionStatus.SUBMITTED);
-        assertThat(response.commentCount()).isZero();
+        assertThat(response.feedbackCount()).isZero();
         assertThat(response.files()).hasSize(1);
         assertThat(response.files().get(0).fileName()).isEqualTo("발표자료.pdf");
         assertThat(response.files().get(0).fileSize()).isEqualTo(1048576L);
+    }
+
+    @Test
+    @DisplayName("[성공] 제출물 상세 조회 시 제출물에 달린 피드백 개수를 반환한다.")
+    void 제출물_상세의_피드백_개수를_반환한다() {
+        prepareTeamAndMember();
+        joinTeam(member, team);
+        final ContestSubmissionItem item = contestSubmissionItemRepository.save(
+                ContestSubmissionItemFixture.createSubmissionItem(contest, track));
+        final ContestSubmission submission = contestSubmissionRepository.save(
+                ContestSubmissionFixture.createSubmission(team.getId(), item));
+        final Member feedbackMember1 = memberRepository.save(MemberFixture.createMemberWithUniqueNum(1));
+        final Member feedbackMember2 = memberRepository.save(MemberFixture.createMemberWithUniqueNum(2));
+        contestSubmissionFeedbackRepository.save(
+                ContestSubmissionFeedbackFixture.createFeedback(submission, feedbackMember1.getId()));
+        contestSubmissionFeedbackRepository.save(
+                ContestSubmissionFeedbackFixture.createFeedback(submission, feedbackMember2.getId()));
+
+        final ContestSubmissionDetailResponse response = contestSubmissionQueryService.getSubmissionDetail(
+                contest.getId(), submission.getId(), member);
+
+        assertThat(response.feedbackCount()).isEqualTo(2);
     }
 
     @Test
@@ -626,6 +648,22 @@ public class ContestSubmissionQueryServiceTest extends IntegrationTest {
         assertThat(response.totalItemCount()).isEqualTo(3);
         assertThat(response.submittedCount()).isEqualTo(2);
         assertThat(response.totalFeedbackCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("[성공] 제출 현황 요약의 전체 항목 수는 팀 분과에 해당하는 항목만 센다.")
+    void 요약_전체_항목_수는_팀_분과_항목만_센다() {
+        prepareTeamAndMember();
+        joinTeam(member, team);
+        final ContestTrack otherTrack = contestTrackRepository.save(ContestTrackFixture.createTrack(contest));
+        contestSubmissionItemRepository.save(ContestSubmissionItemFixture.createSubmissionItem(contest));
+        contestSubmissionItemRepository.save(ContestSubmissionItemFixture.createSubmissionItem(contest, track));
+        contestSubmissionItemRepository.save(ContestSubmissionItemFixture.createSubmissionItem(contest, otherTrack));
+
+        final TeamSubmissionSummaryResponse response = contestSubmissionQueryService.getTeamSubmissionSummary(
+                contest.getId(), team.getId(), member);
+
+        assertThat(response.totalItemCount()).isEqualTo(2);
     }
 
     @Test

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestApiDocsTest.java
@@ -939,7 +939,7 @@ public class ContestApiDocsTest extends RestDocsTest {
                         new ContestSubmissionFileResponse(101L, "발표자료.pdf", 1048576L),
                         new ContestSubmissionFileResponse(102L, "데모영상.mp4", 20971520L)
                 ),
-                0
+                2
         );
 
         when(contestSubmissionQueryService.getSubmissionDetail(any(), any(), any())).thenReturn(response);
@@ -971,7 +971,7 @@ public class ContestApiDocsTest extends RestDocsTest {
                                 numberFieldWithPath("files[].fileId", "파일 ID"),
                                 stringFieldWithPath("files[].fileName", "파일명"),
                                 numberFieldWithPath("files[].fileSize", "파일 용량 (byte)"),
-                                numberFieldWithPath("commentCount", "코멘트 개수 (코멘트 기능 추가 전까지 항상 0)")
+                                numberFieldWithPath("feedbackCount", "피드백 개수")
                         )
                 ));
     }


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #189

## 📜 작업 내용
- 제출물 상세 조회 api 를 일부 수정했습니다.
- trackName 누락 수정: 제출물 상세 조회의 trackName을 **제출 항목의 분과 → 팀의 분과** 기준으로 변경하였습니다. 
  - 기존에는 제출 항목은 분과 미지정(null, 대회에 속한 전체 팀)이면 항상 null이 반환되었습니다.
- commentCount → feedbackCount: 도메인 명칭에 맞게 (comment→feedback) 통일했습니다. 추가로 피드백 기능 구현 전이라 0으로 고정되어 있던 하드코딩된 값을 실제 피드백 개수로 수정했습니다.
- 제출 시점 분과 검증 추가: 제출 항목에 분과가 지정돼 있을 때, 다른 분과의 팀이 제출하던 것을 차단하였습니다. 조회는 팀의 분과에 맞게 조회되고 있었습니다.
- 제출 현황 요약의 totalItemCount가 대회 전체 제출 항목 수였는데, 팀 분과에 해당하는 항목 수(미지정 + 팀 분과)로 변경하였습니다.

## 💬 리뷰 요구사항

- 리뷰 요구사항을 작성해주세요.

## ✨ 기타

- 오늘의 한마디
