### PR TITLE
Feature/#199 제출 파일 일괄 다운로드 API 개발

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/submission-file.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/submission-file.adoc
@@ -98,6 +98,39 @@ include::{snippets}/download-submissions-fail-no-submissions/http-response.adoc[
 
 ====
 
+== `GET`: 제출 파일 일괄 다운로드 (zip)
+
+특정 제출물에 딸린 모든 파일을 하나의 zip으로 묶어 내려줍니다. 파일은 zip 최상위(루트)에 담기며, zip 파일명은 `{팀명}_{날짜}.zip` 형식입니다.
+
+.Path Parameters
+include::{snippets}/download-submission-files/path-parameters.adoc[]
+
+.HTTP Request Headers
+include::{snippets}/download-submission-files/request-headers.adoc[]
+
+.HTTP Request
+include::{snippets}/download-submission-files/http-request.adoc[]
+
+.HTTP Response
+include::{snippets}/download-submission-files/http-response.adoc[]
+
+.Response Headers
+include::{snippets}/download-submission-files/response-headers.adoc[]
+
+=== ⚠️ 실패 케이스
+
+.❌ Case 1: 존재하지 않는 제출물
+
+[%collapsible]
+
+====
+
+include::{snippets}/download-submission-files-fail-submission-not-found/http-request.adoc[]
+
+include::{snippets}/download-submission-files-fail-submission-not-found/http-response.adoc[]
+
+====
+
 == `GET`: 제출 파일 개별 다운로드
 
 제출물 상세에서 파일을 하나씩 내려받습니다.

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionFileController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestSubmissionFileController.java
@@ -51,6 +51,18 @@ public class ContestSubmissionFileController {
                 .body(submissionDownload.body());
     }
 
+    @GetMapping("/{submissionId}/files")
+    public ResponseEntity<StreamingResponseBody> downloadSubmissionFiles(
+            @PathVariable final Long contestId,
+            @PathVariable final Long submissionId
+    ) {
+        final SubmissionDownload download = contestSubmissionFileQueryService.generateSubmissionDownload(contestId, submissionId);
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("application/zip"))
+                .header(HttpHeaders.CONTENT_DISPOSITION, FileDownloadUtil.attachmentHeader(download.fileName()))
+                .body(download.body());
+    }
+
     @GetMapping("/{submissionId}/files/{fileId}")
     public ResponseEntity<Resource> downloadSubmissionFile(
             @PathVariable final Long contestId,

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionFileQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionFileQueryService.java
@@ -8,6 +8,7 @@ import com.opus.opus.modules.contest.application.dto.response.DownloadTargetResp
 import com.opus.opus.modules.contest.application.dto.response.DownloadTargetsResponse;
 import com.opus.opus.modules.contest.application.dto.response.SubmissionDownload;
 import com.opus.opus.modules.contest.domain.Contest;
+import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.dao.DownloadSubmissionRow;
 import com.opus.opus.modules.contest.domain.dao.DownloadTargetResult;
 import com.opus.opus.modules.contest.exception.ContestException;
@@ -16,6 +17,7 @@ import com.opus.opus.modules.file.application.FileDocumentQueryService;
 import com.opus.opus.modules.file.application.convenience.FileDocumentConvenience;
 import com.opus.opus.modules.file.application.dto.DocumentFileDownload;
 import com.opus.opus.modules.file.domain.dao.SubmissionFileInfo;
+import com.opus.opus.modules.team.application.convenience.TeamConvenience;
 import java.io.InputStream;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -23,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -40,6 +43,7 @@ public class ContestSubmissionFileQueryService {
     private final ContestSubmissionConvenience contestSubmissionConvenience;
     private final FileDocumentConvenience fileDocumentConvenience;
     private final FileDocumentQueryService fileDocumentQueryService;
+    private final TeamConvenience teamConvenience;
 
     public DocumentFileDownload downloadSubmissionFile(final Long contestId, final Long submissionId, final Long fileId) {
         contestConvenience.validateExistContest(contestId);
@@ -47,6 +51,17 @@ public class ContestSubmissionFileQueryService {
         fileDocumentConvenience.validateFileBelongsToSubmission(submissionId, fileId);
 
         return fileDocumentQueryService.download(fileId);
+    }
+
+    public SubmissionDownload generateSubmissionDownload(final Long contestId, final Long submissionId) {
+        contestConvenience.validateExistContest(contestId);
+        final ContestSubmission submission = contestSubmissionConvenience.getValidateSubmissionInContest(contestId, submissionId);
+
+        final List<SubmissionFileInfo> files = fileDocumentQueryService.findFilesBySubmissionIds(List.of(submissionId));
+        final String teamName = teamConvenience.getValidateExistTeam(submission.getTeamId()).getTeamName();
+
+        return new SubmissionDownload(generateZipFileName(teamName),
+                buildZipFileBody(files, SubmissionFileInfo::fileName));
     }
 
     public DownloadTargetsResponse getDownloadTargets(final Long contestId, final Long submissionItemId, final Long trackId) {
@@ -78,7 +93,8 @@ public class ContestSubmissionFileQueryService {
             throw new ContestException(ContestExceptionType.NO_SUBMISSIONS_TO_DOWNLOAD);
         }
 
-        return new SubmissionDownload(generateZipFileName(contest), buildZipFileBody(files, teamNameBySubmissionId));
+        return new SubmissionDownload(generateZipFileName(contest.getContestName()),
+                buildZipFileBody(files, file -> teamNameBySubmissionId.get(file.submissionId()) + "/" + file.fileName()));
     }
 
     private DownloadTargetResponse toDownloadTargetResponse(final DownloadTargetResult result) {
@@ -98,13 +114,12 @@ public class ContestSubmissionFileQueryService {
     }
 
     private StreamingResponseBody buildZipFileBody(final List<SubmissionFileInfo> files,
-                                                   final Map<Long, String> teamNameBySubmissionId) {
+                                                   final Function<SubmissionFileInfo, String> entryNameResolver) {
         return outputStream -> {
             final Set<String> usedEntryNames = new HashSet<>();
             try (ZipOutputStream zipOutputStream = new ZipOutputStream(outputStream)) {
                 for (final SubmissionFileInfo file : files) {
-                    final String entryName = deduplicateEntryName(usedEntryNames,
-                            teamNameBySubmissionId.get(file.submissionId()) + "/" + file.fileName());
+                    final String entryName = deduplicateEntryName(usedEntryNames, entryNameResolver.apply(file));
                     zipOutputStream.putNextEntry(new ZipEntry(entryName));
                     try (InputStream inputStream = fileDocumentQueryService.openStream(file.fileDocumentId())) {
                         inputStream.transferTo(zipOutputStream);
@@ -133,9 +148,8 @@ public class ContestSubmissionFileQueryService {
         return candidate;
     }
 
-    private String generateZipFileName(final Contest contest) {
+    private String generateZipFileName(final String name) {
         final String date = LocalDate.now().format(DateTimeFormatter.BASIC_ISO_DATE);
-        final String contestName = contest.getContestName().replaceAll("\\s+", "");
-        return "%s_%s.zip".formatted(contestName, date);
+        return "%s_%s.zip".formatted(name.replaceAll("\\s+", ""), date);
     }
 }

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionFileQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestSubmissionFileQueryService.java
@@ -61,7 +61,7 @@ public class ContestSubmissionFileQueryService {
         final String teamName = teamConvenience.getValidateExistTeam(submission.getTeamId()).getTeamName();
 
         return new SubmissionDownload(generateZipFileName(teamName),
-                buildZipFileBody(files, SubmissionFileInfo::fileName));
+                buildZipFileBody(files, file -> sanitizeEntryName(file.fileName())));
     }
 
     public DownloadTargetsResponse getDownloadTargets(final Long contestId, final Long submissionItemId, final Long trackId) {
@@ -94,7 +94,8 @@ public class ContestSubmissionFileQueryService {
         }
 
         return new SubmissionDownload(generateZipFileName(contest.getContestName()),
-                buildZipFileBody(files, file -> teamNameBySubmissionId.get(file.submissionId()) + "/" + file.fileName()));
+                buildZipFileBody(files, file -> sanitizeEntryName(teamNameBySubmissionId.get(file.submissionId()))
+                        + "/" + sanitizeEntryName(file.fileName())));
     }
 
     private DownloadTargetResponse toDownloadTargetResponse(final DownloadTargetResult result) {
@@ -128,6 +129,20 @@ public class ContestSubmissionFileQueryService {
                 }
             }
         };
+    }
+
+    // zip slip 방지: 업로드 원본 파일명/팀명이 "../", 절대경로("/..."), "C:\..." 같은 경로 요소를 담고 있으면
+    // 압축 해제 시 대상 디렉토리 밖으로 파일이 쓰일 수 있으므로, 경로 구분자를 제거하고 마지막 이름 성분만 남긴다.
+    private String sanitizeEntryName(final String rawName) {
+        if (rawName == null || rawName.isBlank()) {
+            return "unnamed";
+        }
+        final String withoutDirectory = rawName.replace('\\', '/');
+        final String baseName = withoutDirectory.substring(withoutDirectory.lastIndexOf('/') + 1).trim();
+        if (baseName.isEmpty() || baseName.equals(".") || baseName.equals("..")) {
+            return "unnamed";
+        }
+        return baseName;
     }
 
     // 만약에 같은 폴더에 동일 파일명이 들어오면 ZipException(duplicate entry)으로 다운로드가 깨지므로

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionFileQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionFileQueryServiceTest.java
@@ -263,6 +263,23 @@ public class ContestSubmissionFileQueryServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[성공] 경로 탈출 문자가 섞인 파일명은 무해화되어 zip 엔트리에 담긴다.")
+    void 경로_탈출_파일명은_무해화되어_담긴다() throws Exception {
+        final ContestSubmission submission = saveSubmission(
+                teamRepository.save(buildTeam(trackAi.getId(), "무해화팀")).getId());
+        saveFile(submission.getId(), "../../../etc/passwd", 100L, 0);
+
+        final SubmissionDownload download = contestSubmissionFileQueryService.generateSubmissionDownload(
+                contest.getId(), submission.getId());
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        download.body().writeTo(out);
+
+        final List<String> names = readEntryNames(out.toByteArray());
+        assertThat(names).containsExactly("passwd");
+        assertThat(names).noneMatch(name -> name.contains(".."));
+    }
+
+    @Test
     @DisplayName("[실패] 존재하지 않는 제출물은 일괄 다운로드할 수 없다.")
     void 존재하지_않는_제출물은_일괄_다운로드할_수_없다() {
         assertThatThrownBy(() -> contestSubmissionFileQueryService.generateSubmissionDownload(

--- a/src/test/java/com/opus/opus/contest/application/ContestSubmissionFileQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestSubmissionFileQueryServiceTest.java
@@ -250,6 +250,53 @@ public class ContestSubmissionFileQueryServiceTest extends IntegrationTest {
     }
 
     @Test
+    @DisplayName("[성공] 제출물의 모든 파일을 팀명 zip으로 담되 파일을 루트에 둔다.")
+    void 제출물의_모든_파일을_zip_루트에_담는다() throws Exception {
+        final SubmissionDownload download = contestSubmissionFileQueryService.generateSubmissionDownload(
+                contest.getId(), submissionAi1.getId());
+        final ByteArrayOutputStream out = new ByteArrayOutputStream();
+        download.body().writeTo(out);
+
+        assertThat(download.fileName()).startsWith("AI팀1_").endsWith(".zip");
+        assertThat(readEntryNames(out.toByteArray()))
+                .containsExactlyInAnyOrder("발표자료.pdf", "보고서.pdf");
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출물은 일괄 다운로드할 수 없다.")
+    void 존재하지_않는_제출물은_일괄_다운로드할_수_없다() {
+        assertThatThrownBy(() -> contestSubmissionFileQueryService.generateSubmissionDownload(
+                contest.getId(), 99999L))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 대회의 제출물은 일괄 다운로드할 수 없다.")
+    void 존재하지_않는_대회의_제출물은_일괄_다운로드할_수_없다() {
+        assertThatThrownBy(() -> contestSubmissionFileQueryService.generateSubmissionDownload(
+                99999L, submissionAi1.getId()))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    }
+
+    @Test
+    @DisplayName("[실패] 다른 대회에 속한 제출물은 일괄 다운로드할 수 없다.")
+    void 다른_대회에_속한_제출물은_일괄_다운로드할_수_없다() {
+        final Contest otherContest = contestRepository.save(ContestFixture.createContest());
+        final ContestSubmissionItem otherItem = submissionItemRepository.save(
+                ContestSubmissionFixture.createSubmissionItem(otherContest));
+        final ContestSubmission otherSubmission = saveSubmission(
+                teamRepository.save(buildTeam(trackAi.getId(), "타대회팀")).getId(), otherItem);
+        saveFile(otherSubmission.getId(), "발표자료.pdf", 100L, 0);
+
+        assertThatThrownBy(() -> contestSubmissionFileQueryService.generateSubmissionDownload(
+                contest.getId(), otherSubmission.getId()))
+                .isInstanceOf(ContestException.class)
+                .hasMessage(NOT_FOUND_SUBMISSION.errorMessage());
+    }
+
+    @Test
     @DisplayName("[실패] 대상에 해당하는 제출이 없으면 예외가 발생한다.")
     void 대상에_해당하는_제출이_없으면_예외가_발생한다() {
         final SubmissionDownloadRequest request = new SubmissionDownloadRequest(List.of(new DownloadTargetRequest(item.getId(), 99999L)));

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionFileApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestSubmissionFileApiDocsTest.java
@@ -114,6 +114,47 @@ public class ContestSubmissionFileApiDocsTest extends RestDocsTest {
     }
 
     @Test
+    @DisplayName("[성공] 제출물의 파일을 zip으로 일괄 다운로드한다.")
+    void 제출물의_파일을_zip으로_일괄_다운로드한다() throws Exception {
+        final StreamingResponseBody body = outputStream -> outputStream.write("zip-binary".getBytes());
+        when(contestSubmissionFileQueryService.generateSubmissionDownload(any(), any()))
+                .thenReturn(new SubmissionDownload("AI스타트업_20260701.zip", body));
+
+        mockMvc.perform(get("/contests/{contestId}/submissions/{submissionId}/files", 1, 12)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isOk())
+                .andDo(document("download-submission-files",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionId").description("제출 ID")
+                        ),
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)")),
+                        responseHeaders(
+                                headerWithName(HttpHeaders.CONTENT_TYPE).description("application/zip"),
+                                headerWithName(HttpHeaders.CONTENT_DISPOSITION).description("attachment; filename=\"...zip\"")
+                        )
+                ));
+    }
+
+    @Test
+    @DisplayName("[실패] 존재하지 않는 제출물의 파일 일괄 다운로드 시 404 에러를 반환한다.")
+    void 존재하지_않는_제출물의_파일_일괄_다운로드_시_에러를_반환한다() throws Exception {
+        willThrow(new ContestException(NOT_FOUND_SUBMISSION))
+                .given(contestSubmissionFileQueryService).generateSubmissionDownload(any(), any());
+
+        mockMvc.perform(get("/contests/{contestId}/submissions/{submissionId}/files", 1, 999)
+                        .header(HttpHeaders.AUTHORIZATION, ADMIN_TOKEN))
+                .andExpect(status().isNotFound())
+                .andDo(document("download-submission-files-fail-submission-not-found",
+                        pathParameters(
+                                parameterWithName("contestId").description("대회 ID"),
+                                parameterWithName("submissionId").description("존재하지 않는 제출 ID")
+                        ),
+                        requestHeaders(headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (관리자)"))
+                ));
+    }
+
+    @Test
     @DisplayName("[성공] 제출 파일을 개별 다운로드한다.")
     void 제출_파일을_개별_다운로드한다() throws Exception {
         when(contestSubmissionFileQueryService.downloadSubmissionFile(any(), any(), any()))


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #199

## 📜 작업 내용

- 특정 제출물에 딸린 모든 파일을 하나의 zip으로 묶어 내려받는 API를 추가했습니다.
  - `GET /contests/{contestId}/submissions/{submissionId}/files` (관리자 전용)
  - 단일 제출물이므로 파일을 zip 최상위(루트)에 담고, zip 파일명은 `{팀명}_{날짜}.zip` 형식입니다.
  - 같은 파일명이 중복되면 확장자 앞에 순번을 붙여(`자료.pdf`, `자료(1).pdf`) 엔트리명 충돌을 회피합니다.
- 기존 분과별 일괄 다운로드와 zip 생성 로직을 공유하도록 리팩터링했습니다.
  - `buildZipFileBody`가 엔트리명 생성 함수를 받도록, `generateZipFileName`이 이름 문자열을 받도록 일반화했습니다.

## 💬 리뷰 요구사항

- zip 스트리밍(`StreamingResponseBody`) 특성상 `openStream()`이 응답 헤더 전송 이후 호출되어, '물리적 파일 없음' 오류는 200 응답 도중 발생합니다. 기존 분과별 다운로드와 동일하게 별도 404 문서화 없이 두었는데 이 처리 방향이 괜찮을지 봐주세요.

## ✨ 기타

- 개별 다운로드는 파일 하나, 이번 API는 제출물 단위 전체 — 두 개 이상 조합은 기존 분과별 일괄 다운로드로 커버됩니다.