### PR TITLE
Bug/#196 메모 재적성 불가 버그

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -128,7 +128,7 @@ CREATE TABLE `contest_submission_memo` (
   `content` varchar(500) NOT NULL,
   `contest_submission_id` bigint NOT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `uk_contest_submission_memo_submission_id` (`contest_submission_id`)
+  UNIQUE KEY `uq_memo_active_submission` ((CASE WHEN `is_deleted` = false THEN `contest_submission_id` ELSE NULL END))
 );
 
 CREATE TABLE `contest_submission` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -380,3 +380,4 @@ CREATE TABLE `team_vote` (
     PRIMARY KEY (`id`),
     UNIQUE KEY `uk_team_vote_member_team` (`member_id`, `team_id`)
 );
+


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #196 

## 📜 작업 내용

- contest_submission_memo테이블에 적용된 유니크 키를 제거하고 is_deleted=false 행에만 유니크 제약이 걸리도록 변경



