### PR TITLE
Refactor/#201 멘토 담당 프로젝트 대회 무관 조회로 변경

### DIFF
--- a/src/main/java/com/opus/opus/docs/asciidoc/mentor.adoc
+++ b/src/main/java/com/opus/opus/docs/asciidoc/mentor.adoc
@@ -16,14 +16,11 @@ link:./opus.html[API 목록으로 돌아가기]
 
 == `GET`: 담당 프로젝트 목록 조회
 
-로그인한 교수/외부멘토 본인에게 배정된 담당 프로젝트(팀) 목록을 조회한다. +
+로그인한 교수/외부멘토 본인이 배정된 모든 대회(종료된 대회 포함)의 담당 프로젝트(팀) 목록을 조회한다. +
 상단 통계(담당 팀 수, 검토 대기 건수)와 프로젝트별 피드백 대기 건수를 함께 반환한다.
 
 .HTTP Request Headers
 include::{snippets}/get-mentor-projects/request-headers.adoc[]
-
-.Path Parameters
-include::{snippets}/get-mentor-projects/path-parameters.adoc[]
 
 .HTTP Request
 include::{snippets}/get-mentor-projects/http-request.adoc[]

--- a/src/main/java/com/opus/opus/modules/contest/api/ContestMentorController.java
+++ b/src/main/java/com/opus/opus/modules/contest/api/ContestMentorController.java
@@ -15,21 +15,20 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/contests/{contestId}")
+@RequestMapping("/contests")
 @Secured({"ROLE_교수", "ROLE_외부멘토"})
 public class ContestMentorController {
 
     private final ContestMentorQueryService contestMentorQueryService;
 
-    @GetMapping("/mentor/projects")
+    @GetMapping("/mentors/me/projects")
     public ResponseEntity<MentorProjectsResponse> getMentorProjects(
-            @PathVariable final Long contestId,
             @LoginMember final Member member
     ) {
-        return ResponseEntity.ok(contestMentorQueryService.getMentorProjects(contestId, member));
+        return ResponseEntity.ok(contestMentorQueryService.getMentorProjects(member));
     }
 
-    @GetMapping("/teams/{teamId}/submissions")
+    @GetMapping("/{contestId}/teams/{teamId}/submissions")
     public ResponseEntity<TeamSubmissionsResponse> getTeamSubmissions(
             @PathVariable final Long contestId,
             @PathVariable final Long teamId,

--- a/src/main/java/com/opus/opus/modules/contest/application/ContestMentorQueryService.java
+++ b/src/main/java/com/opus/opus/modules/contest/application/ContestMentorQueryService.java
@@ -10,6 +10,7 @@ import com.opus.opus.modules.contest.application.dto.response.MentorProjectRespo
 import com.opus.opus.modules.contest.application.dto.response.MentorProjectsResponse;
 import com.opus.opus.modules.contest.application.dto.response.MentorSubmissionResponse;
 import com.opus.opus.modules.contest.application.dto.response.TeamSubmissionsResponse;
+import com.opus.opus.modules.contest.domain.ContestMember;
 import com.opus.opus.modules.contest.domain.ContestSubmission;
 import com.opus.opus.modules.contest.domain.ContestTrack;
 import com.opus.opus.modules.contest.domain.dao.ContestMemberRepository;
@@ -45,32 +46,37 @@ public class ContestMentorQueryService {
     private final TeamConvenience teamConvenience;
     private final FileDocumentQueryService fileDocumentQueryService;
 
-    public MentorProjectsResponse getMentorProjects(final Long contestId, final Member mentor) {
-        contestConvenience.validateExistContest(contestId);
-
-        final List<Long> teamIds = contestMemberRepository.findByContestIdAndMemberId(contestId, mentor.getId())
-                .map(contestMember -> List.copyOf(contestMember.getTeamIds()))
-                .orElseGet(List::of);
-        if (teamIds.isEmpty()) {
-            return new MentorProjectsResponse(0, 0L, List.of());
-        }
-
-        final Map<Long, Team> teams = teamConvenience.getTeamsByIds(teamIds);
-        final Map<Long, String> trackNames = trackNameMap(contestId);
-        final Map<Long, Long> pendingCounts = pendingFeedbackCountsByTeam(contestId, mentor.getId(), teamIds);
+    public MentorProjectsResponse getMentorProjects(final Member mentor) {
         final String roleType = mentor.getStaffRoleName();
 
-        final List<MentorProjectResponse> projects = teamIds.stream()
-                .map(teams::get)
-                .filter(Objects::nonNull)
-                .map(team -> MentorProjectResponse.of(team, trackNames.get(team.getTrackId()), roleType,
-                        pendingCounts.getOrDefault(team.getId(), 0L)))
+        final List<MentorProjectResponse> projects = contestMemberRepository.findAllByMemberId(mentor.getId()).stream()
+                .flatMap(contestMember -> projectsOf(contestMember, mentor.getId(), roleType).stream())
                 .toList();
 
         final long totalPendingCount = projects.stream()
                 .mapToLong(MentorProjectResponse::pendingFeedbackCount)
                 .sum();
         return new MentorProjectsResponse(projects.size(), totalPendingCount, projects);
+    }
+
+    private List<MentorProjectResponse> projectsOf(final ContestMember contestMember, final Long memberId,
+                                                   final String roleType) {
+        final List<Long> teamIds = List.copyOf(contestMember.getTeamIds());
+        if (teamIds.isEmpty()) {
+            return List.of();
+        }
+
+        final Long contestId = contestMember.getContest().getId();
+        final Map<Long, Team> teams = teamConvenience.getTeamsByIds(teamIds);
+        final Map<Long, String> trackNames = trackNameMap(contestId);
+        final Map<Long, Long> pendingCounts = pendingFeedbackCountsByTeam(contestId, memberId, teamIds);
+
+        return teamIds.stream()
+                .map(teams::get)
+                .filter(Objects::nonNull)
+                .map(team -> MentorProjectResponse.of(team, trackNames.get(team.getTrackId()), roleType,
+                        pendingCounts.getOrDefault(team.getId(), 0L)))
+                .toList();
     }
 
     public TeamSubmissionsResponse getTeamSubmissions(final Long contestId, final Long teamId, final Member mentor) {

--- a/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
+++ b/src/main/java/com/opus/opus/modules/contest/domain/dao/ContestMemberRepository.java
@@ -9,6 +9,8 @@ public interface ContestMemberRepository extends JpaRepository<ContestMember, Lo
 
     List<ContestMember> findAllByContestId(final Long contestId);
 
+    List<ContestMember> findAllByMemberId(final Long memberId);
+
     boolean existsByContestIdAndMemberId(final Long contestId, final Long memberId);
 
     Optional<ContestMember> findByIdAndContestId(final Long id, final Long contestId);

--- a/src/test/java/com/opus/opus/contest/application/ContestMentorQueryServiceTest.java
+++ b/src/test/java/com/opus/opus/contest/application/ContestMentorQueryServiceTest.java
@@ -4,7 +4,6 @@ import static com.opus.opus.contest.ContestMemberFixture.createContestMember;
 import static com.opus.opus.contest.ContestSubmissionFeedbackFixture.createFeedback;
 import static com.opus.opus.contest.ContestSubmissionFixture.createSubmission;
 import static com.opus.opus.member.MemberFixture.createMemberWithRole;
-import static com.opus.opus.modules.contest.exception.ContestExceptionType.NOT_FOUND_CONTEST;
 import static com.opus.opus.modules.contest.exception.ContestMemberExceptionType.NOT_ASSIGNED_TEAM;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_교수;
 import static com.opus.opus.modules.member.domain.MemberRoleType.ROLE_외부멘토;
@@ -34,7 +33,6 @@ import com.opus.opus.modules.contest.domain.dao.ContestSubmissionFeedbackReposit
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionItemRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestSubmissionRepository;
 import com.opus.opus.modules.contest.domain.dao.ContestTrackRepository;
-import com.opus.opus.modules.contest.exception.ContestException;
 import com.opus.opus.modules.contest.exception.ContestMemberException;
 import com.opus.opus.modules.file.domain.File;
 import com.opus.opus.modules.file.domain.FileDocument;
@@ -113,7 +111,7 @@ public class ContestMentorQueryServiceTest extends IntegrationTest {
     @Test
     @DisplayName("[성공] 담당 프로젝트 목록과 통계를 조회한다.")
     void 담당_프로젝트_목록과_통계를_조회한다() {
-        final MentorProjectsResponse response = contestMentorQueryService.getMentorProjects(contest.getId(), professor);
+        final MentorProjectsResponse response = contestMentorQueryService.getMentorProjects(professor);
 
         assertThat(response.assignedTeamCount()).isEqualTo(2);
         assertThat(response.pendingFeedbackCount()).isEqualTo(3);
@@ -133,7 +131,7 @@ public class ContestMentorQueryServiceTest extends IntegrationTest {
     void 배정되지_않은_멘토는_빈_목록을_반환한다() {
         final Member unassigned = memberRepository.save(createMemberWithRole("이멘토", 2, ROLE_외부멘토));
 
-        final MentorProjectsResponse response = contestMentorQueryService.getMentorProjects(contest.getId(), unassigned);
+        final MentorProjectsResponse response = contestMentorQueryService.getMentorProjects(unassigned);
 
         assertThat(response.assignedTeamCount()).isEqualTo(0);
         assertThat(response.pendingFeedbackCount()).isEqualTo(0);
@@ -141,11 +139,29 @@ public class ContestMentorQueryServiceTest extends IntegrationTest {
     }
 
     @Test
-    @DisplayName("[실패] 존재하지 않는 대회의 담당 프로젝트는 조회할 수 없다.")
-    void 존재하지_않는_대회의_담당_프로젝트는_조회할_수_없다() {
-        assertThatThrownBy(() -> contestMentorQueryService.getMentorProjects(999L, professor))
-                .isInstanceOf(ContestException.class)
-                .hasMessage(NOT_FOUND_CONTEST.errorMessage());
+    @DisplayName("[성공] 여러 대회에 배정된 멘토는 모든 대회의 담당 프로젝트를 합산해 조회한다.")
+    void 여러_대회에_배정된_멘토는_모든_대회의_프로젝트를_합산한다() {
+        final Contest contest2 = contestRepository.save(ContestFixture.createContest());
+        final ContestTrack track2 = contestTrackRepository.save(ContestTrackFixture.createTrack(contest2));
+        final Team team2 = teamRepository.save(Team.builder()
+                .teamName("2대회팀")
+                .projectName("두번째 프로젝트")
+                .contestId(contest2.getId())
+                .trackId(track2.getId())
+                .itemOrder(1)
+                .build());
+        contestMemberRepository.save(createContestMember(contest2, professor.getId(), List.of(team2.getId())));
+
+        final MentorProjectsResponse response = contestMentorQueryService.getMentorProjects(professor);
+
+        assertThat(response.assignedTeamCount()).isEqualTo(3);
+        assertThat(response.pendingFeedbackCount()).isEqualTo(3);
+        assertThat(response.projects()).extracting(MentorProjectResponse::teamId)
+                .contains(developTeam.getId(), planningTeam.getId(), team2.getId());
+
+        final MentorProjectResponse project2 = findProject(response, team2.getId());
+        assertThat(project2.trackName()).isEqualTo(track2.getTrackName());
+        assertThat(project2.pendingFeedbackCount()).isEqualTo(0);
     }
 
     @Test

--- a/src/test/java/com/opus/opus/restdocs/docs/ContestMentorApiDocsTest.java
+++ b/src/test/java/com/opus/opus/restdocs/docs/ContestMentorApiDocsTest.java
@@ -48,15 +48,12 @@ public class ContestMentorApiDocsTest extends RestDocsTest {
                 new MentorProjectResponse(11L, "보안팀2", "보안 프로젝트", "융합트랙", "ROLE_교수", 0L)
         ));
 
-        when(contestMentorQueryService.getMentorProjects(any(), any())).thenReturn(response);
+        when(contestMentorQueryService.getMentorProjects(any())).thenReturn(response);
 
-        mockMvc.perform(get("/contests/{contestId}/mentor/projects", 1)
+        mockMvc.perform(get("/contests/mentors/me/projects")
                         .header(HttpHeaders.AUTHORIZATION, MENTOR_TOKEN))
                 .andExpect(status().isOk())
                 .andDo(document("get-mentor-projects",
-                        pathParameters(
-                                parameterWithName("contestId").description("대회 ID")
-                        ),
                         requestHeaders(
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("Bearer {accessToken} (교수/외부멘토)")
                         ),


### PR DESCRIPTION
## 🔥 연관된 이슈

close: #201

## 📜 작업 내용

- 멘토(교수/외부멘토) 담당 프로젝트 조회를 특정 대회 스코프에서 대회 무관 조회로 변경했습니다.
  - `GET /contests/{contestId}/mentor/projects` → `GET /contests/mentors/me/projects`
  - 본인이 배정된 **모든 대회(종료된 대회 포함)**의 담당 프로젝트를 집계해 반환하며, 상단 통계(담당 팀 수, 검토 대기 건수)도 전 대회 합산입니다.
- 서비스에서 `ContestMember`를 멤버 기준으로 전부 조회(`findAllByMemberId`)한 뒤, 대회별 기존 집계 로직(트랙명·피드백 대기 건수)을 재사용해 flatten·합산하도록 구현했습니다.
- 컨트롤러 클래스 매핑을 `/contests/{contestId}` → `/contests`로 조정하고 `{contestId}`를 팀 제출물 조회 메서드로 옮겼습니다. (팀 제출물 API URL은 그대로 유지)

## 💬 리뷰 요구사항

- 조회 범위를 '현재 진행 대회'가 아니라 '배정된 모든 대회(종료 포함)'로 잡았습니다. 멘토가 참여한 대회 수만큼 대회별 쿼리가 반복되는데(현재 규모에선 문제없다고 판단), 이 방향이 괜찮은지 봐주세요.

## ✨ 기타

- `me`는 `@LoginMember`로 해석되며, 기존 `/members/me` 컨벤션과 URL 스타일을 맞췄습니다.